### PR TITLE
Feat/Stripe: Added primary keys to all objects and small docs fix

### DIFF
--- a/docs/stripe.md
+++ b/docs/stripe.md
@@ -112,7 +112,8 @@ create foreign table stripe.accounts (
 )
   server stripe_server
   options (
-    object 'accounts'
+    object 'accounts',
+    rowid_column 'id'
   );
 ```
 
@@ -162,7 +163,8 @@ create foreign table stripe.balance_transactions (
 )
   server stripe_server
   options (
-    object 'balance_transactions'
+    object 'balance_transactions',
+    rowid_column 'id'
   );
 ```
 
@@ -193,7 +195,8 @@ create foreign table stripe.charges (
 )
   server stripe_server
   options (
-    object 'charges'
+    object 'charges',
+    rowid_column 'id'
   );
 ```
 
@@ -251,7 +254,8 @@ create foreign table stripe.disputes (
 )
   server stripe_server
   options (
-    object 'disputes'
+    object 'disputes',
+    rowid_column 'id'
   );
 ```
 
@@ -278,7 +282,8 @@ create foreign table stripe.events (
 )
   server stripe_server
   options (
-    object 'events'
+    object 'events',
+    rowid_column 'id'
   );
 ```
 
@@ -309,7 +314,8 @@ create foreign table stripe.files (
 )
   server stripe_server
   options (
-    object 'files'
+    object 'files',
+    rowid_column 'id'
   );
 ```
 
@@ -337,7 +343,8 @@ create foreign table stripe.file_links (
 )
   server stripe_server
   options (
-    object 'file_links'
+    object 'file_links',
+    rowid_column 'id'
   );
 ```
 
@@ -362,7 +369,8 @@ create foreign table stripe.invoices (
 )
   server stripe_server
   options (
-    object 'invoices'
+    object 'invoices',
+    rowid_column 'id'
   );
 
 ```
@@ -391,7 +399,8 @@ create foreign table stripe.mandates (
 )
   server stripe_server
   options (
-    object 'mandates'
+    object 'mandates',
+    rowid_column 'id'
   );
 ```
 
@@ -419,7 +428,8 @@ create foreign table stripe.payment_intents (
 )
   server stripe_server
   options (
-    object 'payment_intents'
+    object 'payment_intents',
+    rowid_column 'id'
   );
 ```
 
@@ -449,7 +459,8 @@ create foreign table stripe.payouts (
 )
   server stripe_server
   options (
-    object 'payouts'
+    object 'payouts',
+    rowid_column 'id'
   );
 ```
 
@@ -478,7 +489,8 @@ create foreign table stripe.prices (
 )
   server stripe_server
   options (
-    object 'pricing'
+    object 'prices',
+    rowid_column 'id'
   );
 ```
 
@@ -538,7 +550,8 @@ create foreign table stripe.refunds (
 )
   server stripe_server
   options (
-    object 'refunds'
+    object 'refunds',
+    rowid_column 'id'
   );
 ```
 
@@ -570,7 +583,8 @@ create foreign table stripe.setup_attempts (
 )
   server stripe_server
   options (
-    object 'setup_attempts'
+    object 'setup_attempts',
+    rowid_column 'id'
   );
 ```
 
@@ -600,7 +614,8 @@ create foreign table stripe.setup_intents (
 )
   server stripe_server
   options (
-    object 'setup_intents'
+    object 'setup_intents',
+    rowid_column 'id'
   );
 ```
 
@@ -659,7 +674,8 @@ create foreign table stripe.tokens (
 )
   server stripe_server
   options (
-    object 'tokens'
+    object 'tokens',
+    rowid_column 'id'
   );
 ```
 
@@ -682,7 +698,8 @@ create foreign table stripe.topups (
 )
   server stripe_server
   options (
-    object 'topups'
+    object 'topups',
+    rowid_column 'id'
   );
 ```
 
@@ -710,7 +727,8 @@ create foreign table stripe.transfers (
 )
   server stripe_server
   options (
-    object 'transfers'
+    object 'transfers',
+    rowid_column 'id'
   );
 ```
 
@@ -761,3 +779,10 @@ update stripe.customers set attrs='{"metadata[foo]": "bar"}' where id ='cus_xxx'
 delete from stripe.customers where id ='cus_xxx';
 ```
 
+##### Removing foreign tables
+
+If you would like to remove a foreign table because you do not use it anymore this can be done easily with the following command
+
+```sql
+drop foreign table stripe.customers, stripe.invoices, stripe.subscriptions;
+```

--- a/wrappers/src/fdw/stripe_fdw/README.md
+++ b/wrappers/src/fdw/stripe_fdw/README.md
@@ -10,6 +10,7 @@ This is a foreign data wrapper for [Stripe](https://stripe.com/) developed using
 
 | Version | Date       | Notes                                                |
 | ------- | ---------- | ---------------------------------------------------- |
+| 0.1.6   | 2023-05-06 | Added more primary keys to almost all objects        |
 | 0.1.5   | 2023-05-01 | Added 'prices' object                                |
 | 0.1.4   | 2023-02-21 | Added Connect objects                                |
 | 0.1.3   | 2022-12-21 | Added more core objects                              |

--- a/wrappers/src/fdw/stripe_fdw/stripe_fdw.rs
+++ b/wrappers/src/fdw/stripe_fdw/stripe_fdw.rs
@@ -234,7 +234,7 @@ macro_rules! report_request_error {
 }
 
 #[wrappers_fdw(
-    version = "0.1.5",
+    version = "0.1.6",
     author = "Supabase",
     website = "https://github.com/supabase/wrappers/tree/main/wrappers/src/fdw/stripe_fdw"
 )]

--- a/wrappers/src/fdw/stripe_fdw/tests.rs
+++ b/wrappers/src/fdw/stripe_fdw/tests.rs
@@ -36,7 +36,8 @@ mod tests {
                 )
                 SERVER my_stripe_server
                 OPTIONS (
-                    object 'accounts'    -- source object in stripe, required
+                    object 'accounts',    -- source object in stripe, required
+                    rowid_column 'id'
                   )
              "#,
                 None,
@@ -76,7 +77,8 @@ mod tests {
                 )
                 SERVER my_stripe_server
                 OPTIONS (
-                    object 'balance_transactions'    -- source object in stripe, required
+                    object 'balance_transactions',    -- source object in stripe, required
+                    rowid_column 'id'
                   )
              "#,
                 None,
@@ -99,7 +101,8 @@ mod tests {
                 )
                 SERVER my_stripe_server
                 OPTIONS (
-                    object 'charges'    -- source object in stripe, required
+                    object 'charges',    -- source object in stripe, required
+                    rowid_column 'id'
                   )
              "#,
                 None,
@@ -141,7 +144,8 @@ mod tests {
                 )
                 SERVER my_stripe_server
                 OPTIONS (
-                    object 'disputes'    -- source object in stripe, required
+                    object 'disputes',    -- source object in stripe, required
+                    rowid_column 'id'
                 )
              "#,
                 None,
@@ -159,7 +163,8 @@ mod tests {
                 )
                 SERVER my_stripe_server
                 OPTIONS (
-                    object 'events'    -- source object in stripe, required
+                    object 'events',    -- source object in stripe, required
+                    rowid_column 'id'
                 )
              "#,
                 None,
@@ -182,7 +187,8 @@ mod tests {
                 )
                 SERVER my_stripe_server
                 OPTIONS (
-                    object 'files'    -- source object in stripe, required
+                    object 'files',    -- source object in stripe, required
+                    rowid_column 'id'
                 )
              "#,
                 None,
@@ -202,7 +208,8 @@ mod tests {
                 )
                 SERVER my_stripe_server
                 OPTIONS (
-                    object 'file_links'    -- source object in stripe, required
+                    object 'file_links',    -- source object in stripe, required
+                    rowid_column 'id'
                 )
              "#,
                 None,
@@ -224,7 +231,8 @@ mod tests {
                 )
                 SERVER my_stripe_server
                 OPTIONS (
-                    object 'invoices'    -- source object in stripe, required
+                    object 'invoices',    -- source object in stripe, required
+                    rowid_column 'id'
                   )
              "#,
                 None,
@@ -244,7 +252,8 @@ mod tests {
                 )
                 SERVER my_stripe_server
                 OPTIONS (
-                    object 'payment_intents'    -- source object in stripe, required
+                    object 'payment_intents',    -- source object in stripe, required
+                    rowid_column 'id'
                   )
              "#,
                 None,
@@ -266,7 +275,8 @@ mod tests {
                 )
                 SERVER my_stripe_server
                 OPTIONS (
-                    object 'payouts'    -- source object in stripe, required
+                    object 'payouts',    -- source object in stripe, required
+                    rowid_column 'id'
                   )
              "#,
                 None,
@@ -287,7 +297,8 @@ mod tests {
                 )
                 SERVER my_stripe_server
                 OPTIONS (
-                    object 'prices'    -- source object in stripe, required
+                    object 'prices',    -- source object in stripe, required
+                    rowid_column 'id'
                   )
              "#,
                 None,
@@ -331,7 +342,8 @@ mod tests {
                 )
                 SERVER my_stripe_server
                 OPTIONS (
-                    object 'refunds'    -- source object in stripe, required
+                    object 'refunds',    -- source object in stripe, required
+                    rowid_column 'id'
                   )
              "#,
                 None,
@@ -354,7 +366,8 @@ mod tests {
                 )
                 SERVER my_stripe_server
                 OPTIONS (
-                    object 'setup_attempts'    -- source object in stripe, required
+                    object 'setup_attempts',    -- source object in stripe, required
+                    rowid_column 'id'
                   )
              "#,
                 None,
@@ -376,7 +389,8 @@ mod tests {
                 )
                 SERVER my_stripe_server
                 OPTIONS (
-                    object 'setup_intents'    -- source object in stripe, required
+                    object 'setup_intents',    -- source object in stripe, required
+                    rowid_column 'id'
                   )
              "#,
                 None,
@@ -416,7 +430,8 @@ mod tests {
                 )
                 SERVER my_stripe_server
                 OPTIONS (
-                  object 'topups'    -- source object in stripe, required
+                  object 'topups',    -- source object in stripe, required
+                  rowid_column 'id'
                 )
              "#,
                 None,
@@ -436,7 +451,8 @@ mod tests {
                 )
                 SERVER my_stripe_server
                 OPTIONS (
-                  object 'transfers'    -- source object in stripe, required
+                  object 'transfers',    -- source object in stripe, required
+                  rowid_column 'id'
                 )
              "#,
                 None,


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR has two changes

- Fixed typo in docs for create script of `prices` object
- Added `rowid_column` to all objects  containing a `id`

## What is the current behavior?

Currently there are some columns that have a `rowid_column` and other who don't. For consistency I added it to all objects containing an `id`. As far as I understands this is not the same as a real constraint because in a foreign table there is no way for PostgreSQL to enforce this behavior but I still think it could help with being a simple form of documentation of the code. Hopefully my hypothesis is correct, and otherwise I'm curious to the explanation since I'm here to learn.

## What is the new behavior?

- All rows with an id now have the `rowid_column` added.

## Additional context

https://www.postgresql.org/docs/current/sql-createforeigntable.html#notes

I was not able to get it running on my local machine so hopefully everything is green 🙃
