### PR TITLE
fix: exclude generated column

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ cargo pgx test --features all_fdws,pg15
 
 - Windows is not supported, that limitation inherits from [pgx](https://github.com/tcdi/pgx).
 - Currently only supports PostgreSQL v14 and v15.
+- Generated column is not supported.
 
 ## Contribution
 

--- a/supabase-wrappers/README.md
+++ b/supabase-wrappers/README.md
@@ -130,6 +130,7 @@ wrappers=# select * from hello;
 
 - Windows is not supported, that limitation inherits from [pgx](https://github.com/tcdi/pgx).
 - Currently only supports PostgreSQL v14 and v15.
+- Generated column is not supported.
 
 ## Contribution
 

--- a/supabase-wrappers/src/utils.rs
+++ b/supabase-wrappers/src/utils.rs
@@ -262,9 +262,12 @@ pub(super) unsafe fn extract_target_columns(
         let rte = pg_sys::planner_rt_fetch((*var).varno as u32, root);
         let attno = (*var).varattno;
         let attname = pg_sys::get_attname((*rte).relid, attno, true);
-
-        // column must exist and not a generated column
         if !attname.is_null() && pg_sys::get_attgenerated((*rte).relid, attno) == 0 {
+            // generated column is not supported
+            if pg_sys::get_attgenerated((*rte).relid, attno) > 0 {
+                report_warning("generated column is not supported");
+            }
+
             let type_oid = pg_sys::get_atttype((*rte).relid, attno);
             ret.push(Column {
                 name: CStr::from_ptr(attname).to_str().unwrap().to_owned(),

--- a/supabase-wrappers/src/utils.rs
+++ b/supabase-wrappers/src/utils.rs
@@ -262,7 +262,9 @@ pub(super) unsafe fn extract_target_columns(
         let rte = pg_sys::planner_rt_fetch((*var).varno as u32, root);
         let attno = (*var).varattno;
         let attname = pg_sys::get_attname((*rte).relid, attno, true);
-        if !attname.is_null() {
+
+        // column must exist and not a generated column
+        if !attname.is_null() && pg_sys::get_attgenerated((*rte).relid, attno) == 0 {
             let type_oid = pg_sys::get_atttype((*rte).relid, attno);
             ret.push(Column {
                 name: CStr::from_ptr(attname).to_str().unwrap().to_owned(),

--- a/supabase-wrappers/src/utils.rs
+++ b/supabase-wrappers/src/utils.rs
@@ -262,10 +262,11 @@ pub(super) unsafe fn extract_target_columns(
         let rte = pg_sys::planner_rt_fetch((*var).varno as u32, root);
         let attno = (*var).varattno;
         let attname = pg_sys::get_attname((*rte).relid, attno, true);
-        if !attname.is_null() && pg_sys::get_attgenerated((*rte).relid, attno) == 0 {
+        if !attname.is_null() {
             // generated column is not supported
             if pg_sys::get_attgenerated((*rte).relid, attno) > 0 {
                 report_warning("generated column is not supported");
+                continue;
             }
 
             let type_oid = pg_sys::get_atttype((*rte).relid, attno);


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to exclude generated column from target columns, so to fix #71 .

## What is the current behavior?

The generated column is not supported yet, but it currently reports an error when using it.

## What is the new behavior?

Although generated column is not supported, it should report a warning instead an error.

## Additional context

N/A
