### PR TITLE
Upgrade pgx to 0.6.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,8 +38,8 @@ jobs:
         extension_name:
           - wrappers
         pgx_version:
-          - 0.5.6
-        postgres: [14]
+          - 0.6.0
+        postgres: [14, 15]
         features:
           - "bigquery_fdw,clickhouse_fdw,stripe_fdw,firebase_fdw"
         box:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -676,19 +676,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_threads"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "once_cell"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
+checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
 name = "overload"
@@ -759,9 +750,9 @@ dependencies = [
 
 [[package]]
 name = "pgx"
-version = "0.5.6"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58b9addd0e22dd8a288414d28680dfca9b5d3304da1b29cc0fc24e65a1af026"
+checksum = "7652ea68f83ee6308d165826c0fde48d439bc6176b6ff91d202158840e58951f"
 dependencies = [
  "atomic-traits",
  "bitflags",
@@ -789,9 +780,9 @@ dependencies = [
 
 [[package]]
 name = "pgx-macros"
-version = "0.5.6"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da7eb8e41b10375bcef714474ca58a6cc049640dd167d7783db308b703c44a14"
+checksum = "893a2aa60e5172feea53db8ec17c5cd0e8c70aa68879fda4c8798fb74c67d7a0"
 dependencies = [
  "pgx-utils",
  "proc-macro2",
@@ -802,9 +793,9 @@ dependencies = [
 
 [[package]]
 name = "pgx-pg-config"
-version = "0.5.6"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78fb4764144e366314eae67fd7aa1801e51790172c62eb7731a6d5ff36036ae4"
+checksum = "604b0165c023ac7fa26d558b89caad6ce8e947dc37654c00356a5e72022e1db5"
 dependencies = [
  "dirs",
  "eyre",
@@ -818,12 +809,13 @@ dependencies = [
 
 [[package]]
 name = "pgx-pg-sys"
-version = "0.5.6"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5116a27961f08337961cfb9e7be73c809e68c1001e9b205b9584ecd744471bb"
+checksum = "b56db285d63898b8b13ceeea3c63d269a46bdd302662312a120c743a5bf0036b"
 dependencies = [
  "bindgen",
  "eyre",
+ "libc",
  "memoffset",
  "once_cell",
  "pgx-macros",
@@ -839,9 +831,9 @@ dependencies = [
 
 [[package]]
 name = "pgx-tests"
-version = "0.5.6"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce250496208c64c546f614d604208edea4b447edd17873a90283e5ac4b9de594"
+checksum = "0b7359545fdddf10242c87f100502268ad155a9cd89c96b69813e6edd80863ac"
 dependencies = [
  "eyre",
  "libc",
@@ -855,16 +847,15 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "shutdown_hooks",
  "thiserror",
  "time",
 ]
 
 [[package]]
 name = "pgx-utils"
-version = "0.5.6"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a866f68ab3fcc7cc38a0b121581f2939deebddde1bae396b1e03498d4d82315e"
+checksum = "1c63119438e1d7f44333908bacf40ec1aa1c6aaac5d8f5023d213a12f28f430e"
 dependencies = [
  "atty",
  "convert_case",
@@ -1020,11 +1011,10 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.5.3"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
+checksum = "1e060280438193c554f654141c9ea9417886713b7acd75974c85b18a69a88e0b"
 dependencies = [
- "autocfg",
  "crossbeam-deque",
  "either",
  "rayon-core",
@@ -1032,9 +1022,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.9.3"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
+checksum = "cac410af5d00ab6884528b4ab69d1e8e146e8d471201800fa1b4524126de6ad3"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -1064,9 +1054,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
+checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1207,9 +1197,9 @@ checksum = "0772c5c30e1a0d91f6834f8e545c69281c099dfa9a3ac58d96a9fd629c8d4898"
 
 [[package]]
 name = "serde"
-version = "1.0.147"
+version = "1.0.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
+checksum = "e53f64bb4ba0191d6d0676e1b141ca55047d83b74f5607e6d8eb88126c52c2dc"
 dependencies = [
  "serde_derive",
 ]
@@ -1226,9 +1216,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.147"
+version = "1.0.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
+checksum = "a55492425aa53521babf6137309e7d34c20bbfbbfcfe2c7f3a047fd1f6b92c0c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1237,9 +1227,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.87"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce777b7b150d76b9cf60d28b55f5847135a003f7d7350c6be7a773508ce7d45"
+checksum = "020ff22c755c2ed3f8cf162dbb41a7268d934702f3ed3631656ea597e08fc3db"
 dependencies = [
  "itoa",
  "ryu",
@@ -1271,12 +1261,6 @@ name = "shlex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
-
-[[package]]
-name = "shutdown_hooks"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6057adedbec913419c92996f395ba69931acbd50b7d56955394cd3f7bedbfa45"
 
 [[package]]
 name = "siphasher"
@@ -1368,9 +1352,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.103"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
+checksum = "60b9b43d45702de4c839cb9b51d9f529c5dd26a4aff255b42b1ebc03e88ee908"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1414,13 +1398,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fab5c8b9980850e06d92ddbe3ab839c062c801f3927c0fb8abd6fc8e918fbca"
+checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
 dependencies = [
  "itoa",
- "libc",
- "num_threads",
  "serde",
  "time-core",
  "time-macros",
@@ -1434,9 +1416,9 @@ checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
 
 [[package]]
 name = "time-macros"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bb801831d812c562ae7d2bfb531f26e66e4e1f6b17307ba4149c5064710e5b"
+checksum = "d967f99f534ca7e495c575c62638eebc2898a8c84c119b89e250477bc4ba16b2"
 dependencies = [
  "time-core",
 ]

--- a/supabase-wrappers-macros/src/instance.rs
+++ b/supabase-wrappers-macros/src/instance.rs
@@ -40,7 +40,6 @@ fn to_tokens(fdw_types: &Punctuated<FdwType, Token![,]>) -> TokenStream2 {
 
     quote! {
         use pgx::prelude::*;
-        use pgx::log::PgSqlErrorCode;
         use std::collections::HashMap;
         use ::supabase_wrappers::prelude::*;
 

--- a/supabase-wrappers-macros/src/modify.rs
+++ b/supabase-wrappers-macros/src/modify.rs
@@ -8,7 +8,7 @@ fn to_tokens() -> TokenStream2 {
             memcxt::{PgMemoryContexts, void_mut_ptr},
             tupdesc::PgTupleDesc,
             rel::PgRelation,
-            log::PgSqlErrorCode,
+            PgSqlErrorCode,
             FromDatum, debug2
         };
         use std::collections::HashMap;
@@ -110,7 +110,7 @@ fn to_tokens() -> TokenStream2 {
                     if pgx::name_data_to_str(&attr.attname) == rowid_name {
                         // make a Var representing the desired value
                         let var = pg_sys::makeVar(
-                            rtindex,
+                            rtindex as i32,
                             attr.attnum,
                             attr.atttypid,
                             attr.atttypmod,

--- a/supabase-wrappers-macros/src/polyfill.rs
+++ b/supabase-wrappers-macros/src/polyfill.rs
@@ -4,7 +4,7 @@ use quote::{quote, ToTokens, TokenStreamExt};
 fn to_tokens() -> TokenStream2 {
     quote! {
         use pgx::prelude::*;
-        use pgx::Datum;
+        use pgx::pg_sys::Datum;
         use std::os::raw::c_int;
         use std::slice;
 

--- a/supabase-wrappers-macros/src/qual.rs
+++ b/supabase-wrappers-macros/src/qual.rs
@@ -61,11 +61,9 @@ fn to_tokens() -> TokenStream2 {
             );
             if htup.is_null() {
                 pg_sys::ReleaseSysCache(htup);
-                pgx::log::elog(
-                    pgx::log::PgLogLevel::ERROR,
-                    &format!("cache lookup operator {} failed", opno),
+                pgx::error!(
+                    "cache lookup operator {} failed", opno
                 );
-                return ptr::null_mut();
             }
             let op = pg_sys::pgx_GETSTRUCT(htup) as pg_sys::Form_pg_operator;
             pg_sys::ReleaseSysCache(htup);

--- a/supabase-wrappers-macros/src/scan.rs
+++ b/supabase-wrappers-macros/src/scan.rs
@@ -14,12 +14,12 @@ fn to_tokens() -> TokenStream2 {
         use pgx::{
             prelude::*,
             list::PgList,
-            log::PgSqlErrorCode,
+            PgSqlErrorCode,
             memcxt::PgMemoryContexts,
             nodes::is_a,
             tupdesc::PgTupleDesc,
             rel::PgRelation,
-            Datum, FromDatum, IntoDatum, PgOid, debug2
+            pg_sys::Datum, FromDatum, IntoDatum, PgOid, debug2
         };
         use std::collections::HashMap;
         use std::os::raw::{c_int, c_char};
@@ -216,11 +216,9 @@ fn to_tokens() -> TokenStream2 {
                     .and_then(|c| match c.parse::<f64>() {
                         Ok(v) => Some(v),
                         Err(_) => {
-                            pgx::log::elog(
-                                pgx::log::PgLogLevel::ERROR,
-                                &format!("invalid option startup_cost: {}", c),
+                            pgx::error!(
+                                "invalid option startup_cost: {}", c
                             );
-                            Some(0.0)
                         }
                     })
                     .unwrap_or(0.0);

--- a/supabase-wrappers-macros/src/utils.rs
+++ b/supabase-wrappers-macros/src/utils.rs
@@ -4,7 +4,6 @@ use quote::{quote, ToTokens, TokenStreamExt};
 fn to_tokens() -> TokenStream2 {
     quote! {
         use pgx::prelude::*;
-        use pgx::log::PgSqlErrorCode;
         use pgx::tupdesc::PgTupleDesc;
         use pgx::list::PgList;
         use std::collections::HashMap;
@@ -84,7 +83,7 @@ fn to_tokens() -> TokenStream2 {
             // get column names from var list
             let col_vars: PgList<pg_sys::Var> = PgList::from_pg(col_vars);
             for var in col_vars.iter_ptr() {
-                let rte = pg_sys::planner_rt_fetch((*var).varno, root);
+                let rte = pg_sys::planner_rt_fetch((*var).varno as u32, root);
                 let attno = (*var).varattno;
                 let attname = pg_sys::get_attname((*rte).relid, attno, true);
                 if !attname.is_null() {

--- a/supabase-wrappers/Cargo.toml
+++ b/supabase-wrappers/Cargo.toml
@@ -11,25 +11,25 @@ categories = ["database"]
 keywords = ["database", "postgres", "postgresql", "extension"]
 
 [features]
-default = ["pg14"]
-pg10 = ["pgx/pg10", "pgx-tests/pg10" ]
+default = ["pg15"]
 pg11 = ["pgx/pg11", "pgx-tests/pg11" ]
 pg12 = ["pgx/pg12", "pgx-tests/pg12" ]
 pg13 = ["pgx/pg13", "pgx-tests/pg13" ]
 pg14 = ["pgx/pg14", "pgx-tests/pg14" ]
+pg15 = ["pgx/pg15", "pgx-tests/pg15" ]
 pg_test = []
 
 [dependencies]
-pgx = { version = "=0.5.6" }
+pgx = {version = "=0.6.0", default-features = false }
 tokio = { version = "1.21", features = ["rt"] }
 uuid = { version = "1.2.2" }
 supabase-wrappers-macros = { version = "0.1", path = "../supabase-wrappers-macros" }
 
 [dev-dependencies]
-pgx-tests = "=0.5.6"
+pgx-tests = "=0.6.0"
 
 [package.metadata.docs.rs]
-features = ["pg14"]
+features = ["pg15"]
 no-default-features = true
 # Enable `#[cfg(docsrs)]` (https://docs.rs/about/builds#cross-compiling)
 rustc-args = ["--cfg", "docsrs"]

--- a/supabase-wrappers/src/interface.rs
+++ b/supabase-wrappers/src/interface.rs
@@ -1,6 +1,6 @@
 use pgx::pg_sys::Oid;
 use pgx::prelude::{Date, Timestamp};
-use pgx::{Datum, FromDatum, IntoDatum, JsonB, PgBuiltInOids, PgOid};
+use pgx::{pg_sys::Datum, FromDatum, IntoDatum, JsonB, PgBuiltInOids, PgOid};
 use std::collections::HashMap;
 use std::fmt;
 use std::iter::Zip;

--- a/supabase-wrappers/src/lib.rs
+++ b/supabase-wrappers/src/lib.rs
@@ -12,11 +12,11 @@
 //! $ cargo pgx new my_project
 //! ```
 //!
-//! And then change default Postgres version to `pg14` and add below dependencies to your project's `Cargo.toml`,
+//! And then change default Postgres version to `pg15` and add below dependencies to your project's `Cargo.toml`,
 //!
 //! ```toml
 //! [features]
-//! default = ["pg14"]
+//! default = ["pg15"]
 //! ...
 //!
 //! [dependencies]

--- a/wrappers/.ci/docker-compose.yaml
+++ b/wrappers/.ci/docker-compose.yaml
@@ -17,8 +17,6 @@ services:
         condition: service_healthy
       firebase:
         condition: service_healthy
-      bigquery:
-        condition: service_healthy
 
   clickhouse:
     image: clickhouse/clickhouse-server
@@ -64,20 +62,3 @@ services:
       interval: 10s
       timeout: 5s
       retries: 30
-
-  bigquery:
-    container_name: bigquery-local
-    build:
-      context: ../..
-      dockerfile: ./wrappers/dockerfiles/bigquery/Dockerfile
-    volumes:
-      - ${PWD}/dockerfiles/bigquery/data.yaml:/app/data.yaml
-    ports:
-      - "9111:9111" # REST
-      - "9060:9060" # gRPC
-    command: --project=test --dataset=dataset1 --data-from-yaml=/app/data.yaml --port=9111
-    healthcheck:
-      test: curl --fail http://0.0.0.0:9111/bigquery/v2/projects/test_project/datasets/test_dataset || exit 1
-      interval: 10s
-      timeout: 5s
-      retries: 3

--- a/wrappers/Cargo.lock
+++ b/wrappers/Cargo.lock
@@ -1530,9 +1530,9 @@ dependencies = [
 
 [[package]]
 name = "pgx"
-version = "0.5.6"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58b9addd0e22dd8a288414d28680dfca9b5d3304da1b29cc0fc24e65a1af026"
+checksum = "7652ea68f83ee6308d165826c0fde48d439bc6176b6ff91d202158840e58951f"
 dependencies = [
  "atomic-traits",
  "bitflags",
@@ -1560,9 +1560,9 @@ dependencies = [
 
 [[package]]
 name = "pgx-macros"
-version = "0.5.6"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da7eb8e41b10375bcef714474ca58a6cc049640dd167d7783db308b703c44a14"
+checksum = "893a2aa60e5172feea53db8ec17c5cd0e8c70aa68879fda4c8798fb74c67d7a0"
 dependencies = [
  "pgx-utils",
  "proc-macro2",
@@ -1573,9 +1573,9 @@ dependencies = [
 
 [[package]]
 name = "pgx-pg-config"
-version = "0.5.6"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78fb4764144e366314eae67fd7aa1801e51790172c62eb7731a6d5ff36036ae4"
+checksum = "604b0165c023ac7fa26d558b89caad6ce8e947dc37654c00356a5e72022e1db5"
 dependencies = [
  "dirs",
  "eyre",
@@ -1589,12 +1589,13 @@ dependencies = [
 
 [[package]]
 name = "pgx-pg-sys"
-version = "0.5.6"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5116a27961f08337961cfb9e7be73c809e68c1001e9b205b9584ecd744471bb"
+checksum = "b56db285d63898b8b13ceeea3c63d269a46bdd302662312a120c743a5bf0036b"
 dependencies = [
  "bindgen",
  "eyre",
+ "libc",
  "memoffset",
  "once_cell",
  "pgx-macros",
@@ -1610,9 +1611,9 @@ dependencies = [
 
 [[package]]
 name = "pgx-tests"
-version = "0.5.6"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce250496208c64c546f614d604208edea4b447edd17873a90283e5ac4b9de594"
+checksum = "0b7359545fdddf10242c87f100502268ad155a9cd89c96b69813e6edd80863ac"
 dependencies = [
  "eyre",
  "libc",
@@ -1626,16 +1627,15 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "shutdown_hooks",
  "thiserror",
  "time 0.3.17",
 ]
 
 [[package]]
 name = "pgx-utils"
-version = "0.5.6"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a866f68ab3fcc7cc38a0b121581f2939deebddde1bae396b1e03498d4d82315e"
+checksum = "1c63119438e1d7f44333908bacf40ec1aa1c6aaac5d8f5023d213a12f28f430e"
 dependencies = [
  "atty",
  "convert_case",
@@ -1879,11 +1879,10 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.5.3"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
+checksum = "1e060280438193c554f654141c9ea9417886713b7acd75974c85b18a69a88e0b"
 dependencies = [
- "autocfg",
  "crossbeam-deque",
  "either",
  "rayon-core",
@@ -1891,9 +1890,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.9.3"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
+checksum = "cac410af5d00ab6884528b4ab69d1e8e146e8d471201800fa1b4524126de6ad3"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -2277,9 +2276,9 @@ checksum = "0772c5c30e1a0d91f6834f8e545c69281c099dfa9a3ac58d96a9fd629c8d4898"
 
 [[package]]
 name = "serde"
-version = "1.0.147"
+version = "1.0.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
+checksum = "e53f64bb4ba0191d6d0676e1b141ca55047d83b74f5607e6d8eb88126c52c2dc"
 dependencies = [
  "serde_derive",
 ]
@@ -2296,9 +2295,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.147"
+version = "1.0.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
+checksum = "a55492425aa53521babf6137309e7d34c20bbfbbfcfe2c7f3a047fd1f6b92c0c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2307,9 +2306,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.87"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce777b7b150d76b9cf60d28b55f5847135a003f7d7350c6be7a773508ce7d45"
+checksum = "020ff22c755c2ed3f8cf162dbb41a7268d934702f3ed3631656ea597e08fc3db"
 dependencies = [
  "itoa",
  "ryu",
@@ -2364,12 +2363,6 @@ name = "shlex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
-
-[[package]]
-name = "shutdown_hooks"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6057adedbec913419c92996f395ba69931acbd50b7d56955394cd3f7bedbfa45"
 
 [[package]]
 name = "siphasher"
@@ -2466,9 +2459,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.103"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
+checksum = "60b9b43d45702de4c839cb9b51d9f529c5dd26a4aff255b42b1ebc03e88ee908"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/wrappers/Cargo.toml
+++ b/wrappers/Cargo.toml
@@ -7,12 +7,12 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [features]
-default = ["pg14"]
-pg10 = ["pgx/pg10", "pgx-tests/pg10" ]
-pg11 = ["pgx/pg11", "pgx-tests/pg11" ]
-pg12 = ["pgx/pg12", "pgx-tests/pg12" ]
-pg13 = ["pgx/pg13", "pgx-tests/pg13" ]
-pg14 = ["pgx/pg14", "pgx-tests/pg14" ]
+default = ["pg15"]
+pg11 = ["pgx/pg11", "pgx-tests/pg11", "supabase-wrappers/pg11" ]
+pg12 = ["pgx/pg12", "pgx-tests/pg12", "supabase-wrappers/pg12" ]
+pg13 = ["pgx/pg13", "pgx-tests/pg13", "supabase-wrappers/pg13" ]
+pg14 = ["pgx/pg14", "pgx-tests/pg14", "supabase-wrappers/pg14" ]
+pg15 = ["pgx/pg15", "pgx-tests/pg15", "supabase-wrappers/pg15" ]
 pg_test = []
 
 helloworld_fdw = []
@@ -25,10 +25,10 @@ firebase_fdw = ["reqwest", "reqwest-middleware", "reqwest-retry", "serde_json", 
 airtable_fdw = ["reqwest", "reqwest-middleware", "reqwest-retry", "serde_json", "serde", "url"]
 
 [dependencies]
-pgx = "=0.5.6"
+pgx = { version = "=0.6.0", features = ["time-crate"] }
 cfg-if = "1.0"
 #supabase-wrappers = "0.1"
-supabase-wrappers = { path = "../supabase-wrappers" }
+supabase-wrappers = { path = "../supabase-wrappers", default-features = false }
 
 # for clickhouse_fdw
 clickhouse-rs = { git = "https://github.com/suharev7/clickhouse-rs", branch = "async-await", features = ["tls"], optional = true }
@@ -55,7 +55,7 @@ regex = { version = "1", optional = true }
 url = { version = "2.3", optional = true }
 
 [dev-dependencies]
-pgx-tests = "=0.5.6"
+pgx-tests = "=0.6.0"
 
 [profile.dev]
 panic = "unwind"

--- a/wrappers/bin/installcheck
+++ b/wrappers/bin/installcheck
@@ -25,7 +25,7 @@ rm -rf "$tmpdir"
 # Initialize: setting PGUSER as the owner
 initdb --no-locale --encoding=UTF8 --nosync -U "$PGUSER"
 # Start the server
-pg_ctl start -o "-F -c listen_addresses=\"\" -c log_min_messages=WARNING -c shared_preload_libraries='pgsodium' -c pgsodium.getkey_script='/usr/share/postgresql/14/extension/pgsodium_getkey.sh' -k $PGDATA"
+pg_ctl start -o "-F -c listen_addresses=\"\" -c log_min_messages=WARNING -c shared_preload_libraries='pgsodium' -c pgsodium.getkey_script='/usr/share/postgresql/15/extension/pgsodium_getkey.sh' -k $PGDATA"
 
 # Start the server
 createdb contrib_regression

--- a/wrappers/dockerfiles/pg/Dockerfile
+++ b/wrappers/dockerfiles/pg/Dockerfile
@@ -1,10 +1,10 @@
-FROM postgres:14
+FROM postgres:15
 RUN apt-get update
 ENV build_deps ca-certificates \
   git \
   build-essential \
   libpq-dev \
-  postgresql-server-dev-14 \
+  postgresql-server-dev-15 \
   curl \
   libreadline6-dev \
   zlib1g-dev
@@ -22,10 +22,10 @@ RUN \
   rustup --version && \
   rustc --version && \
   cargo --version
-  
+
 # PGX
-RUN cargo install cargo-pgx
-RUN cargo pgx init --pg14 $(which pg_config)
+RUN cargo install cargo-pgx --version 0.6.0
+RUN cargo pgx init --pg15 $(which pg_config)
 USER root
 
 # Install libsodium
@@ -40,7 +40,7 @@ RUN \
   git clone https://github.com/michelp/pgsodium.git && \
   cd pgsodium && \
   make && make install && \
-  cp getkey_scripts/pgsodium_getkey_urandom.sh /usr/share/postgresql/14/extension/pgsodium_getkey.sh
+  cp getkey_scripts/pgsodium_getkey_urandom.sh /usr/share/postgresql/15/extension/pgsodium_getkey.sh
 
 # Install Vault
 RUN \
@@ -57,7 +57,7 @@ COPY wrappers/Cargo.lock Cargo.lock
 COPY wrappers/wrappers.control wrappers.control
 COPY wrappers/bin bin
 COPY wrappers/src src
-RUN cargo pgx install --features pg14,clickhouse_fdw,firebase_fdw,bigquery_fdw,stripe_fdw
+RUN cargo pgx install --features pg15,clickhouse_fdw,firebase_fdw,bigquery_fdw,stripe_fdw
 
 COPY wrappers/test test
 RUN chown -R postgres:postgres /home/app

--- a/wrappers/src/fdw/airtable_fdw/airtable_fdw.rs
+++ b/wrappers/src/fdw/airtable_fdw/airtable_fdw.rs
@@ -1,4 +1,4 @@
-use pgx::log::PgSqlErrorCode;
+use pgx::prelude::PgSqlErrorCode;
 use reqwest::{self, header};
 use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};
 use reqwest_retry::{policies::ExponentialBackoff, RetryTransientMiddleware};

--- a/wrappers/src/fdw/bigquery_fdw/bigquery_fdw.rs
+++ b/wrappers/src/fdw/bigquery_fdw/bigquery_fdw.rs
@@ -8,7 +8,7 @@ use gcp_bigquery_client::{
     },
     Client,
 };
-use pgx::log::PgSqlErrorCode;
+use pgx::prelude::PgSqlErrorCode;
 use pgx::prelude::{Date, Timestamp};
 use serde_json::json;
 use std::collections::HashMap;

--- a/wrappers/src/fdw/clickhouse_fdw/clickhouse_fdw.rs
+++ b/wrappers/src/fdw/clickhouse_fdw/clickhouse_fdw.rs
@@ -1,7 +1,6 @@
 use chrono::DateTime;
 use clickhouse_rs::{types, types::Block, types::SqlType, ClientHandle, Pool};
-use pgx::log::PgSqlErrorCode;
-use pgx::prelude::Timestamp;
+use pgx::prelude::{PgSqlErrorCode, Timestamp};
 use std::collections::HashMap;
 use time::OffsetDateTime;
 

--- a/wrappers/src/fdw/firebase_fdw/firebase_fdw.rs
+++ b/wrappers/src/fdw/firebase_fdw/firebase_fdw.rs
@@ -1,5 +1,4 @@
-use pgx::log::PgSqlErrorCode;
-use pgx::prelude::Timestamp;
+use pgx::prelude::*;
 use pgx::JsonB;
 use regex::Regex;
 use reqwest::{self, header};

--- a/wrappers/src/fdw/stripe_fdw/stripe_fdw.rs
+++ b/wrappers/src/fdw/stripe_fdw/stripe_fdw.rs
@@ -1,4 +1,4 @@
-use pgx::log::PgSqlErrorCode;
+use pgx::prelude::PgSqlErrorCode;
 use reqwest::{self, header};
 use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};
 use reqwest_retry::{policies::ExponentialBackoff, RetryTransientMiddleware};


### PR DESCRIPTION
Problem: wrappers uses pgx 0.5.6

This version is outdated.

Solution: upgrade to 0.6.0

I've also set the default version of Postgres to 15 as pgx supports it now and this is the most recent version that keeps evolving, therefore it would be better to track it to catch new failures.

## What kind of change does this PR introduce?

Dependency update

## What is the current behavior?

Using pgx 0.5.6

## What is the new behavior?

Using pgx 0.6.0

## Additional context

