### PR TITLE
feat: add numeric type support and timeout option for bq fdw

### DIFF
--- a/docs/bigquery.md
+++ b/docs/bigquery.md
@@ -2,6 +2,20 @@
 
 BigQuery FDW supports both data read and modify.
 
+### Supported Data Types
+
+| Postgres Type      | BigQuery Type   |
+| ------------------ | --------------- |
+| boolean            | BOOL            |
+| bigint             | INT64           |
+| double precision   | FLOAT64         |
+| numeric            | NUMERIC         |
+| text               | STRING          |
+| varchar            | STRING          |
+| date               | DATE            |
+| timestamp          | DATETIME        |
+| timestamp          | TIMESTAMP       |
+
 ### Wrapper 
 To get started with the BigQuery wrapper, create a foreign data wrapper specifying `handler` and `validator` as below.
 
@@ -104,6 +118,8 @@ The full list of foreign table options are below:
    ```
    table '(select * except(props), to_json_string(props) as props from `my_project.my_dataset.my_table`)'
    ```
+
+   **Note**: When using subquery in this option, full qualitified table name must be used.
 
 - `location` - Source table location, optional. Default is 'US'.
 - `rowid_column` - Primary key column name, optional for data scan, required for data modify

--- a/docs/bigquery.md
+++ b/docs/bigquery.md
@@ -122,6 +122,7 @@ The full list of foreign table options are below:
    **Note**: When using subquery in this option, full qualitified table name must be used.
 
 - `location` - Source table location, optional. Default is 'US'.
+- `timeout` - Query request timeout in milliseconds, optional. Default is '30000' (30 seconds).
 - `rowid_column` - Primary key column name, optional for data scan, required for data modify
 
 #### Examples

--- a/wrappers/dockerfiles/bigquery/data.yaml
+++ b/wrappers/dockerfiles/bigquery/data.yaml
@@ -10,9 +10,14 @@ projects:
               mode: REQUIRED
             - name: name
               type: STRING
-              mode: required
+              mode: REQUIRED
+            - name: num
+              type: NUMERIC
+              mode: REQUIRED
           data:
             - id: 1
               name: foo
+              num: 0.123
             - id: 2
               name: bar
+              num: 1234.56789

--- a/wrappers/src/fdw/bigquery_fdw/README.md
+++ b/wrappers/src/fdw/bigquery_fdw/README.md
@@ -11,6 +11,7 @@ This is a foreign data wrapper for [BigQuery](https://cloud.google.com/bigquery)
 
 | Version | Date       | Notes                                                |
 | ------- | ---------- | ---------------------------------------------------- |
+| 0.1.3   | 2023-04-03 | Added support for `NUMERIC` type                     |
 | 0.1.2   | 2023-03-15 | Added subquery support for `table` option            |
 | 0.1.1   | 2023-02-15 | Upgrade bq client lib to v0.16.5, code improvement   |
 | 0.1.0   | 2022-11-30 | Initial version                                      |

--- a/wrappers/src/fdw/bigquery_fdw/tests.rs
+++ b/wrappers/src/fdw/bigquery_fdw/tests.rs
@@ -29,7 +29,8 @@ mod tests {
                 r#"
                   CREATE FOREIGN TABLE test_table (
                     id bigint,
-                    name text
+                    name text,
+                    num numeric
                   )
                   SERVER my_bigquery_server
                   OPTIONS (
@@ -44,7 +45,8 @@ mod tests {
                 r#"
                   CREATE FOREIGN TABLE test_table_with_subquery (
                     id bigint,
-                    name text
+                    name text,
+                    num numeric
                   )
                   SERVER my_bigquery_server
                   OPTIONS (
@@ -88,6 +90,13 @@ mod tests {
                 .collect::<Vec<_>>();
 
             assert_eq!(results, vec!["FOO", "BAR"]);
+
+            let results = c
+                .select("SELECT num FROM test_table ORDER BY num", None, None)
+                .filter_map(|r| r.by_name("num").ok().and_then(|v| v.value::<f64>()))
+                .collect::<Vec<_>>();
+
+            assert_eq!(results, vec![0.123, 1234.56789]);
 
             // DISABLED: error: [FIXME]
             // insert failed: Request error (error: error decoding response body: missing field `status` at line 1 column 436)

--- a/wrappers/src/fdw/bigquery_fdw/tests.rs
+++ b/wrappers/src/fdw/bigquery_fdw/tests.rs
@@ -45,8 +45,7 @@ mod tests {
                 r#"
                   CREATE FOREIGN TABLE test_table_with_subquery (
                     id bigint,
-                    name text,
-                    num numeric
+                    name text
                   )
                   SERVER my_bigquery_server
                   OPTIONS (
@@ -92,11 +91,11 @@ mod tests {
             assert_eq!(results, vec!["FOO", "BAR"]);
 
             let results = c
-                .select("SELECT num FROM test_table ORDER BY num", None, None)
-                .filter_map(|r| r.by_name("num").ok().and_then(|v| v.value::<f64>()))
+                .select("SELECT num::text FROM test_table ORDER BY num", None, None)
+                .filter_map(|r| r.by_name("num").ok().and_then(|v| v.value::<&str>()))
                 .collect::<Vec<_>>();
 
-            assert_eq!(results, vec![0.123, 1234.56789]);
+            assert_eq!(results, vec!["0.123", "1234.56789"]);
 
             // DISABLED: error: [FIXME]
             // insert failed: Request error (error: error decoding response body: missing field `status` at line 1 column 436)


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR added below 2 features to BigQuery FDW:

1. `NUMERIC` data type support
2. `timeout` foreign table option

## What is the current behavior?

1. There is no support for `NUMERIC` data type. See details: https://github.com/supabase/wrappers/issues/70#issuecomment-1493418694
2. Current query request timeout is 10 seconds, it will return empty result if it expired.

## What is the new behavior?

1. `NUMERIC` data type is supported
2. Default query request timeout is 30 seconds and can be adjusted by foreign table option `timeout`, will also raise error if timeout expired.

## Additional context

N/A
