### PR TITLE
chore: use borrowed row in iter_scan()

### DIFF
--- a/supabase-wrappers/src/lib.rs
+++ b/supabase-wrappers/src/lib.rs
@@ -136,12 +136,9 @@
 //!         self.tgt_cols = columns.to_vec();
 //!     }
 //!
-//!     fn iter_scan(&mut self) -> Option<Row> {
+//!     fn iter_scan(&mut self, row: &mut Row) -> Option<()> {
 //!         // this is called on each row and we only return one row here
 //!         if self.row_cnt < 1 {
-//!             // create an empty row
-//!             let mut row = Row::new();
-//!
 //!             // add values to row if they are in target column list
 //!             for tgt_col in &self.tgt_cols {
 //!                 match tgt_col.as_str() {
@@ -153,8 +150,8 @@
 //!
 //!             self.row_cnt += 1;
 //!
-//!             // return the 'Some(row)' to Postgres and continue data scan
-//!             return Some(row);
+//!             // return the 'Some(())' to Postgres and continue data scan
+//!             return Some(());
 //!         }
 //!
 //!         // return 'None' to stop data scan

--- a/supabase-wrappers/src/scan.rs
+++ b/supabase-wrappers/src/scan.rs
@@ -81,10 +81,9 @@ impl<W: ForeignDataWrapper> FdwState<W> {
         )
     }
 
-    fn iter_scan_borrowed(&mut self) -> Option<()> {
-        self.instance.iter_scan_borrowed(&mut self.row)
+    fn iter_scan(&mut self) -> Option<()> {
+        self.instance.iter_scan(&mut self.row)
     }
-
 
     fn re_scan(&mut self) {
         self.instance.re_scan()
@@ -320,7 +319,7 @@ pub(super) extern "C" fn iterate_foreign_scan<W: ForeignDataWrapper>(
         let mut old_ctx = state.tmp_ctx.set_as_current();
 
         state.row.clear();
-        if state.iter_scan_borrowed().is_some() {
+        if state.iter_scan().is_some() {
             if state.row.cols.len() != state.tgts.len() {
                 report_error(
                     PgSqlErrorCode::ERRCODE_FDW_INVALID_COLUMN_NUMBER,
@@ -332,7 +331,7 @@ pub(super) extern "C" fn iterate_foreign_scan<W: ForeignDataWrapper>(
 
             for i in 0..state.row.cells.len() {
                 let att_idx = state.tgt_attnos[i] - 1;
-                let cell =  state.row.cells.get_unchecked_mut(i);
+                let cell = state.row.cells.get_unchecked_mut(i);
                 match cell.take() {
                     Some(cell) => {
                         state.values[att_idx] = cell.into_datum().unwrap();

--- a/wrappers/src/fdw/airtable_fdw/airtable_fdw.rs
+++ b/wrappers/src/fdw/airtable_fdw/airtable_fdw.rs
@@ -161,10 +161,13 @@ impl ForeignDataWrapper for AirtableFdw {
         self.scan_result = Some(rows);
     }
 
-    fn iter_scan(&mut self) -> Option<Row> {
+    fn iter_scan(&mut self, row: &mut Row) -> Option<()> {
         if let Some(ref mut result) = self.scan_result {
             if !result.is_empty() {
-                return result.drain(0..1).last();
+                return result
+                    .drain(0..1)
+                    .last()
+                    .map(|src_row| row.replace_with(src_row));
             }
         }
         None

--- a/wrappers/src/fdw/bigquery_fdw/bigquery_fdw.rs
+++ b/wrappers/src/fdw/bigquery_fdw/bigquery_fdw.rs
@@ -286,18 +286,17 @@ impl ForeignDataWrapper for BigQueryFdw {
         }
     }
 
-    fn iter_scan(&mut self) -> Option<Row> {
+    fn iter_scan(&mut self, row: &mut Row) -> Option<()> {
         if let Some((ref tbl, ref mut rs)) = self.scan_result {
             if rs.next_row() {
                 if let Some(fields) = &tbl.schema.fields {
-                    let mut ret = Row::new();
                     for tgt_col in &self.tgt_cols {
                         if let Some(field) = fields.iter().find(|&f| &f.name == tgt_col) {
                             let cell = field_to_cell(rs, field);
-                            ret.push(&field.name, cell);
+                            row.push(&field.name, cell);
                         }
                     }
-                    return Some(ret);
+                    return Some(());
                 }
             }
         }

--- a/wrappers/src/fdw/firebase_fdw/firebase_fdw.rs
+++ b/wrappers/src/fdw/firebase_fdw/firebase_fdw.rs
@@ -366,10 +366,13 @@ impl ForeignDataWrapper for FirebaseFdw {
         }
     }
 
-    fn iter_scan(&mut self) -> Option<Row> {
+    fn iter_scan(&mut self, row: &mut Row) -> Option<()> {
         if let Some(ref mut result) = self.scan_result {
             if !result.is_empty() {
-                return result.drain(0..1).last();
+                return result
+                    .drain(0..1)
+                    .last()
+                    .map(|src_row| row.replace_with(src_row));
             }
         }
         None

--- a/wrappers/src/fdw/helloworld_fdw/helloworld_fdw.rs
+++ b/wrappers/src/fdw/helloworld_fdw/helloworld_fdw.rs
@@ -51,12 +51,9 @@ impl ForeignDataWrapper for HelloWorldFdw {
         self.tgt_cols = columns.to_vec();
     }
 
-    fn iter_scan(&mut self) -> Option<Row> {
+    fn iter_scan(&mut self, row: &mut Row) -> Option<()> {
         // this is called on each row and we only return one row here
         if self.row_cnt < 1 {
-            // create an empty row
-            let mut row = Row::new();
-
             // add values to row if they are in target column list
             for tgt_col in &self.tgt_cols {
                 match tgt_col.as_str() {
@@ -68,8 +65,8 @@ impl ForeignDataWrapper for HelloWorldFdw {
 
             self.row_cnt += 1;
 
-            // return the Some(row) to Postgres and continue data scan
-            return Some(row);
+            // return Some(()) to Postgres and continue data scan
+            return Some(());
         }
 
         // return 'None' to stop data scan

--- a/wrappers/src/fdw/stripe_fdw/stripe_fdw.rs
+++ b/wrappers/src/fdw/stripe_fdw/stripe_fdw.rs
@@ -503,10 +503,13 @@ impl ForeignDataWrapper for StripeFdw {
         }
     }
 
-    fn iter_scan(&mut self) -> Option<Row> {
+    fn iter_scan(&mut self, row: &mut Row) -> Option<()> {
         if let Some(ref mut result) = self.scan_result {
             if !result.is_empty() {
-                return result.drain(0..1).last();
+                return result
+                    .drain(0..1)
+                    .last()
+                    .map(|src_row| row.replace_with(src_row));
             }
         }
         None


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to use borrowed `row` in `iter_scan()` to improve performance, see #46 .

## What is the current behavior?

Currently in each call of the `iter_scan()` function, an empty new row needs to be created and values are copied over to Postgres, this can be slow when reading large number of rows.

## What is the new behavior?

The new `iter_scan()` function will pass a pre-allocated `row` and FDW can optionally use `mem::replace()` to directly move data in.

## Additional context

See more details in #46 .
