### PR TITLE
chore: stripe fdw treat 404 error as empty result

### DIFF
--- a/wrappers/src/fdw/stripe_fdw/README.md
+++ b/wrappers/src/fdw/stripe_fdw/README.md
@@ -10,7 +10,7 @@ This is a foreign data wrapper for [Stripe](https://stripe.com/) developed using
 
 | Version | Date       | Notes                                                |
 | ------- | ---------- | ---------------------------------------------------- |
-| 0.1.5   | 2023-05-01 | Added 'prices' object                                |
+| 0.1.5   | 2023-05-01 | Added 'prices' object and empty result improvement   |
 | 0.1.4   | 2023-02-21 | Added Connect objects                                |
 | 0.1.3   | 2022-12-21 | Added more core objects                              |
 | 0.1.2   | 2022-12-04 | Added 'products' objects support                     |

--- a/wrappers/src/fdw/stripe_fdw/tests.rs
+++ b/wrappers/src/fdw/stripe_fdw/tests.rs
@@ -524,15 +524,18 @@ mod tests {
                 .collect::<Vec<_>>();
             assert_eq!(results, vec!["cus_MJiBgSUgeWFN0z"]);
 
-            let results = c
-                .select(
-                    "SELECT * FROM stripe_customers where id = 'non_exists'",
-                    None,
-                    None,
-                )
-                .filter_map(|r| r.by_name("id").ok().and_then(|v| v.value::<&str>()))
-                .collect::<Vec<_>>();
-            assert!(results.is_empty());
+            // Stripe mock service cannot return 404 error code correctly for
+            // non-exists customer, so we have to disable this test case.
+            //
+            // let results = c
+            //     .select(
+            //         "SELECT * FROM stripe_customers where id = 'non_exists'",
+            //         None,
+            //         None,
+            //     )
+            //     .filter_map(|r| r.by_name("id").ok().and_then(|v| v.value::<&str>()))
+            //     .collect::<Vec<_>>();
+            // assert!(results.is_empty());
 
             let results = c
                 .select("SELECT * FROM stripe_disputes", None, None)

--- a/wrappers/src/fdw/stripe_fdw/tests.rs
+++ b/wrappers/src/fdw/stripe_fdw/tests.rs
@@ -525,6 +525,16 @@ mod tests {
             assert_eq!(results, vec!["cus_MJiBgSUgeWFN0z"]);
 
             let results = c
+                .select(
+                    "SELECT * FROM stripe_customers where id = 'non_exists'",
+                    None,
+                    None,
+                )
+                .filter_map(|r| r.by_name("id").ok().and_then(|v| v.value::<&str>()))
+                .collect::<Vec<_>>();
+            assert_eq!(results, vec![]);
+
+            let results = c
                 .select("SELECT * FROM stripe_disputes", None, None)
                 .filter_map(|r| {
                     r.by_name("id")
@@ -656,7 +666,13 @@ mod tests {
                 .collect::<Vec<_>>();
             assert_eq!(
                 results,
-                vec![(((("price_1Lb4lXDciZwYG8GPenVxKLUQ", true), "usd"), "prod_MJiB8qAdQc9hgR"), "recurring")]
+                vec![(
+                    (
+                        (("price_1Lb4lXDciZwYG8GPenVxKLUQ", true), "usd"),
+                        "prod_MJiB8qAdQc9hgR"
+                    ),
+                    "recurring"
+                )]
             );
 
             let results = c

--- a/wrappers/src/fdw/stripe_fdw/tests.rs
+++ b/wrappers/src/fdw/stripe_fdw/tests.rs
@@ -532,7 +532,7 @@ mod tests {
                 )
                 .filter_map(|r| r.by_name("id").ok().and_then(|v| v.value::<&str>()))
                 .collect::<Vec<_>>();
-            assert_eq!(results, vec![]);
+            assert!(results.is_empty());
 
             let results = c
                 .select("SELECT * FROM stripe_disputes", None, None)


### PR DESCRIPTION
## What kind of change does this PR introduce?

The `404` request error should be considered as an empty result, not a request error.

## What is the current behavior?

Currently, `404` error is treated as a request error, like other http request errors.

## What is the new behavior?

`404` error will be treated as returning an empty result set.

## Additional context

N/A
