### PR TITLE
feat: add more Stripe Connect objects

### DIFF
--- a/docs/stripe.md
+++ b/docs/stripe.md
@@ -1,23 +1,26 @@
 [Stripe](https://stripe.com) is an API driven online payment processing utilty. `supabase/wrappers` exposes below endpoints.
 
-1.  [Balance](https://stripe.com/docs/api/balance) (*read only*)
-2.  [Balance Transactions](https://stripe.com/docs/api/balance_transactions/list) (*read only*)
-3.  [Charges](https://stripe.com/docs/api/charges/list) (*read only*)
-4.  [Customers](https://stripe.com/docs/api/customers/list) (*read and modify*)
-5.  [Disputes](https://stripe.com/docs/api/disputes/list) (*read only*)
-6.  [Events](https://stripe.com/docs/api/events/list) (*read only*)
-7.  [Files](https://stripe.com/docs/api/files/list) (*read only*)
-8.  [File Links](https://stripe.com/docs/api/file_links/list) (*read only*)
-9.  [Invoices](https://stripe.com/docs/api/invoices/list) (*read only*)
-10. [Mandates](https://stripe.com/docs/api/mandates) (*read only*)
-11. [PaymentIntents](https://stripe.com/docs/api/payment_intents/list) (*read only*)
-12. [Payouts](https://stripe.com/docs/api/payouts/list) (*read only*)
-13. [Products](https://stripe.com/docs/api/products/list) (*read and modify*)
-14. [Refunds](https://stripe.com/docs/api/refunds/list) (*read only*)
-15. [SetupAttempts](https://stripe.com/docs/api/setup_attempts/list) (*read only*)
-16. [SetupIntents](https://stripe.com/docs/api/setup_intents/list) (*read only*)
-17. [Subscriptions](https://stripe.com/docs/api/subscriptions/list) (*read and modify*)
-18. [Tokens](https://stripe.com/docs/api/tokens) (*read only*)
+1.  [Accounts](https://stripe.com/docs/api/accounts/list) (*read only*)
+2.  [Balance](https://stripe.com/docs/api/balance) (*read only*)
+3.  [Balance Transactions](https://stripe.com/docs/api/balance_transactions/list) (*read only*)
+4.  [Charges](https://stripe.com/docs/api/charges/list) (*read only*)
+5.  [Customers](https://stripe.com/docs/api/customers/list) (*read and modify*)
+6.  [Disputes](https://stripe.com/docs/api/disputes/list) (*read only*)
+7.  [Events](https://stripe.com/docs/api/events/list) (*read only*)
+8.  [Files](https://stripe.com/docs/api/files/list) (*read only*)
+9.  [File Links](https://stripe.com/docs/api/file_links/list) (*read only*)
+10. [Invoices](https://stripe.com/docs/api/invoices/list) (*read only*)
+11. [Mandates](https://stripe.com/docs/api/mandates) (*read only*)
+12. [PaymentIntents](https://stripe.com/docs/api/payment_intents/list) (*read only*)
+13. [Payouts](https://stripe.com/docs/api/payouts/list) (*read only*)
+14. [Products](https://stripe.com/docs/api/products/list) (*read and modify*)
+15. [Refunds](https://stripe.com/docs/api/refunds/list) (*read only*)
+16. [SetupAttempts](https://stripe.com/docs/api/setup_attempts/list) (*read only*)
+17. [SetupIntents](https://stripe.com/docs/api/setup_intents/list) (*read only*)
+18. [Subscriptions](https://stripe.com/docs/api/subscriptions/list) (*read and modify*)
+19. [Tokens](https://stripe.com/docs/api/tokens) (*read only*)
+20. [Topups](https://stripe.com/docs/api/topups/list) (*read only*)
+21. [Transfers](https://stripe.com/docs/api/transfers/list) (*read only*)
 
 ### Wrapper 
 To get started with the Stripe wrapper, create a foreign data wrapper specifying `handler` and `validator` as below.
@@ -88,6 +91,33 @@ The Stripe tables mirror Stripe's API.
 ```sql
 create schema stripe;
 ```
+
+##### Accounts
+*read only*
+
+This is an object representing a Stripe account.
+
+Ref: [Stripe docs](https://stripe.com/docs/api/accounts/list)
+
+```sql
+create foreign table stripe.accounts (
+  id text,
+  business_type text,
+  country text,
+  email text,
+  type text,
+  created timestamp,
+  attrs jsonb
+)
+  server stripe_server
+  options (
+    object 'accounts'
+  );
+```
+
+While any column is allowed in a where clause, it is most efficient to filter by:
+
+- id
 
 ##### Balance
 *read only*
@@ -603,9 +633,61 @@ create foreign table stripe.tokens (
   );
 ```
 
+##### Top-ups
+*read only*
+
+To top up your Stripe balance, you create a top-up object.
+
+Ref: [Stripe docs](https://stripe.com/docs/api/topups/list)
+
+```sql
+create foreign table stripe.topups (
+  id text,
+  amount bigint,
+  currency text,
+  description text,
+  status text,
+  created timestamp,
+  attrs jsonb
+)
+  server stripe_server
+  options (
+    object 'topups'
+  );
+```
+
 While any column is allowed in a where clause, it is most efficient to filter by:
 
 - id
+- status
+
+##### Transfers
+*read only*
+
+A Transfer object is created when you move funds between Stripe accounts as part of Connect.
+
+Ref: [Stripe docs](https://stripe.com/docs/api/transfers/list)
+
+```sql
+create foreign table stripe.transfers (
+  id text,
+  amount bigint,
+  currency text,
+  description text,
+  destination text,
+  created timestamp,
+  attrs jsonb
+)
+  server stripe_server
+  options (
+    object 'transfers'
+  );
+```
+
+While any column is allowed in a where clause, it is most efficient to filter by:
+
+- id
+- destination
 
 ### Examples
 

--- a/wrappers/src/fdw/stripe_fdw/README.md
+++ b/wrappers/src/fdw/stripe_fdw/README.md
@@ -10,6 +10,7 @@ This is a foreign data wrapper for [Stripe](https://stripe.com/) developed using
 
 | Version | Date       | Notes                                                |
 | ------- | ---------- | ---------------------------------------------------- |
+| 0.1.4   | 2023-02-21 | Added Connect objects                                |
 | 0.1.3   | 2022-12-21 | Added more core objects                              |
 | 0.1.2   | 2022-12-04 | Added 'products' objects support                     |
 | 0.1.1   | 2022-12-03 | Added quals pushdown support                         |

--- a/wrappers/src/fdw/stripe_fdw/stripe_fdw.rs
+++ b/wrappers/src/fdw/stripe_fdw/stripe_fdw.rs
@@ -235,7 +235,7 @@ macro_rules! report_request_error {
 }
 
 #[wrappers_fdw(
-    version = "0.1.3",
+    version = "0.1.4",
     author = "Supabase",
     website = "https://github.com/supabase/wrappers/tree/main/wrappers/src/fdw/stripe_fdw"
 )]
@@ -280,6 +280,7 @@ impl StripeFdw {
             "setup_intents" => vec!["customer", "payment_method"],
             "subscriptions" => vec!["customer", "price", "status"],
             "tokens" => vec![],
+            "topups" => vec!["status"],
             "transfers" => vec!["destination"],
             _ => {
                 report_error(
@@ -307,7 +308,9 @@ impl StripeFdw {
                 vec![
                     ("id", "string"),
                     ("business_type", "string"),
+                    ("country", "string"),
                     ("email", "string"),
+                    ("type", "string"),
                     ("created", "timestamp"),
                 ],
                 tgt_cols,
@@ -541,14 +544,27 @@ impl StripeFdw {
                 ],
                 tgt_cols,
             ),
+            "topups" => body_to_rows(
+                resp_body,
+                vec![
+                    ("id", "string"),
+                    ("amount", "i64"),
+                    ("currency", "string"),
+                    ("description", "string"),
+                    ("status", "string"),
+                    ("created", "timestamp"),
+                ],
+                tgt_cols,
+            ),
             "transfers" => body_to_rows(
                 resp_body,
                 vec![
                     ("id", "string"),
                     ("amount", "i64"),
                     ("currency", "string"),
-                    ("created", "timestamp"),
+                    ("description", "string"),
                     ("destination", "string"),
+                    ("created", "timestamp"),
                 ],
                 tgt_cols,
             ),

--- a/wrappers/src/fdw/stripe_fdw/tests.rs
+++ b/wrappers/src/fdw/stripe_fdw/tests.rs
@@ -395,7 +395,7 @@ mod tests {
                 )
                 SERVER my_stripe_server
                 OPTIONS (
-                  object 'topups',    -- source object in stripe, required
+                  object 'topups'    -- source object in stripe, required
                 )
              "#,
                 None,
@@ -415,7 +415,7 @@ mod tests {
                 )
                 SERVER my_stripe_server
                 OPTIONS (
-                  object 'transfers',    -- source object in stripe, required
+                  object 'transfers'    -- source object in stripe, required
                 )
              "#,
                 None,


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to add and improve 3 [Stripe Connect objects](https://stripe.com/docs/api/accounts):

- Accounts
- Top-ups (new)
- Transfers

## What is the current behavior?

Currently there are only 2 Stripe Connect objects: `Accounts` and `Transfers`.

## What is the new behavior?

Added a new object `Top-ups` and also added test cases and documents.

## Additional context

N/A
