### PR TITLE
feat: enrich target column in interface

### DIFF
--- a/supabase-wrappers/src/interface.rs
+++ b/supabase-wrappers/src/interface.rs
@@ -204,6 +204,21 @@ impl Row {
     }
 }
 
+/// A column definition in a table
+///
+/// The column represents a column definition in a table.
+#[derive(Debug, Clone, Default)]
+pub struct Column {
+    /// column name
+    pub name: String,
+
+    /// 1-based column number
+    pub num: usize,
+
+    /// column type OID, can be used to match pg_sys::BuiltinOid
+    pub type_oid: pg_sys::Oid,
+}
+
 /// A restiction value used in [`Qual`], either a [`Cell`] or an array of [`Cell`]
 #[derive(Debug, Clone)]
 pub enum Value {
@@ -414,7 +429,7 @@ pub trait ForeignDataWrapper {
     fn get_rel_size(
         &mut self,
         _quals: &[Qual],
-        _columns: &[String],
+        _columns: &[Column],
         _sorts: &[Sort],
         _limit: &Option<Limit>,
         _options: &HashMap<String, String>,
@@ -434,7 +449,7 @@ pub trait ForeignDataWrapper {
     fn begin_scan(
         &mut self,
         quals: &[Qual],
-        columns: &[String],
+        columns: &[Column],
         sorts: &[Sort],
         limit: &Option<Limit>,
         options: &HashMap<String, String>,

--- a/supabase-wrappers/src/lib.rs
+++ b/supabase-wrappers/src/lib.rs
@@ -72,7 +72,7 @@
 //!     row_cnt: i64,
 //!
 //!     // target column name list
-//!     tgt_cols: Vec<String>,
+//!     tgt_cols: Vec<Column>,
 //! }
 //!
 //! impl ForeignDataWrapper for HelloWorldFdw {
@@ -124,7 +124,7 @@
 //!     fn begin_scan(
 //!         &mut self,
 //!         _quals: &[Qual],
-//!         columns: &[String],
+//!         columns: &[Column],
 //!         _sorts: &[Sort],
 //!         _limit: &Option<Limit>,
 //!         _options: &HashMap<String, String>,

--- a/wrappers/src/fdw/airtable_fdw/airtable_fdw.rs
+++ b/wrappers/src/fdw/airtable_fdw/airtable_fdw.rs
@@ -47,7 +47,7 @@ impl AirtableFdw {
     }
 
     // convert response body text to rows
-    fn parse_resp(&self, resp_body: &str, columns: &[String]) -> (Vec<Row>, Option<String>) {
+    fn parse_resp(&self, resp_body: &str, columns: &[Column]) -> (Vec<Row>, Option<String>) {
         let response: AirtableResponse = serde_json::from_str(resp_body).unwrap();
         let mut result = Vec::new();
 
@@ -105,7 +105,7 @@ impl ForeignDataWrapper for AirtableFdw {
     fn begin_scan(
         &mut self,
         _quals: &[Qual], // TODO: Propagate filters
-        columns: &[String],
+        columns: &[Column],
         _sorts: &[Sort],        // TODO: Propagate sort
         _limit: &Option<Limit>, // TODO: maxRecords
         options: &HashMap<String, String>,

--- a/wrappers/src/fdw/airtable_fdw/result.rs
+++ b/wrappers/src/fdw/airtable_fdw/result.rs
@@ -4,7 +4,7 @@ use serde_json::Value;
 use std::collections::HashMap;
 use std::fmt;
 use std::marker::PhantomData;
-use supabase_wrappers::interface::{Cell, Row};
+use supabase_wrappers::interface::{Cell, Column, Row};
 
 #[derive(Deserialize, Debug)]
 pub struct AirtableResponse {
@@ -97,15 +97,15 @@ impl AirtableRecord {
         }
     }
 
-    pub fn to_row(&self, columns: &[String]) -> Row {
+    pub fn to_row(&self, columns: &[Column]) -> Row {
         let mut row = Row::new();
         for col in columns.iter() {
-            if col == "id" {
+            if col.name == "id" {
                 row.push("id", Some(Cell::String(self.id.clone())));
             } else {
                 row.push(
-                    col,
-                    match self.fields.0.get(col) {
+                    &col.name,
+                    match self.fields.0.get(&col.name) {
                         Some(val) => AirtableRecord::value_to_cell(val),
                         None => None,
                     },

--- a/wrappers/src/fdw/firebase_fdw/firebase_fdw.rs
+++ b/wrappers/src/fdw/firebase_fdw/firebase_fdw.rs
@@ -66,7 +66,7 @@ fn body_to_rows(
     resp: &JsonValue,
     obj_key: &str,
     normal_cols: Vec<(&str, &str, &str)>,
-    tgt_cols: &[String],
+    tgt_cols: &[Column],
 ) -> Vec<Row> {
     let mut result = Vec::new();
 
@@ -85,7 +85,7 @@ fn body_to_rows(
         // extract normal columns
         for tgt_col in tgt_cols {
             if let Some((src_name, col_name, col_type)) =
-                normal_cols.iter().find(|(_, c, _)| c == tgt_col)
+                normal_cols.iter().find(|(_, c, _)| c == &tgt_col.name)
             {
                 let cell = obj
                     .as_object()
@@ -113,7 +113,7 @@ fn body_to_rows(
         }
 
         // put all properties into 'attrs' JSON column
-        if tgt_cols.iter().any(|c| c == "attrs") {
+        if tgt_cols.iter().any(|c| &c.name == "attrs") {
             let attrs = serde_json::from_str(&obj.to_string()).unwrap();
             row.push("attrs", Some(Cell::Json(JsonB(attrs))));
         }
@@ -125,7 +125,7 @@ fn body_to_rows(
 }
 
 // convert response body text to rows
-fn resp_to_rows(obj: &str, resp: &JsonValue, tgt_cols: &[String]) -> Vec<Row> {
+fn resp_to_rows(obj: &str, resp: &JsonValue, tgt_cols: &[Column]) -> Vec<Row> {
     let mut result = Vec::new();
 
     match obj {
@@ -307,7 +307,7 @@ impl ForeignDataWrapper for FirebaseFdw {
     fn begin_scan(
         &mut self,
         _quals: &[Qual],
-        columns: &[String],
+        columns: &[Column],
         _sorts: &[Sort],
         _limit: &Option<Limit>,
         options: &HashMap<String, String>,

--- a/wrappers/src/fdw/helloworld_fdw/helloworld_fdw.rs
+++ b/wrappers/src/fdw/helloworld_fdw/helloworld_fdw.rs
@@ -12,7 +12,7 @@ pub(crate) struct HelloWorldFdw {
     row_cnt: i64,
 
     // target column name list
-    tgt_cols: Vec<String>,
+    tgt_cols: Vec<Column>,
 }
 
 impl ForeignDataWrapper for HelloWorldFdw {
@@ -39,7 +39,7 @@ impl ForeignDataWrapper for HelloWorldFdw {
     fn begin_scan(
         &mut self,
         _quals: &[Qual],
-        columns: &[String],
+        columns: &[Column],
         _sorts: &[Sort],
         _limit: &Option<Limit>,
         _options: &HashMap<String, String>,
@@ -56,7 +56,7 @@ impl ForeignDataWrapper for HelloWorldFdw {
         if self.row_cnt < 1 {
             // add values to row if they are in target column list
             for tgt_col in &self.tgt_cols {
-                match tgt_col.as_str() {
+                match tgt_col.name.as_str() {
                     "id" => row.push("id", Some(Cell::I64(self.row_cnt))),
                     "col" => row.push("col", Some(Cell::String("Hello world".to_string()))),
                     _ => {}


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to enrich the target `column` in interface.

## What is the current behavior?

Currently, the `column` in interface is simply a column name string without other metadata, which is limited in some cases. 

## What is the new behavior?

The `column` now is enriched to a struct with 3 properties:

- `name` - column name
- `num` - column number in table definition, 1-based
- `type_oid` - column type OID

## Additional context

This is a breaking change as it changed the foreign data wrapper interface, all FDWs need to adopt this change.
