### PR TITLE
fix: add cell compatible types

### DIFF
--- a/supabase-wrappers/src/interface.rs
+++ b/supabase-wrappers/src/interface.rs
@@ -121,6 +121,22 @@ impl IntoDatum for Cell {
     fn type_oid() -> Oid {
         Oid::INVALID
     }
+
+    fn is_compatible_with(other: Oid) -> bool {
+        Self::type_oid() == other
+            || other == pg_sys::BOOLOID
+            || other == pg_sys::CHAROID
+            || other == pg_sys::INT2OID
+            || other == pg_sys::FLOAT4OID
+            || other == pg_sys::INT4OID
+            || other == pg_sys::FLOAT8OID
+            || other == pg_sys::INT8OID
+            || other == pg_sys::NUMERICOID
+            || other == pg_sys::TEXTOID
+            || other == pg_sys::DATEOID
+            || other == pg_sys::TIMESTAMPOID
+            || other == pg_sys::JSONBOID
+    }
 }
 
 impl FromDatum for Cell {


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to add compatible types for `Cell`, so the [FromDatum](https://docs.rs/pgrx/0.8.3/pgrx/datum/trait.FromDatum.html#) trait can be used with it. This `is_compatible_with()` function is enforced in `FromDatum` from pgrx v0.8.3, so we have to define it.

## What is the current behavior?

Currently, the `FromDatum` trait of `Cell` cannot work properly.

## What is the new behavior?

The `FromDatum` trait of `Cell` can work as expected.

## Additional context

N/A
