### PR TITLE
fix: modify stripe attrs column order, fix #57

### DIFF
--- a/wrappers/src/fdw/stripe_fdw/stripe_fdw.rs
+++ b/wrappers/src/fdw/stripe_fdw/stripe_fdw.rs
@@ -105,13 +105,11 @@ fn body_to_rows(
                         _ => None,
                     });
                 row.push(col_name, cell);
+            } else if tgt_col == "attrs" {
+                // put all properties into 'attrs' JSON column
+                let attrs = serde_json::from_str(&obj.to_string()).unwrap();
+                row.push("attrs", Some(Cell::Json(JsonB(attrs))));
             }
-        }
-
-        // put all properties into 'attrs' JSON column
-        if tgt_cols.iter().any(|c| c == "attrs") {
-            let attrs = serde_json::from_str(&obj.to_string()).unwrap();
-            row.push("attrs", Some(Cell::Json(JsonB(attrs))));
         }
 
         result.push(row);

--- a/wrappers/src/fdw/stripe_fdw/tests.rs
+++ b/wrappers/src/fdw/stripe_fdw/tests.rs
@@ -494,6 +494,16 @@ mod tests {
             assert_eq!(results, vec![("cus_MJiBgSUgeWFN0z", 287883090000000)]);
 
             let results = c
+                .select(
+                    "SELECT attrs->>'id' as id FROM stripe_customers",
+                    None,
+                    None,
+                )
+                .filter_map(|r| r.by_name("id").ok().and_then(|v| v.value::<&str>()))
+                .collect::<Vec<_>>();
+            assert_eq!(results, vec!["cus_MJiBgSUgeWFN0z"]);
+
+            let results = c
                 .select("SELECT * FROM stripe_disputes", None, None)
                 .filter_map(|r| {
                     r.by_name("id")


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix #57 

## What is the current behavior?

The `attrs` column order is wrongly placed in target column list, so queries like below returns empty.

```
select attrs from stripe.charges where id = 'ch_3MZiaiI3rSV8HFQa0lzuJV2I';
```

## What is the new behavior?

Tha `attrs` column order should be correct so the query above can work correctly.

## Additional context

N/A
