### PR TITLE
fix: add float type support for bigquery fdw

### DIFF
--- a/wrappers/src/fdw/bigquery_fdw/bigquery_fdw.rs
+++ b/wrappers/src/fdw/bigquery_fdw/bigquery_fdw.rs
@@ -37,6 +37,10 @@ fn field_to_cell(rs: &ResultSet, field: &TableFieldSchema) -> Option<Cell> {
             .get_i64_by_name(&field.name)
             .unwrap_or_else(|err| field_type_error!(field, err))
             .map(Cell::I64),
+        FieldType::Float64 | FieldType::Float => rs
+            .get_f64_by_name(&field.name)
+            .unwrap_or_else(|err| field_type_error!(field, err))
+            .map(Cell::F64),
         FieldType::String => rs
             .get_string_by_name(&field.name)
             .unwrap_or_else(|err| field_type_error!(field, err))


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to add float data type support bigquery fdw.

## What is the current behavior?

Currently it cannot read `Float/Float64` data type from BigQuery.

## What is the new behavior?

It should be able to read `Float/Float64` data types.

## Additional context

N/A
