### PR TITLE
fix: fix multiple sorts deparse

### DIFF
--- a/supabase-wrappers/src/interface.rs
+++ b/supabase-wrappers/src/interface.rs
@@ -320,7 +320,7 @@ pub struct Sort {
 
 impl Sort {
     pub fn deparse(&self) -> String {
-        let mut sql = format!("order by {}", self.field);
+        let mut sql = self.field.to_string();
 
         if self.reversed {
             sql.push_str(" desc");
@@ -333,6 +333,12 @@ impl Sort {
         } else {
             sql.push_str(" nulls last")
         }
+
+        sql
+    }
+
+    pub fn deparse_with_collate(&self) -> String {
+        let mut sql = self.deparse();
 
         if let Some(collate) = &self.collate {
             sql.push_str(&format!(" collate {}", collate));

--- a/wrappers/src/fdw/bigquery_fdw/bigquery_fdw.rs
+++ b/wrappers/src/fdw/bigquery_fdw/bigquery_fdw.rs
@@ -126,8 +126,13 @@ impl BigQueryFdw {
         };
 
         // push down sorts
-        for sort in sorts {
-            sql.push_str(&format!(" {}", sort.deparse()));
+        if !sorts.is_empty() {
+            let order_by = sorts
+                .iter()
+                .map(|sort| sort.deparse())
+                .collect::<Vec<String>>()
+                .join(", ");
+            sql.push_str(&format!(" order by {}", order_by));
         }
 
         // push down limits

--- a/wrappers/src/fdw/bigquery_fdw/tests.rs
+++ b/wrappers/src/fdw/bigquery_fdw/tests.rs
@@ -58,7 +58,11 @@ mod tests {
             assert_eq!(results, vec!["foo", "bar"]);
 
             let results = c
-                .select("SELECT name FROM test_table ORDER BY id DESC LIMIT 1", None, None)
+                .select(
+                    "SELECT name FROM test_table ORDER BY id DESC, name LIMIT 1",
+                    None,
+                    None,
+                )
                 .filter_map(|r| r.by_name("name").ok().and_then(|v| v.value::<&str>()))
                 .collect::<Vec<_>>();
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to fix a bug when deparsing multiple sorts.

## What is the current behavior?

When the `order by` have multiple columns, the deparsed sql is like `order by x order by y` which is incorrect.

## What is the new behavior?

The `Sort::deparse()` outputs sql without `order by`, which should be done in fdw.

## Additional context

N/A
