### PR TITLE
docs: add docs for new() and update Cargo.lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ To develop a FDW using `Wrappers`, you only need to implement the [ForeignDataWr
 
 ```rust
 pub trait ForeignDataWrapper {
+    // create a FDW instance
+    fn new(...) -> Self;
+
     // functions for data scan, e.g. select
     fn begin_scan(...);
     fn iter_scan(...) -> Option<Row>;
@@ -62,7 +65,7 @@ pub trait ForeignDataWrapper {
 }
 ```
 
-In a minimum FDW, which supports data scan only, `begin_scan()`, `iter_scan()` and `end_scan()` are required, all the other functions are optional.
+In a minimum FDW, which supports data scan only, `new()`, `begin_scan()`, `iter_scan()` and `end_scan()` are required, all the other functions are optional.
 
 To know more about FDW development, please visit the [Wrappers documentation](https://docs.rs/supabase-wrappers/latest/supabase_wrappers/).
 

--- a/supabase-wrappers/README.md
+++ b/supabase-wrappers/README.md
@@ -45,6 +45,9 @@ To develop a FDW using `Wrappers`, you only need to implement the [ForeignDataWr
 
 ```rust
 pub trait ForeignDataWrapper {
+    // create a FDW instance
+    fn new(...) -> Self;
+
     // functions for data scan, e.g. select
     fn begin_scan(...);
     fn iter_scan(...) -> Option<Row>;
@@ -62,7 +65,7 @@ pub trait ForeignDataWrapper {
 }
 ```
 
-In a minimum FDW, which supports data scan only, `begin_scan()`, `iter_scan()` and `end_scan()` are required, all the other functions are optional.
+In a minimum FDW, which supports data scan only, `new()`, `begin_scan()`, `iter_scan()` and `end_scan()` are required, all the other functions are optional.
 
 To know more about FDW development, please visit the [Wrappers documentation](https://docs.rs/supabase-wrappers/latest/supabase_wrappers/).
 

--- a/wrappers/Cargo.lock
+++ b/wrappers/Cargo.lock
@@ -3210,7 +3210,7 @@ dependencies = [
 
 [[package]]
 name = "wrappers"
-version = "0.1.0"
+version = "0.1.5"
 dependencies = [
  "cfg-if",
  "chrono",


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to add docs for required function `new()` and also update wrappers version in Cargo.lock file.

## What is the current behavior?

Required `new()` function is missing in READMEs.

## What is the new behavior?

Add missing `new()` function docs.

## Additional context

N/A
