### PR TITLE
feat: add custom sql support for clickhouse fdw

### DIFF
--- a/docs/clickhouse.md
+++ b/docs/clickhouse.md
@@ -8,6 +8,7 @@ ClickHouse FDW supports both data read and modify.
 | ------------------ | ----------------- |
 | boolean            | UInt8             |
 | smallint           | Int16             |
+| integer            | UInt16            |
 | integer            | Int32             |
 | bigint             | UInt32            |
 | bigint             | Int64             |
@@ -15,6 +16,7 @@ ClickHouse FDW supports both data read and modify.
 | real               | Float32           |
 | double precision   | Float64           |
 | text               | String            |
+| date               | Date              |
 | timestamp          | DateTime          |
 
 ### Wrapper 
@@ -94,6 +96,31 @@ ClickHouse wrapper is implemented with [ELT](https://hevodata.com/learn/etl-vs-e
 The full list of foreign table options are below:
 
 - `table` - Source table name in ClickHouse, required.
+
+   This can also be a subquery enclosed in parentheses, for example,
+
+   ```
+   table '(select * from my_table)'
+   ```
+
+   [Parametrized view](https://clickhouse.com/docs/en/sql-reference/statements/create/view#parameterized-view) is also supported in the subquery. In this case, you need to define a column for each parameter and use `where` to pass values to them. For example,
+
+   ```
+    create foreign table test_vw (
+      id bigint,
+      col1 text,
+      col2 bigint,
+      _param1 text,
+      _param2 bigint
+    )
+      server clickhouse_server
+      options (
+        table '(select * from my_view(column1=${_param1}, column2=${_param2}))'
+      );
+
+    select * from test_vw where _param1='aaa' and _param2=32;
+   ```
+
 - `rowid_column` - Primary key column name, optional for data scan, required for data modify
 
 #### Examples

--- a/wrappers/Cargo.lock
+++ b/wrappers/Cargo.lock
@@ -3877,6 +3877,7 @@ dependencies = [
  "aws-sdk-s3",
  "cfg-if",
  "chrono",
+ "chrono-tz",
  "clickhouse-rs",
  "csv",
  "futures",

--- a/wrappers/Cargo.toml
+++ b/wrappers/Cargo.toml
@@ -17,7 +17,7 @@ pg_test = []
 
 helloworld_fdw = []
 bigquery_fdw = ["gcp-bigquery-client", "time", "serde_json", "serde", "wiremock", "futures", "yup-oauth2"]
-clickhouse_fdw = ["clickhouse-rs", "chrono", "time"]
+clickhouse_fdw = ["clickhouse-rs", "chrono", "chrono-tz", "time", "regex"]
 stripe_fdw = ["reqwest", "reqwest-middleware", "reqwest-retry", "serde_json", "time"]
 firebase_fdw = ["reqwest", "reqwest-middleware", "reqwest-retry", "serde_json", "yup-oauth2", "regex", "time"]
 s3_fdw = ["reqwest", "reqwest-middleware", "reqwest-retry", "aws-config", "aws-sdk-s3", "tokio", "tokio-util", "csv", "async-compression", "serde_json", "http"]
@@ -37,6 +37,7 @@ supabase-wrappers = { path = "../supabase-wrappers", default-features = false }
 # for clickhouse_fdw
 clickhouse-rs = { git = "https://github.com/suharev7/clickhouse-rs", branch = "async-await", features = ["tls"], optional = true }
 chrono = { version = "0.4", optional = true }
+chrono-tz = { version = "0.6", optional = true }
 
 # for bigquery_fdw, firebase_fdw, airtable_fdw and etc.
 gcp-bigquery-client = { version = "0.16.5", optional = true }

--- a/wrappers/src/fdw/clickhouse_fdw/tests.rs
+++ b/wrappers/src/fdw/clickhouse_fdw/tests.rs
@@ -56,6 +56,20 @@ mod tests {
                 None,
                 None,
             );
+            c.update(
+                r#"
+                  CREATE FOREIGN TABLE test_cust_sql (
+                    id bigint,
+                    name text
+                  )
+                  SERVER my_clickhouse_server
+                  OPTIONS (
+                    table '(select * from test_table)'
+                  )
+             "#,
+                None,
+                None,
+            );
 
             assert_eq!(c.select("SELECT * FROM test_table", None, None).len(), 0);
             c.update(
@@ -68,6 +82,13 @@ mod tests {
             );
             assert_eq!(
                 c.select("SELECT name FROM test_table", None, None)
+                    .first()
+                    .get_one::<&str>()
+                    .unwrap(),
+                "test"
+            );
+            assert_eq!(
+                c.select("SELECT name FROM test_cust_sql", None, None)
                     .first()
                     .get_one::<&str>()
                     .unwrap(),


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is mainly to add custom sql support `table` option, also with some improvements.

## What is the current behavior?

Currently, the custom sql isn't supported.

## What is the new behavior?

- `table` option now can support custom sql
- added `UInt16` and `Date` type support
- custom sql can support Parametrized view
- made `rowid_column` optional for read-only foreign table

## Additional context

N/A
