### PR TITLE
Use stable Rust in CI

### DIFF
--- a/wrappers/dockerfiles/pg/Dockerfile
+++ b/wrappers/dockerfiles/pg/Dockerfile
@@ -18,7 +18,7 @@ USER postgres
 
 # Install Rust
 RUN \
-  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --profile minimal --default-toolchain nightly && \
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --profile minimal --default-toolchain stable && \
   rustup --version && \
   rustc --version && \
   cargo --version


### PR DESCRIPTION
Problem: CI uses nightly Rust

This may cause unexpected bugs or performance issues.

Solution: track stable Rust instead

Nothing in the project seem to require nightly Rust at the moment.

## What kind of change does this PR introduce?

CI update

## What is the current behavior?

Using nightly Rust in CI

## What is the new behavior?

Using stable Rust in CI

## Additional context

