### PR TITLE
fix: add prepared statement support

### DIFF
--- a/supabase-wrappers/src/interface.rs
+++ b/supabase-wrappers/src/interface.rs
@@ -223,7 +223,7 @@ pub struct Column {
     pub num: usize,
 
     /// column type OID, can be used to match pg_sys::BuiltinOid
-    pub type_oid: pg_sys::Oid,
+    pub type_oid: Oid,
 }
 
 /// A restiction value used in [`Qual`], either a [`Cell`] or an array of [`Cell`]
@@ -231,6 +231,16 @@ pub struct Column {
 pub enum Value {
     Cell(Cell),
     Array(Vec<Cell>),
+}
+
+/// Query parameter
+#[derive(Debug, Clone)]
+pub struct Param {
+    /// 1-based parameter id
+    pub id: usize,
+
+    /// parameter type OID
+    pub type_oid: Oid,
 }
 
 /// Query restrictions, a.k.a conditions in `WHERE` clause
@@ -277,6 +287,7 @@ pub struct Qual {
     pub operator: String,
     pub value: Value,
     pub use_or: bool,
+    pub param: Option<Param>,
 }
 
 impl Qual {

--- a/supabase-wrappers/src/interface.rs
+++ b/supabase-wrappers/src/interface.rs
@@ -19,13 +19,13 @@ use std::slice::Iter;
 // https://doxygen.postgresql.org/pg__foreign__table_8h.html
 
 /// Constant can be used in [validator](ForeignDataWrapper::validator)
-pub const FOREIGN_DATA_WRAPPER_RELATION_ID: pg_sys::Oid = 2328;
+pub const FOREIGN_DATA_WRAPPER_RELATION_ID: Oid = 2328;
 
 /// Constant can be used in [validator](ForeignDataWrapper::validator)
-pub const FOREIGN_SERVER_RELATION_ID: pg_sys::Oid = 1417;
+pub const FOREIGN_SERVER_RELATION_ID: Oid = 1417;
 
 /// Constant can be used in [validator](ForeignDataWrapper::validator)
-pub const FOREIGN_TABLE_RELATION_ID: pg_sys::Oid = 3118;
+pub const FOREIGN_TABLE_RELATION_ID: Oid = 3118;
 
 /// A data cell in a data row
 #[derive(Debug)]
@@ -594,7 +594,7 @@ pub trait ForeignDataWrapper {
     /// # Example
     ///
     /// ```rust,no_run
-    /// fn validator(opt_list: Vec<Option<String>>, catalog: Option<pg_sys::Oid>) {
+    /// fn validator(opt_list: Vec<Option<String>>, catalog: Option<Oid>) {
     ///     if let Some(oid) = catalog {
     ///         match oid {
     ///             FOREIGN_DATA_WRAPPER_RELATION_ID => {
@@ -612,5 +612,5 @@ pub trait ForeignDataWrapper {
     ///     }
     /// }
     /// ```
-    fn validator(_options: Vec<Option<String>>, _catalog: Option<pg_sys::Oid>) {}
+    fn validator(_options: Vec<Option<String>>, _catalog: Option<Oid>) {}
 }

--- a/supabase-wrappers/src/lib.rs
+++ b/supabase-wrappers/src/lib.rs
@@ -210,7 +210,7 @@
 //!          Sort Key: col
 //!          ->  Foreign Scan on hello  (cost=0.00..1.00 rows=1 width=0)
 //!                Filter: (id = 1)
-//!                Wrappers: quals = [Qual { field: "id", operator: "=", value: Cell(I32(1)), use_or: false }]
+//!                Wrappers: quals = [Qual { field: "id", operator: "=", value: Cell(I32(1)), use_or: false, param: None }]
 //!                Wrappers: tgts = [Column { name: "id", num: 1, type_oid: 20 }, Column { name: "col", num: 2, type_oid: 25 }]
 //!                Wrappers: sorts = [Sort { field: "col", field_no: 2, reversed: false, nulls_first: false, collate: None }]
 //!                Wrappers: limit = Some(Limit { count: 1, offset: 0 })
@@ -244,6 +244,7 @@ use pgx::AllocatedByPostgres;
 
 mod instance;
 mod limit;
+mod memctx;
 mod modify;
 mod polyfill;
 mod qual;

--- a/supabase-wrappers/src/memctx.rs
+++ b/supabase-wrappers/src/memctx.rs
@@ -1,0 +1,57 @@
+//! Helper functions for Wrappers Memory Context management
+//!
+
+use pgx::{memcxt::PgMemoryContexts, pg_sys::AsPgCStr, prelude::*};
+
+// Wrappers root memory context name
+const ROOT_MEMCTX_NAME: &str = "WrappersRootMemCtx";
+
+// search memory context by name under specified MemoryContext
+unsafe fn find_memctx_under(name: &str, under: PgMemoryContexts) -> Option<PgMemoryContexts> {
+    let mut ctx = (*under.value()).firstchild;
+    while !ctx.is_null() {
+        if let Ok(ctx_name) = std::ffi::CStr::from_ptr((*ctx).name).to_str() {
+            if ctx_name == name {
+                return Some(PgMemoryContexts::For(ctx));
+            }
+        }
+        ctx = (*ctx).nextchild;
+    }
+    None
+}
+
+// search for root memory context under CacheMemoryContext, create a new one if not exists
+unsafe fn ensure_root_wrappers_memctx() -> PgMemoryContexts {
+    find_memctx_under(ROOT_MEMCTX_NAME, PgMemoryContexts::CacheMemoryContext).unwrap_or_else(|| {
+        let name = PgMemoryContexts::CacheMemoryContext.pstrdup(ROOT_MEMCTX_NAME);
+        let ctx = pg_sys::AllocSetContextCreateExtended(
+            PgMemoryContexts::CacheMemoryContext.value(),
+            name,
+            pg_sys::ALLOCSET_DEFAULT_MINSIZE as usize,
+            pg_sys::ALLOCSET_DEFAULT_INITSIZE as usize,
+            pg_sys::ALLOCSET_DEFAULT_MAXSIZE as usize,
+        );
+        PgMemoryContexts::For(ctx)
+    })
+}
+
+// search Wrappers memory context by name, reset it if exists otherwise create a new one
+pub(super) unsafe fn refresh_wrappers_memctx(name: &str) -> PgMemoryContexts {
+    let mut root = ensure_root_wrappers_memctx();
+    find_memctx_under(name, PgMemoryContexts::For(root.value()))
+        .map(|mut ctx| {
+            ctx.reset();
+            ctx
+        })
+        .unwrap_or_else(|| {
+            let name = root.switch_to(|_| name.as_pg_cstr());
+            let ctx = pg_sys::AllocSetContextCreateExtended(
+                root.value(),
+                name,
+                pg_sys::ALLOCSET_DEFAULT_MINSIZE as usize,
+                pg_sys::ALLOCSET_DEFAULT_INITSIZE as usize,
+                pg_sys::ALLOCSET_DEFAULT_MAXSIZE as usize,
+            );
+            PgMemoryContexts::For(ctx)
+        })
+}

--- a/supabase-wrappers/src/modify.rs
+++ b/supabase-wrappers/src/modify.rs
@@ -1,6 +1,6 @@
 use pgx::{
-    debug2, memcxt::PgMemoryContexts, prelude::*, rel::PgRelation, tupdesc::PgTupleDesc, FromDatum,
-    PgSqlErrorCode,
+    debug2, memcxt::PgMemoryContexts, pg_sys::Oid, prelude::*, rel::PgRelation,
+    tupdesc::PgTupleDesc, FromDatum, PgSqlErrorCode,
 };
 use std::collections::HashMap;
 use std::os::raw::c_int;
@@ -9,6 +9,7 @@ use std::ptr;
 use crate::prelude::*;
 
 use super::instance;
+use super::memctx;
 use super::polyfill;
 use super::utils;
 
@@ -20,25 +21,25 @@ struct FdwModifyState<W: ForeignDataWrapper> {
     // row id attribute number and type id
     rowid_name: String,
     rowid_attno: pg_sys::AttrNumber,
-    rowid_typid: pg_sys::Oid,
+    rowid_typid: Oid,
 
     // foreign table options
     opts: HashMap<String, String>,
 
-    // temporary memory context
+    // temporary memory context per foreign table, created under Wrappers root
+    // memory context
     tmp_ctx: PgMemoryContexts,
 }
 
 impl<W: ForeignDataWrapper> FdwModifyState<W> {
-    unsafe fn new(foreigntableid: pg_sys::Oid) -> Self {
+    unsafe fn new(foreigntableid: Oid, tmp_ctx: PgMemoryContexts) -> Self {
         Self {
             instance: instance::create_fdw_instance(foreigntableid),
             rowid_name: String::default(),
             rowid_attno: 0,
             rowid_typid: 0,
             opts: HashMap::new(),
-            tmp_ctx: PgMemoryContexts::CurTransactionContext
-                .switch_to(|_| PgMemoryContexts::new("Wrappers temp modify data")),
+            tmp_ctx,
         }
     }
 
@@ -60,12 +61,6 @@ impl<W: ForeignDataWrapper> FdwModifyState<W> {
 
     fn end_modify(&mut self) {
         self.instance.end_modify();
-    }
-
-    fn clear(&mut self) {
-        self.opts.clear();
-        self.opts.shrink_to_fit();
-        self.tmp_ctx.reset();
     }
 }
 
@@ -156,17 +151,23 @@ pub(super) extern "C" fn plan_foreign_modify<W: ForeignDataWrapper>(
         for attr in tup_desc.iter().filter(|a| !a.attisdropped) {
             let attname = pgx::name_data_to_str(&attr.attname);
             if attname == rowid_name {
+                let ftable_id = rel.oid();
+
+                // refresh leftover memory context
+                let ctx_name = format!("Wrappers_modify_{}", ftable_id);
+                let ctx = memctx::refresh_wrappers_memctx(&ctx_name);
+
                 // create modify state
-                let mut state = FdwModifyState::<W>::new(rel.oid());
+                let mut state = FdwModifyState::<W>::new(ftable_id, ctx);
 
                 state.rowid_name = rowid_name.to_string();
                 state.rowid_typid = attr.atttypid;
                 state.opts = opts;
 
-                let boxed_state =
-                    PgBox::new_in_context(state, PgMemoryContexts::CurTransactionContext)
-                        .into_pg_boxed();
-                return FdwModifyState::serialize_to_list(boxed_state);
+                // install callback to drop the state when memory context is reset
+                let mut ctx = PgMemoryContexts::For(state.tmp_ctx.value());
+                let p = PgBox::from_pg(ctx.leak_and_drop_on_delete(state));
+                return FdwModifyState::serialize_to_list(p, ctx);
             }
         }
 
@@ -195,8 +196,7 @@ pub(super) extern "C" fn begin_foreign_modify<W: ForeignDataWrapper>(
 
     unsafe {
         let mut state = FdwModifyState::<W>::deserialize_from_list(fdw_private as _);
-
-        let mut old_ctx = state.tmp_ctx.set_as_current();
+        assert!(!state.is_null());
 
         // search for rowid attribute number
         let subplan = (*polyfill::outer_plan_state(&mut (*mtstate).ps)).plan;
@@ -207,8 +207,6 @@ pub(super) extern "C" fn begin_foreign_modify<W: ForeignDataWrapper>(
         state.begin_modify();
 
         (*rinfo).ri_FdwState = state.into_pg() as _;
-
-        old_ctx.set_as_current();
     }
 }
 
@@ -224,13 +222,8 @@ pub(super) extern "C" fn exec_foreign_insert<W: ForeignDataWrapper>(
         let mut state =
             PgBox::<FdwModifyState<W>>::from_pg((*rinfo).ri_FdwState as *mut FdwModifyState<W>);
 
-        state.tmp_ctx.reset();
-        let mut old_ctx = state.tmp_ctx.set_as_current();
-
         let row = utils::tuple_table_slot_to_row(slot);
         state.insert(&row);
-
-        old_ctx.set_as_current();
     }
 
     slot
@@ -257,15 +250,10 @@ pub(super) extern "C" fn exec_foreign_delete<W: ForeignDataWrapper>(
         let mut state =
             PgBox::<FdwModifyState<W>>::from_pg((*rinfo).ri_FdwState as *mut FdwModifyState<W>);
 
-        state.tmp_ctx.reset();
-        let mut old_ctx = state.tmp_ctx.set_as_current();
-
         let cell = get_rowid_cell(&state, plan_slot);
         if let Some(rowid) = cell {
             state.delete(&rowid);
         }
-
-        old_ctx.set_as_current();
     }
 
     slot
@@ -283,9 +271,6 @@ pub(super) extern "C" fn exec_foreign_update<W: ForeignDataWrapper>(
         let mut state =
             PgBox::<FdwModifyState<W>>::from_pg((*rinfo).ri_FdwState as *mut FdwModifyState<W>);
 
-        state.tmp_ctx.reset();
-        let mut old_ctx = state.tmp_ctx.set_as_current();
-
         let rowid_cell = get_rowid_cell(&state, plan_slot);
         if let Some(rowid) = rowid_cell {
             let mut new_row = utils::tuple_table_slot_to_row(plan_slot);
@@ -302,8 +287,6 @@ pub(super) extern "C" fn exec_foreign_update<W: ForeignDataWrapper>(
 
             state.update(&rowid, &new_row);
         }
-
-        old_ctx.set_as_current();
     }
 
     slot
@@ -318,9 +301,8 @@ pub(super) extern "C" fn end_foreign_modify<W: ForeignDataWrapper>(
     unsafe {
         let fdw_state = (*rinfo).ri_FdwState as *mut FdwModifyState<W>;
         if !fdw_state.is_null() {
-            let mut state = PgBox::<FdwModifyState<W>>::from_rust(fdw_state);
+            let mut state = PgBox::<FdwModifyState<W>>::from_pg(fdw_state);
             state.end_modify();
-            state.clear();
         }
     }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to add support for prepared statement, which uses query parameters. PostgREST uses the prepared statement to access foreign table, without this support PostgREST will fail after several successful accesses. This PR will fix #56 .

## What is the current behavior?

There is no support for prepared statement, it will cause unexpected result when use it to access foreign tables several times.

For example, create a prepared statement like below,

```sql
prepare get_product(text) as select id, name from products where id=$1;
```
and then repeat query it with parameter value,
```sql
execute get_product('prod_NuECg9VTeI3IIJ');
```
This will produce correct `quals` to FDW in the first several queries, but later queries will get empty `quals`. The reason is because Postgres does some optimisations for repeated query, skipping parsing and planning and directly executing with cached plan. The scan state currently only lives within current transaction, so when it is directly executing the scan state won't be available. 

## What is the new behavior?

The new behavior is prepared statement and query parameter are supported, so PostgREST will be able to access foreign table without problems.

To achieve this goal, memory context management is also refactored. A new root memory context `WrappersRootMemCtx` will be created under `CacheMemoryContext`, and each foreign table will have child memory context for both scan and modify. Scan and modify state objects will be associated with that memory context. The children memory context will be reset when the query run in next time, state and FDW instance will also be dropped at that time, given FDW chance to release resources.

For example, below is the memory context structure after running scan on table A (oid 5321) and B (oid 8984), table B also ran a modify.

<pre>
CacheMemoryContext
  |__ WrappersRootMemCtx
        |__ Wrappers_scan_5321
        |__ Wrappers_scan_8984
        |__ Wrappers_modify_8984
</pre>

The children `Wrappers_*` memory contexts will be reset when the scan or modify re-parsing. The root `WrappersRootMemCtx` will be long lived during a server process session.

## Additional context

n/a
