### PR TITLE
Problem: CI is painfully slow

### DIFF
--- a/.github/workflows/test_wrappers.yml
+++ b/.github/workflows/test_wrappers.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   test:
     name: Run tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-20.04-4core
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
Solution: use a larger runner (4 cores, 16 GB RAM)