### PR TITLE
feat: add pagination and pushdown for bq fdw

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1332,7 +1332,7 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "supabase-wrappers"
-version = "0.1.6"
+version = "0.1.8"
 dependencies = [
  "pgx",
  "pgx-tests",
@@ -1343,7 +1343,7 @@ dependencies = [
 
 [[package]]
 name = "supabase-wrappers-macros"
-version = "0.1.6"
+version = "0.1.8"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/supabase-wrappers-macros/Cargo.toml
+++ b/supabase-wrappers-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "supabase-wrappers-macros"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 authors = ["Supabase Inc. https://supabase.com/"]
 license = "Apache-2.0"

--- a/supabase-wrappers/Cargo.toml
+++ b/supabase-wrappers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "supabase-wrappers"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 authors = ["Supabase Inc. https://supabase.com/"]
 license = "Apache-2.0"

--- a/supabase-wrappers/src/interface.rs
+++ b/supabase-wrappers/src/interface.rs
@@ -309,6 +309,30 @@ pub struct Sort {
     pub collate: Option<String>,
 }
 
+impl Sort {
+    pub fn deparse(&self) -> String {
+        let mut sql = format!("order by {}", self.field);
+
+        if self.reversed {
+            sql.push_str(" desc");
+        } else {
+            sql.push_str(" asc");
+        }
+
+        if self.nulls_first {
+            sql.push_str(" nulls first")
+        } else {
+            sql.push_str(" nulls last")
+        }
+
+        if let Some(collate) = &self.collate {
+            sql.push_str(&format!(" collate {}", collate));
+        }
+
+        sql
+    }
+}
+
 /// Query limit, a.k.a `LIMIT count OFFSET offset` clause
 ///
 /// ## Examples
@@ -326,6 +350,12 @@ pub struct Sort {
 pub struct Limit {
     pub count: i64,
     pub offset: i64,
+}
+
+impl Limit {
+    pub fn deparse(&self) -> String {
+        format!("limit {} offset {}", self.count, self.offset)
+    }
 }
 
 /// The Foreign Data Wrapper trait

--- a/wrappers/Cargo.lock
+++ b/wrappers/Cargo.lock
@@ -597,9 +597,9 @@ dependencies = [
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f94fa09c2aeea5b8839e414b7b841bf429fd25b9c522116ac97ee87856d88b2"
+checksum = "c9b0705efd4599c15a38151f4721f7bc388306f61084d3bfd50bd07fbca5cb60"
 
 [[package]]
 name = "either"
@@ -811,9 +811,9 @@ dependencies = [
 
 [[package]]
 name = "gcp-bigquery-client"
-version = "0.16.0"
+version = "0.16.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e69a989cb1a881d708518866b7d9aa9fb2ada03578a193863fb0436706fd6c8a"
+checksum = "601ca5cb46e9918e053c39b60a0e5f0d1b312e8ed71ab3010dec4300ac9e9149"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1982,7 +1982,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls",
- "rustls-pemfile 1.0.1",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -2139,18 +2139,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0167bac7a9f490495f3c33013e7722b53cb087ecbe082fb0c6387c96f634ea50"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile 1.0.1",
+ "rustls-pemfile",
  "schannel",
  "security-framework",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ee86d63972a7c661d1536fefe8c3c8407321c3df668891286de28abcd087360"
-dependencies = [
- "base64",
 ]
 
 [[package]]
@@ -2440,7 +2431,7 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "supabase-wrappers"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "pgx",
  "supabase-wrappers-macros",
@@ -2450,7 +2441,7 @@ dependencies = [
 
 [[package]]
 name = "supabase-wrappers-macros"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2592,9 +2583,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.24.1"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d9f76183f91ecfb55e1d7d5602bd1d979e38a3a522fe900241cf195624d67ae"
+checksum = "c8e00990ebabbe4c14c08aca901caed183ecd5c09562a12c824bb53d3c3fd3af"
 dependencies = [
  "autocfg",
  "bytes",
@@ -3210,7 +3201,7 @@ dependencies = [
 
 [[package]]
 name = "wrappers"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "cfg-if",
  "chrono",
@@ -3243,9 +3234,9 @@ dependencies = [
 
 [[package]]
 name = "yup-oauth2"
-version = "8.0.0"
+version = "8.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9b7cbafca6169d93ee1da6b8e4bd9d78250a322f9aafbd468607bae3d2a0e75"
+checksum = "f8cb398cca4dedd0203666d7c3e7a089d14557be759efd57ab75f067949276e7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3258,7 +3249,7 @@ dependencies = [
  "log",
  "percent-encoding",
  "rustls",
- "rustls-pemfile 0.3.0",
+ "rustls-pemfile",
  "seahash",
  "serde",
  "serde_json",

--- a/wrappers/Cargo.toml
+++ b/wrappers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wrappers"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 
 [lib]
@@ -38,7 +38,7 @@ clickhouse-rs = { git = "https://github.com/suharev7/clickhouse-rs", branch = "a
 chrono = { version = "0.4", optional = true }
 
 # for bigquery_fdw, firebase_fdw, airtable_fdw and etc.
-gcp-bigquery-client = { version = "0.16.0", optional = true }
+gcp-bigquery-client = { version = "0.16.5", optional = true }
 time = { version = "0.3.17", features = ["parsing"], optional = true }
 serde = { version = "1", optional = true }
 serde_json = { version = "1.0.86", optional = true }

--- a/wrappers/src/fdw/bigquery_fdw/README.md
+++ b/wrappers/src/fdw/bigquery_fdw/README.md
@@ -134,3 +134,4 @@ insert into people values (4, 'Yoda', current_timestamp());
 | Version | Date       | Notes                                                |
 | ------- | ---------- | ---------------------------------------------------- |
 | 0.1.0   | 2022-11-30 | Initial version                                      |
+| 0.1.1   | 2023-02-15 | Upgrade bq client lib to v0.16.5, code improvement   |

--- a/wrappers/src/fdw/bigquery_fdw/tests.rs
+++ b/wrappers/src/fdw/bigquery_fdw/tests.rs
@@ -57,6 +57,13 @@ mod tests {
 
             assert_eq!(results, vec!["foo", "bar"]);
 
+            let results = c
+                .select("SELECT name FROM test_table ORDER BY id DESC LIMIT 1", None, None)
+                .filter_map(|r| r.by_name("name").ok().and_then(|v| v.value::<&str>()))
+                .collect::<Vec<_>>();
+
+            assert_eq!(results, vec!["bar"]);
+
             // DISABLED: error: [FIXME]
             // insert failed: Request error (error: error decoding response body: missing field `status` at line 1 column 436)
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to add result pagination and `order` and 'limit' pushdown for BigQuery FDW.

## What is the current behavior?

The BQ FDW currently can only read one page of data which is not more than 10MB, thus caused incorrect result if the source dataset is large. Also there is no  which caused slow queries.

## What is the new behavior?

Result pagination and `order` and `limit` pushdown have been added.

## Additional context

N/A
