### PR TITLE
fix: add special treatment for null check in qual

### DIFF
--- a/supabase-wrappers/src/interface.rs
+++ b/supabase-wrappers/src/interface.rs
@@ -259,7 +259,15 @@ impl Qual {
             "".to_string()
         } else {
             match &self.value {
-                Value::Cell(cell) => format!("{} {} {}", self.field, self.operator, cell),
+                Value::Cell(cell) => match self.operator.as_str() {
+                    "is" | "is not" => match cell {
+                        Cell::String(cell) if cell == "null" => {
+                            format!("{} {} null", self.field, self.operator)
+                        }
+                        _ => format!("{} {} {}", self.field, self.operator, cell),
+                    },
+                    _ => format!("{} {} {}", self.field, self.operator, cell),
+                },
                 Value::Array(_) => unreachable!(),
             }
         }


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to fix a bug in `qual.deparse()` when dealing with null check condition.

## What is the current behavior?

#58

## What is the new behavior?

The null check in qual should be deparsed correctly.

## Additional context

N/A
