### PR TITLE
:fix: allocate plan in query memory context

### DIFF
--- a/supabase-wrappers/src/scan.rs
+++ b/supabase-wrappers/src/scan.rs
@@ -208,13 +208,11 @@ pub(super) extern "C" fn get_foreign_plan<W: ForeignDataWrapper>(
     unsafe {
         let mut state = PgBox::<FdwState<W>>::from_pg((*baserel).fdw_private as _);
 
-        state.tmp_ctx.reset();
-        let mut old_ctx = state.tmp_ctx.set_as_current();
+        // Plan and plan data (e.g. scan_clauses) must live for the entire duration of the query
+        // As such, it must be allocated in the caller's memory context
 
         // make foreign scan plan
         let scan_clauses = pg_sys::extract_actual_clauses(scan_clauses, false);
-
-        old_ctx.set_as_current();
 
         let fdw_private = FdwState::serialize_to_list(state);
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix preventing the backend from crashing when `EXPLAIN ANALYZE` is used on a FDW query with nontrivial quals.

## What is the current behavior?

Backend crashes due to plan memory being allocated in a temporary memory context.

## What is the new behavior?

`explain_foreign_scan` allocates the plan in the query (caller's) memory context, thus ensuring it lives long enough.

## Additional context

Fixes https://github.com/supabase/wrappers/issues/45