### PR TITLE
feat: add subquery to bq fdw table option

### DIFF
--- a/wrappers/src/fdw/bigquery_fdw/README.md
+++ b/wrappers/src/fdw/bigquery_fdw/README.md
@@ -91,7 +91,7 @@ create foreign table people (
   options (
     table 'people',     -- source table in BigQuery, required
                         -- This can also be a subquery enclosed in parentheses, for example,
-                        -- `table '(select * except(props), to_json_string(props) as props from ``my_project.my_dataset.my_table``)`
+                        -- table '(select * except(props), to_json_string(props) as props from `my_project.my_dataset.my_table`)'
     location 'EU',      -- table location, optional
     rowid_column 'id',  -- primary key column name, optional for scan, required for modify
     startup_cost '42'   -- execution startup cost for exection planning, optional

--- a/wrappers/src/fdw/bigquery_fdw/README.md
+++ b/wrappers/src/fdw/bigquery_fdw/README.md
@@ -90,6 +90,8 @@ create foreign table people (
   server my_bigquery_server
   options (
     table 'people',     -- source table in BigQuery, required
+                        -- This can also be a subquery enclosed in parentheses, for example,
+                        -- `table '(select * except(props), to_json_string(props) as props from ``my_project.my_dataset.my_table``)`
     location 'EU',      -- table location, optional
     rowid_column 'id',  -- primary key column name, optional for scan, required for modify
     startup_cost '42'   -- execution startup cost for exection planning, optional
@@ -133,5 +135,6 @@ insert into people values (4, 'Yoda', current_timestamp());
 
 | Version | Date       | Notes                                                |
 | ------- | ---------- | ---------------------------------------------------- |
-| 0.1.0   | 2022-11-30 | Initial version                                      |
+| 0.1.2   | 2023-03-15 | Added subquery support for `table` option            |
 | 0.1.1   | 2023-02-15 | Upgrade bq client lib to v0.16.5, code improvement   |
+| 0.1.0   | 2022-11-30 | Initial version                                      |

--- a/wrappers/src/fdw/bigquery_fdw/bigquery_fdw.rs
+++ b/wrappers/src/fdw/bigquery_fdw/bigquery_fdw.rs
@@ -83,7 +83,7 @@ fn field_to_cell(rs: &ResultSet, field: &TableFieldSchema) -> Option<Cell> {
 }
 
 #[wrappers_fdw(
-    version = "0.1.1",
+    version = "0.1.2",
     author = "Supabase",
     website = "https://github.com/supabase/wrappers/tree/main/wrappers/src/fdw/bigquery_fdw"
 )]
@@ -116,7 +116,11 @@ impl BigQueryFdw {
                 .collect::<Vec<String>>()
                 .join(", ")
         };
-        let table = format!("`{}.{}.{}`", self.project_id, self.dataset_id, self.table,);
+        let table = if self.table.starts_with('(') {
+            self.table.clone()
+        } else {
+            format!("`{}.{}.{}`", self.project_id, self.dataset_id, self.table,)
+        };
 
         let mut sql = if quals.is_empty() {
             format!("select {} from {}", tgts, table)


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to add subquery support to `table` option in BigQuery FDW, possibly fix #69 and #70 . 

## What is the current behavior?

Currently, the `table` foreign table option in BigQuery FDW can only specify a table or view name, which limits the fdw usage in some cases.

## What is the new behavior?

In the `table` option we can specify a subquery enclosed in parentheses. For example,

```sql
OPTIONS (
    table '(select * except(props), to_json_string(props) as props from `my_project.my_dataset.my_table`)'
)
```

## Additional context

As the [dependent lib](https://docs.rs/gcp-bigquery-client/latest/gcp_bigquery_client/model/field_type/enum.FieldType.html) doesn't support JSON type at this moment, this feature can be used as a workaround to read JSON data from BQ.
