### PR TITLE
Fix typo on README s/WEHRE/WHERE/

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 - Support for rich data types.
 - Support both sync and async backends, such as RDBMS, RESTful APIs, flat files and etc.
 - Built on top of [pgx](https://github.com/tcdi/pgx), providing higher level interfaces, without hiding lower-level C APIs.
-- `WEHRE`, `ORDER BY`, `LIMIT` pushdown are supported.
+- `WHERE`, `ORDER BY`, `LIMIT` pushdown are supported.
 
 ## Documentation
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs Update

Assuming this is supposed to be the SQL `WHERE` keyword.

## What is the current behavior?

N/A

## What is the new behavior?

N/A

## Additional context

N/A
