### PR TITLE
Add Array/Object type handling to Airtable wrapper

### DIFF
--- a/wrappers/src/fdw/airtable_fdw/result.rs
+++ b/wrappers/src/fdw/airtable_fdw/result.rs
@@ -1,3 +1,4 @@
+use pgx::JsonB;
 use serde::de::{MapAccess, Visitor};
 use serde::{Deserialize, Deserializer};
 use serde_json::Value;
@@ -83,6 +84,7 @@ impl<'de> Deserialize<'de> for AirtableFields {
 impl AirtableRecord {
     fn value_to_cell(value: &Value) -> Option<Cell> {
         use serde_json::Value::*;
+
         match value {
             Null => None,
             Bool(v) => Some(Cell::Bool(*v)),
@@ -90,10 +92,9 @@ impl AirtableRecord {
                 .as_i64()
                 .map_or_else(|| n.as_f64().map(Cell::F64), |v| Some(Cell::I64(v))),
             String(v) => Some(Cell::String(v.clone())),
+            Array(v) => Some(Cell::Json(JsonB(serde_json::Value::Array(v.clone())))),
+            Object(v) => Some(Cell::Json(JsonB(serde_json::Value::Object(v.clone())))),
             // XXX Handle timestamps somehow...
-
-            // XXX Fix (probably map to JsonB)
-            _ => panic!("Unsupported: Array/Object"),
         }
     }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Introduces feature that allows Airtable FDW to handle `Object` and `Array` types from Airtable API.

## What is the current behavior?

FDW is not currently able to map Airtable `Object` / `Array` types to postgres. If it is attempted, the FDW handler raises a panic.

## What is the new behavior?

Airtable `Object` and `Array` types are mapped to `pgx::JsonB`. This means that these types must be mapped to a `jsonb` postgres column data type.

## Additional context

These types are especially useful, as this now allows users to handle Airtable types such as:
 - Image
 - Link to another record

This is by no means bulletproof (I am a Rust noob) or necessarily able to handle every Airtable type that maps to array / object, but it is certainly better than not being able to handle any of these Airtable types at all. 