### PR TITLE
docs: change badge link and fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![crates.io badge](https://img.shields.io/crates/v/supabase-wrappers.svg)](https://crates.io/crates/supabase-wrappers)
 [![docs.rs badge](https://docs.rs/supabase-wrappers/badge.svg)](https://docs.rs/supabase-wrappers)
-[![Release Status](https://img.shields.io/github/workflow/status/supabase/wrappers/Release)](https://github.com/supabase/wrappers/actions/workflows/Release)
+[![Test Status](https://img.shields.io/github/workflow/status/supabase/wrappers/Test%20Wrappers)](https://github.com/supabase/wrappers/actions/workflows/test_wrappers.yml)
 [![MIT/Apache-2 licensed](https://img.shields.io/crates/l/supabase-wrappers.svg)](./LICENSE)
 [![Contributors](https://img.shields.io/github/contributors/supabase/wrappers)](https://github.com/supabase/wrappers/graphs/contributors)
 

--- a/supabase-wrappers-macros/README.md
+++ b/supabase-wrappers-macros/README.md
@@ -1,3 +1,3 @@
 # supabase-wrappers-macros
 
-This crate is to provide helper macros for `Wrapper` and NOT supposed to be used directly, please use [supabase-wrappers](https://github.com/supabase/wrappers/tree/main/supabase-wrappers) instead.
+This crate is to provide helper macros for `Wrappers` and NOT supposed to be used directly, please use [supabase-wrappers](https://github.com/supabase/wrappers/tree/main/supabase-wrappers) instead.

--- a/supabase-wrappers/README.md
+++ b/supabase-wrappers/README.md
@@ -2,7 +2,7 @@
 
 [![crates.io badge](https://img.shields.io/crates/v/supabase-wrappers.svg)](https://crates.io/crates/supabase-wrappers)
 [![docs.rs badge](https://docs.rs/supabase-wrappers/badge.svg)](https://docs.rs/supabase-wrappers)
-[![Release Status](https://img.shields.io/github/workflow/status/supabase/wrappers/Release)](https://github.com/supabase/wrappers/actions/workflows/Release)
+[![Test Status](https://img.shields.io/github/workflow/status/supabase/wrappers/Test%20Wrappers)](https://github.com/supabase/wrappers/actions/workflows/test_wrappers.yml)
 [![MIT/Apache-2 licensed](https://img.shields.io/crates/l/supabase-wrappers.svg)](./LICENSE)
 [![Contributors](https://img.shields.io/github/contributors/supabase/wrappers)](https://github.com/supabase/wrappers/graphs/contributors)
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to fix badge link and fix typo in docs.

## What is the current behavior?

N/A

## What is the new behavior?

N/A

## Additional context

N/A
