### PR TITLE
BigQuery Tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ cmake*/
 .direnv
 results/
 wrappers/results/
+wrappers/regression.*

--- a/wrappers/.ci/docker-compose.yaml
+++ b/wrappers/.ci/docker-compose.yaml
@@ -15,6 +15,8 @@ services:
         condition: service_healthy
       firebase:
         condition: service_healthy
+      bigquery:
+        condition: service_started
 
   clickhouse:
     image: clickhouse/clickhouse-server
@@ -49,3 +51,13 @@ services:
       interval: 10s
       timeout: 5s
       retries: 30
+
+  bigquery:
+    container_name: bigquery-local
+    image: ghcr.io/goccy/bigquery-emulator:latest
+    volumes:
+      - ${PWD}/dockerfiles/bigquery/data.yaml:/app/data.yaml
+    ports:
+      - "9111:9111" # REST
+      - "9060:9060" # gRPC
+    command: --project=test --dataset=dataset1 --data-from-yaml=/app/data.yaml --port=9111

--- a/wrappers/Cargo.lock
+++ b/wrappers/Cargo.lock
@@ -27,6 +27,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "async-channel"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14485364214912d3b19cc3435dde4df66065127f05fa0d75c712f36f12c2f28"
+dependencies = [
+ "concurrent-queue",
+ "event-listener",
+ "futures-core",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -192,6 +213,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
 
 [[package]]
+name = "cache-padded"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1db59621ec70f09c5e9b597b220c7a2b43611f4710dc03ceb8748637775692c"
+
+[[package]]
 name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -315,6 +342,15 @@ checksum = "35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "1.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af4780a44ab5696ea9e28294517f1fffb421a83a25af521333c838635509db9c"
+dependencies = [
+ "cache-padded",
 ]
 
 [[package]]
@@ -510,6 +546,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "deadpool"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "421fe0f90f2ab22016f32a9881be5134fdd71c65298917084b0c7477cbc3856e"
+dependencies = [
+ "async-trait",
+ "deadpool-runtime",
+ "num_cpus",
+ "retain_mut",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaa37046cc0f6c3cc6090fbdbf73ef0b8ef4cfcc37f6befc0020f63e8cf121e1"
+
+[[package]]
 name = "digest"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -570,6 +625,12 @@ checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "eyre"
@@ -687,6 +748,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
 
 [[package]]
+name = "futures-lite"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694489acd39452c77daa48516b894c153f192c3578d5a839b62c58099fcbf48"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+ "waker-fn",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -708,6 +784,12 @@ name = "futures-task"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
@@ -743,7 +825,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "time 0.3.16",
+ "time 0.3.17",
  "tokio",
  "tokio-stream",
  "url",
@@ -758,6 +840,17 @@ checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -882,6 +975,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-types"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e9b187a72d63adbfba487f48095306ac823049cb504ee195541e91c7775f5ad"
+dependencies = [
+ "anyhow",
+ "async-channel",
+ "base64",
+ "futures-lite",
+ "http",
+ "infer",
+ "pin-project-lite",
+ "rand 0.7.3",
+ "serde",
+ "serde_json",
+ "serde_qs",
+ "serde_urlencoded",
+ "url",
+]
+
+[[package]]
 name = "httparse"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -994,6 +1108,12 @@ dependencies = [
  "autocfg",
  "hashbrown",
 ]
+
+[[package]]
+name = "infer"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64e9829a50b42bb782c1df523f78d332fe371b10c661e78b7a3c34b0198e9fac"
 
 [[package]]
 name = "instant"
@@ -1277,9 +1397,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
+checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
 name = "openssl"
@@ -1337,6 +1457,12 @@ name = "owo-colors"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
+
+[[package]]
+name = "parking"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
 
 [[package]]
 name = "parking_lot"
@@ -1426,10 +1552,10 @@ dependencies = [
  "serde_cbor",
  "serde_json",
  "thiserror",
- "time 0.3.16",
+ "time 0.3.17",
  "tracing",
  "tracing-error",
- "uuid 1.2.1",
+ "uuid 1.2.2",
 ]
 
 [[package]]
@@ -1502,7 +1628,7 @@ dependencies = [
  "serde_json",
  "shutdown_hooks",
  "thiserror",
- "time 0.3.16",
+ "time 0.3.17",
 ]
 
 [[package]]
@@ -1556,7 +1682,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1181c94580fa345f50f19d738aaa39c0ed30a600d95cb2d3e23f94266f14fbf"
 dependencies = [
  "phf_shared",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -1634,7 +1760,7 @@ dependencies = [
  "hmac",
  "md-5",
  "memchr",
- "rand",
+ "rand 0.8.5",
  "sha2",
  "stringprep",
 ]
@@ -1682,13 +1808,36 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom 0.1.16",
+ "libc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -1698,7 +1847,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom 0.1.16",
 ]
 
 [[package]]
@@ -1707,7 +1865,16 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.8",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -1749,16 +1916,16 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.8",
  "redox_syscall",
  "thiserror",
 ]
 
 [[package]]
 name = "regex"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
+checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1869,6 +2036,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "retain_mut"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4389f1d5789befaf6029ebd9f7dac4af7f7e3d61b69d4f30e2ac02b57e7712b0"
+
+[[package]]
 name = "retry-policies"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1876,7 +2049,7 @@ checksum = "47f9e19b18c6cdd796cc70aea8a9ea5ee7b813be611c6589e3624fcdbfd05f9d"
 dependencies = [
  "anyhow",
  "chrono",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -2144,6 +2317,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_qs"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7715380eec75f029a4ef7de39a9200e0a63823176b759d055b613f5a87df6a6"
+dependencies = [
+ "percent-encoding",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2370,9 +2554,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fab5c8b9980850e06d92ddbe3ab839c062c801f3927c0fb8abd6fc8e918fbca"
+checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
 dependencies = [
  "itoa",
  "libc",
@@ -2390,9 +2574,9 @@ checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
 
 [[package]]
 name = "time-macros"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bb801831d812c562ae7d2bfb531f26e66e4e1f6b17307ba4149c5064710e5b"
+checksum = "d967f99f534ca7e495c575c62638eebc2898a8c84c119b89e250477bc4ba16b2"
 dependencies = [
  "time-core",
 ]
@@ -2682,6 +2866,7 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -2692,11 +2877,11 @@ checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 
 [[package]]
 name = "uuid"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feb41e78f93363bb2df8b0e86a2ca30eed7806ea16ea0c790d757cf93f79be83"
+checksum = "422ee0de9031b5b948b97a8fc04e3aa35230001a722ddd27943e0be31564ce4c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.8",
 ]
 
 [[package]]
@@ -2739,6 +2924,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "waker-fn"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
+
+[[package]]
 name = "want"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2747,6 +2938,12 @@ dependencies = [
  "log",
  "try-lock",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
@@ -2996,12 +3193,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "wiremock"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "249dc68542861d17eae4b4e5e8fb381c2f9e8f255a84f6771d5fdf8b6c03ce3c"
+dependencies = [
+ "assert-json-diff",
+ "async-trait",
+ "base64",
+ "deadpool",
+ "futures",
+ "futures-timer",
+ "http-types",
+ "hyper",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "wrappers"
 version = "0.1.0"
 dependencies = [
  "cfg-if",
  "chrono",
  "clickhouse-rs",
+ "futures",
  "gcp-bigquery-client",
  "pgx",
  "pgx-tests",
@@ -3009,9 +3229,12 @@ dependencies = [
  "reqwest",
  "reqwest-middleware",
  "reqwest-retry",
+ "serde",
  "serde_json",
  "supabase-wrappers",
- "time 0.3.16",
+ "tempfile",
+ "time 0.3.17",
+ "wiremock",
  "yup-oauth2",
 ]
 
@@ -3045,7 +3268,7 @@ dependencies = [
  "seahash",
  "serde",
  "serde_json",
- "time 0.3.16",
+ "time 0.3.17",
  "tokio",
  "tower-service",
  "url",

--- a/wrappers/Cargo.toml
+++ b/wrappers/Cargo.toml
@@ -16,7 +16,7 @@ pg14 = ["pgx/pg14", "pgx-tests/pg14" ]
 pg_test = []
 
 helloworld_fdw = []
-bigquery_fdw = ["gcp-bigquery-client", "time", "serde_json"]
+bigquery_fdw = ["gcp-bigquery-client", "time", "serde_json", "serde", "wiremock", "futures", "tempfile"]
 clickhouse_fdw = ["clickhouse-rs", "chrono", "time"]
 stripe_fdw = ["reqwest", "reqwest-middleware", "reqwest-retry", "serde_json"]
 firebase_fdw = ["reqwest", "reqwest-middleware", "reqwest-retry", "serde_json", "yup-oauth2", "regex", "time"]
@@ -34,12 +34,16 @@ chrono = { version = "0.4", optional = true }
 # for bigquery_fdw, firebase_fdw and etc.
 gcp-bigquery-client = { version = "0.16.0", optional = true }
 time = { version = "0.3.15", features = ["parsing"], optional = true }
+serde = { version = "1", optional = true }
+serde_json = { version = "1.0.86", optional = true }
+wiremock = { version = "0.5", optional = true }
+futures = { version = "0.3", optional = true }
+tempfile = { version = "3", optional = true }
 
 # for stripe_fdw, firebase_fdw and etc.
 reqwest = { version = "0.11.12", features = ["json"], optional = true }
 reqwest-middleware = { version = "0.1.6", optional = true }
 reqwest-retry = { version = "0.1.5", optional = true }
-serde_json = { version = "1.0.86", optional = true }
 
 # for firebase_fdw
 yup-oauth2 = { version = "8.0.0", optional = true }

--- a/wrappers/dockerfiles/bigquery/data.yaml
+++ b/wrappers/dockerfiles/bigquery/data.yaml
@@ -1,0 +1,18 @@
+projects:
+- id: test_project
+  datasets:
+    - id: test_dataset
+      tables:
+        - id: test_table
+          columns:
+            - name: id
+              type: INTEGER
+              mode: REQUIRED
+            - name: name
+              type: STRING
+              mode: required
+          data:
+            - id: 1
+              name: foo
+            - id: 2
+              name: bar

--- a/wrappers/dockerfiles/pg/Dockerfile
+++ b/wrappers/dockerfiles/pg/Dockerfile
@@ -42,7 +42,7 @@ COPY wrappers/Cargo.lock Cargo.lock
 COPY wrappers/wrappers.control wrappers.control
 COPY wrappers/bin bin
 COPY wrappers/src src
-RUN cargo pgx install --features pg14,clickhouse_fdw,firebase_fdw
+RUN cargo pgx install --features pg14,clickhouse_fdw,firebase_fdw,bigquery_fdw
 
 COPY wrappers/test test
 RUN chown -R postgres:postgres /home/app

--- a/wrappers/src/fdw/bigquery_fdw/bigquery_fdw.rs
+++ b/wrappers/src/fdw/bigquery_fdw/bigquery_fdw.rs
@@ -1,4 +1,5 @@
 use gcp_bigquery_client::{
+    client_builder::ClientBuilder,
     model::{
         field_type::FieldType, query_request::QueryRequest, query_response::ResultSet,
         table::Table, table_data_insert_all_request::TableDataInsertAllRequest,
@@ -6,6 +7,7 @@ use gcp_bigquery_client::{
     },
     Client,
 };
+use futures::executor;
 use pgx::log::PgSqlErrorCode;
 use pgx::prelude::{Date, Timestamp};
 use serde_json::json;
@@ -92,6 +94,7 @@ pub(crate) struct BigQueryFdw {
     rowid_col: String,
     tgt_cols: Vec<String>,
     scan_result: Option<(Table, ResultSet)>,
+    auth_mock: Option<GoogleAuthMock>,
 }
 
 impl BigQueryFdw {
@@ -105,28 +108,75 @@ impl BigQueryFdw {
             rowid_col: "".to_string(),
             tgt_cols: Vec::new(),
             scan_result: None,
+            auth_mock: None,
         };
 
-        let sa_key_file = require_option("sa_key_file", options);
         let project_id = require_option("project_id", options);
         let dataset_id = require_option("dataset_id", options);
-        if sa_key_file.is_none() || project_id.is_none() || dataset_id.is_none() {
+
+        if project_id.is_none() || dataset_id.is_none() {
             return ret;
         }
-
-        let sa_key_file = sa_key_file.unwrap();
         ret.project_id = project_id.unwrap();
-        ret.dataset_id = dataset_id.unwrap();
+		ret.dataset_id = dataset_id.unwrap();
 
+        // Is authentication mocked
+        let mock_auth: bool = options
+            .get("mock_auth")
+            .map(|t| t.to_owned())
+            .unwrap_or("false".to_string()) == "true".to_string();
+
+        let dummy_sa_key_file = tempfile::Builder::new().prefix("bigquery_dummy_auth").suffix(".json").tempfile().unwrap();
+        let dummy_sa_key_file: &std::path::Path = dummy_sa_key_file.path();
+        let dummy_sa_key_file_path: String = dummy_sa_key_file.to_str().unwrap().to_string();
+
+        let api_endpoint = options
+            .get("api_endpoint")
+            .map(|t| t.to_owned())
+            .unwrap_or("https://bigquery.googleapis.com/bigquery/v2".to_string());
+
+        let (auth_endpoint, sa_key_file) = match mock_auth {
+            true => {
+                // Key file is not required if we're mocking auth
+                let auth_mock = executor::block_on(GoogleAuthMock::start());
+                executor::block_on(auth_mock.mock_token(1));
+                let auth_mock_uri = auth_mock.uri();
+                let dummy_auth_config = dummy_configuration(&auth_mock_uri);
+                ret.auth_mock = Some(auth_mock);
+
+                std::fs::write(
+                    dummy_sa_key_file,
+                    serde_json::to_string_pretty(&dummy_auth_config).unwrap()
+                ).unwrap();
+
+                (auth_mock_uri.to_string(), dummy_sa_key_file_path)
+            }
+            false => {
+                // Key file is required if we're not mocking auth
+                let sa_key_file = require_option("sa_key_file", options);
+
+                if sa_key_file.is_none() {
+                    return ret;
+                }
+                ("https://www.googleapis.com/auth/bigquery".to_string(), sa_key_file.unwrap())
+            }
+        };
+
+        
+        
         ret.client = match ret
             .rt
-            .block_on(Client::from_service_account_key_file(&sa_key_file))
+            .block_on(ClientBuilder::new()
+			.with_auth_base_url(auth_endpoint)
+			// Url of the BigQuery emulator docker image.
+			.with_v2_base_url(api_endpoint)
+			.build_from_service_account_key_file(sa_key_file.as_ref()))
         {
             Ok(client) => Some(client),
             Err(err) => {
                 report_error(
                     PgSqlErrorCode::ERRCODE_FDW_ERROR,
-                    &format!("create client failed: {}", err),
+                    &format!("create client failed: {}, {}", err, sa_key_file),
                 );
                 None
             }
@@ -358,3 +408,84 @@ impl ForeignDataWrapper for BigQueryFdw {
 
     fn end_modify(&mut self) {}
 }
+
+use auth_mock::GoogleAuthMock;
+
+mod auth_mock {
+    use serde::Serialize;
+    use std::ops::Deref;
+    use wiremock::{
+        matchers::{method, path},
+        Mock, MockServer, ResponseTemplate, Times,
+    };
+
+    pub const AUTH_TOKEN_ENDPOINT: &str = "/:o/oauth2/token";
+
+    pub struct GoogleAuthMock {
+        server: MockServer,
+    }
+
+    impl Deref for GoogleAuthMock {
+        type Target = MockServer;
+
+        fn deref(&self) -> &Self::Target {
+            &self.server
+        }
+    }
+
+    impl GoogleAuthMock {
+        pub async fn start() -> Self {
+            Self {
+                server: MockServer::start().await,
+            }
+        }
+    }
+
+    #[derive(Eq, PartialEq, Serialize, Debug, Clone)]
+    pub struct Token {
+        access_token: String,
+        token_type: String,
+        expires_in: u32,
+    }
+
+    impl Token {
+        fn fake() -> Self {
+            Self {
+                access_token: "aaaa".to_string(),
+                token_type: "bearer".to_string(),
+                expires_in: 9999999,
+            }
+        }
+    }
+
+    impl GoogleAuthMock {
+        /// Mock token, given how many times the endpoint will be called.
+        pub async fn mock_token<T: Into<Times>>(&self, n_times: T) {
+            let response = ResponseTemplate::new(200).set_body_json(Token::fake());
+            Mock::given(method("POST"))
+                .and(path(AUTH_TOKEN_ENDPOINT))
+                .respond_with(response)
+                .named("mock token")
+                .expect(n_times)
+                .mount(self)
+                .await;
+        }
+    }
+}
+
+pub fn dummy_configuration(oauth_server: &str) -> serde_json::Value {
+    let oauth_endpoint = format!("{}/:o/oauth2", oauth_server);
+    serde_json::json!({
+      "type": "service_account",
+      "project_id": "dummy",
+      "private_key_id": "dummy",
+      "private_key": "-----BEGIN PRIVATE KEY-----\nMIIEvwIBADANBgkqhkiG9w0BAQEFAASCBKkwggSlAgEAAoIBAQDNk6cKkWP/4NMu\nWb3s24YHfM639IXzPtTev06PUVVQnyHmT1bZgQ/XB6BvIRaReqAqnQd61PAGtX3e\n8XocTw+u/ZfiPJOf+jrXMkRBpiBh9mbyEIqBy8BC20OmsUc+O/YYh/qRccvRfPI7\n3XMabQ8eFWhI6z/t35oRpvEVFJnSIgyV4JR/L/cjtoKnxaFwjBzEnxPiwtdy4olU\nKO/1maklXexvlO7onC7CNmPAjuEZKzdMLzFszikCDnoKJC8k6+2GZh0/JDMAcAF4\nwxlKNQ89MpHVRXZ566uKZg0MqZqkq5RXPn6u7yvNHwZ0oahHT+8ixPPrAEjuPEKM\nUPzVRz71AgMBAAECggEAfdbVWLW5Befkvam3hea2+5xdmeN3n3elrJhkiXxbAhf3\nE1kbq9bCEHmdrokNnI34vz0SWBFCwIiWfUNJ4UxQKGkZcSZto270V8hwWdNMXUsM\npz6S2nMTxJkdp0s7dhAUS93o9uE2x4x5Z0XecJ2ztFGcXY6Lupu2XvnW93V9109h\nkY3uICLdbovJq7wS/fO/AL97QStfEVRWW2agIXGvoQG5jOwfPh86GZZRYP9b8VNw\ntkAUJe4qpzNbWs9AItXOzL+50/wsFkD/iWMGWFuU8DY5ZwsL434N+uzFlaD13wtZ\n63D+tNAxCSRBfZGQbd7WxJVFfZe/2vgjykKWsdyNAQKBgQDnEBgSI836HGSRk0Ub\nDwiEtdfh2TosV+z6xtyU7j/NwjugTOJEGj1VO/TMlZCEfpkYPLZt3ek2LdNL66n8\nDyxwzTT5Q3D/D0n5yE3mmxy13Qyya6qBYvqqyeWNwyotGM7hNNOix1v9lEMtH5Rd\nUT0gkThvJhtrV663bcAWCALmtQKBgQDjw2rYlMUp2TUIa2/E7904WOnSEG85d+nc\norhzthX8EWmPgw1Bbfo6NzH4HhebTw03j3NjZdW2a8TG/uEmZFWhK4eDvkx+rxAa\n6EwamS6cmQ4+vdep2Ac4QCSaTZj02YjHb06Be3gptvpFaFrotH2jnpXxggdiv8ul\n6x+ooCffQQKBgQCR3ykzGoOI6K/c75prELyR+7MEk/0TzZaAY1cSdq61GXBHLQKT\nd/VMgAN1vN51pu7DzGBnT/dRCvEgNvEjffjSZdqRmrAVdfN/y6LSeQ5RCfJgGXSV\nJoWVmMxhCNrxiX3h01Xgp/c9SYJ3VD54AzeR/dwg32/j/oEAsDraLciXGQKBgQDF\nMNc8k/DvfmJv27R06Ma6liA6AoiJVMxgfXD8nVUDW3/tBCVh1HmkFU1p54PArvxe\nchAQqoYQ3dUMBHeh6ZRJaYp2ATfxJlfnM99P1/eHFOxEXdBt996oUMBf53bZ5cyJ\n/lAVwnQSiZy8otCyUDHGivJ+mXkTgcIq8BoEwERFAQKBgQDmImBaFqoMSVihqHIf\nDa4WZqwM7ODqOx0JnBKrKO8UOc51J5e1vpwP/qRpNhUipoILvIWJzu4efZY7GN5C\nImF9sN3PP6Sy044fkVPyw4SYEisxbvp9tfw8Xmpj/pbmugkB2ut6lz5frmEBoJSN\n3osZlZTgx+pM3sO6ITV6U4ID2Q==\n-----END PRIVATE KEY-----\n",
+      "client_email": "dummy@developer.gserviceaccount.com",
+      "client_id": "dummy",
+      "auth_uri": format!("{}/auth", oauth_endpoint),
+      "token_uri": format!("{}{}", oauth_server, auth_mock::AUTH_TOKEN_ENDPOINT),
+      "auth_provider_x509_cert_url": format!("{}/v1/certs", oauth_endpoint),
+      "client_x509_cert_url": format!("{}/robot/v1/metadata/x509/457015483506-compute%40developer.gserviceaccount.com", oauth_server)
+    })
+}
+

--- a/wrappers/test/expected/bigquery.out
+++ b/wrappers/test/expected/bigquery.out
@@ -1,0 +1,52 @@
+-- create foreign data wrapper and enable 'BigQueryFdw'
+drop foreign data wrapper if exists bigquery_wrapper cascade;
+NOTICE:  foreign-data wrapper "bigquery_wrapper" does not exist, skipping
+create foreign data wrapper bigquery_wrapper
+  handler wrappers_handler
+  validator wrappers_validator
+  options (
+    wrapper 'BigQueryFdw'
+  );
+-- create a wrappers BigQuery server and specify connection info
+drop server if exists my_bigquery_server cascade;
+NOTICE:  server "my_bigquery_server" does not exist, skipping
+create server my_bigquery_server
+  foreign data wrapper bigquery_wrapper
+  options (
+    project_id 'test_project',
+    dataset_id 'test_dataset',
+	api_endpoint 'http://bigquery:9111',
+	mock_auth 'true'
+  );
+  
+-- create an example foreign table
+drop foreign table if exists test_table;
+NOTICE:  foreign table "test_table" does not exist, skipping
+create foreign table test_table (
+  id bigint,
+  name text
+)
+  server my_bigquery_server
+  options (
+    table 'test_table',
+    rowid_column 'id'
+  );
+  
+  
+select * from test_table;
+ id | name 
+----+------
+  1 | foo
+  2 | bar
+(2 rows)
+
+insert into test_table (id, name)
+values (3, 'baz');
+select * from test_table;
+ id | name 
+----+------
+  1 | foo
+  2 | bar
+  3 | baz
+(3 rows)
+

--- a/wrappers/test/sql/bigquery.sql
+++ b/wrappers/test/sql/bigquery.sql
@@ -1,0 +1,38 @@
+-- create foreign data wrapper and enable 'BigQueryFdw'
+drop foreign data wrapper if exists bigquery_wrapper cascade;
+create foreign data wrapper bigquery_wrapper
+  handler wrappers_handler
+  validator wrappers_validator
+  options (
+    wrapper 'BigQueryFdw'
+  );
+
+-- create a wrappers BigQuery server and specify connection info
+drop server if exists my_bigquery_server cascade;
+create server my_bigquery_server
+  foreign data wrapper bigquery_wrapper
+  options (
+    project_id 'test_project',
+    dataset_id 'test_dataset',
+	api_endpoint 'http://bigquery:9111',
+	mock_auth 'true'
+  );
+  
+-- create an example foreign table
+drop foreign table if exists test_table;
+create foreign table test_table (
+  id bigint,
+  name text
+)
+  server my_bigquery_server
+  options (
+    table 'test_table',
+    rowid_column 'id'
+  );
+  
+  
+select * from test_table;
+
+insert into test_table (id, name)
+values (3, 'baz');
+select * from test_table;


### PR DESCRIPTION
## What kind of change does this PR introduce?
Adds `select` and `insert` tests for `bigquery_fdw`

Note:
`update` and `delete` are not currently covered. When using those methods against the [bigquery emulator](https://github.com/goccy/bigquery-emulator) the query hangs. After the process exists (after ~15 seconds) the update/delete DID occur, but the client doesn't return. That issue is not present when connecting to cloud hosted BigQuery.

I'd like to merge this to get some minimal coverage and circle back to update/delete in a separate PR