### PR TITLE
Perf improvements

### DIFF
--- a/supabase-wrappers/src/interface.rs
+++ b/supabase-wrappers/src/interface.rs
@@ -189,6 +189,11 @@ impl Row {
         iter = keep.iter();
         self.cells.retain(|_| *iter.next().unwrap());
     }
+
+    pub fn clear(&mut self) {
+        self.cols.clear();
+        self.cells.clear();
+    }
 }
 
 /// A restiction value used in [`Qual`], either a [`Cell`] or an array of [`Cell`]
@@ -378,6 +383,11 @@ pub trait ForeignDataWrapper {
     ///
     /// [See more details](https://www.postgresql.org/docs/current/fdw-callbacks.html#FDW-CALLBACKS-SCAN).
     fn iter_scan(&mut self) -> Option<Row>;
+
+    fn iter_scan_borrowed(&mut self, row: &mut Row) -> Option<()> {
+        let _ = std::mem::replace(row, self.iter_scan()?);
+        Some(())
+    }
 
     /// Called when restart the scan from the beginning.
     ///

--- a/supabase-wrappers/src/scan.rs
+++ b/supabase-wrappers/src/scan.rs
@@ -306,7 +306,8 @@ pub(super) extern "C" fn begin_foreign_scan<W: ForeignDataWrapper>(
 pub(super) extern "C" fn iterate_foreign_scan<W: ForeignDataWrapper>(
     node: *mut pg_sys::ForeignScanState,
 ) -> *mut pg_sys::TupleTableSlot {
-    debug2!("---> iterate_foreign_scan");
+    // `debug!` macros are quite expensive at the moment, so avoid logging in the inner loop
+    // debug2!("---> iterate_foreign_scan");
     unsafe {
         let mut state = PgBox::<FdwState<W>>::from_pg((*node).fdw_state as _);
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

A new iter_scan method to reuse a borrowed `Row`; a few additional performance improvements.

## What is the current behavior?

`ForeignDataWrapper::iter_scan` requires the implementor to build a Row, which is quite expensive.

## What is the new behavior?

`ForeignDataWrapper::iter_scan_borrowed` takes a mutable ref to a Row owned by the caller; the implementor just needs to populate it.
A default implementation is provided that simply delegates to `ForeignDataWrapper::iter_scan` and swaps the returned `Row`.

## Additional context

On my machine (intel 8700k), in release mode, pg15, with a sample FDW that yields 10M "helloworld" rows, the time taken to execute `SELECT * FROM bench WHERE id < 0` are:
* Original: 3244,732 ms (00:03,245)
* Without `debug2!` on `iter_scan`: 1565,417 ms (00:01,565)
* Reusing `Row`: 1241,977 ms (00:01,242)

I've been unable to run the tests on this, the docs seem out of date and `cargo test` fails to compile.