### PR TITLE
Remove 3s sleep from clickhouse test

### DIFF
--- a/wrappers/test/expected/clickhouse.out
+++ b/wrappers/test/expected/clickhouse.out
@@ -1,10 +1,3 @@
--- The clickhouse healthcheck lies
-select pg_sleep(3);
- pg_sleep 
-----------
- 
-(1 row)
-
 -- create foreign data wrapper and enable 'ClickHouseFdw'
 drop foreign data wrapper if exists clickhouse_wrapper;
 NOTICE:  foreign-data wrapper "clickhouse_wrapper" does not exist, skipping

--- a/wrappers/test/sql/clickhouse.sql
+++ b/wrappers/test/sql/clickhouse.sql
@@ -1,5 +1,3 @@
--- The clickhouse healthcheck lies
-select pg_sleep(3);
 -- create foreign data wrapper and enable 'ClickHouseFdw'
 drop foreign data wrapper if exists clickhouse_wrapper;
 create foreign data wrapper clickhouse_wrapper


### PR DESCRIPTION
## What kind of change does this PR introduce?
Sleeping to avoid startup race condition is no longer needed since Bo updated the `depends_on` for click house to require `service_healthy`
