### PR TITLE
feat: add fdw stats collection

### DIFF
--- a/wrappers/sql/bootstrap.sql
+++ b/wrappers/sql/bootstrap.sql
@@ -1,0 +1,24 @@
+-- SQL statements are intended to go before all other generated SQL.
+
+DROP TABLE IF EXISTS wrappers_fdw_stats;
+
+CREATE TABLE wrappers_fdw_stats (
+  fdw_name          text NOT NULL PRIMARY KEY,
+  create_times      bigint NULL,
+  rows_in           bigint NULL,
+  rows_out          bigint NULL,
+  bytes_in          bigint NULL,
+  bytes_out         bigint NULL,
+  metadata          jsonb NULL,
+  created_at        timestamptz NOT NULL DEFAULT timezone('utc'::text, now()),
+  updated_at        timestamptz NOT NULL DEFAULT timezone('utc'::text, now())
+);
+
+COMMENT ON TABLE wrappers_fdw_stats IS 'Wrappers Foreign Data Wrapper statistics';
+COMMENT ON COLUMN wrappers_fdw_stats.create_times IS 'Total number of times the FDW instacne has been created';
+COMMENT ON COLUMN wrappers_fdw_stats.rows_in IS 'Total rows input from origin';
+COMMENT ON COLUMN wrappers_fdw_stats.rows_out IS 'Total rows output to Postgres';
+COMMENT ON COLUMN wrappers_fdw_stats.bytes_in IS 'Total bytes input from origin';
+COMMENT ON COLUMN wrappers_fdw_stats.bytes_out IS 'Total bytes output to Postgres';
+COMMENT ON COLUMN wrappers_fdw_stats.metadata IS 'Metadata specific for the FDW';
+

--- a/wrappers/sql/finalize.sql
+++ b/wrappers/sql/finalize.sql
@@ -1,0 +1,2 @@
+-- SQL statements are intended to go after all other generated SQL.
+

--- a/wrappers/src/fdw/airtable_fdw/README.md
+++ b/wrappers/src/fdw/airtable_fdw/README.md
@@ -63,4 +63,5 @@ select * from t1;
 
 | Version | Date       | Notes                                                |
 | ------- | ---------- | ---------------------------------------------------- |
+| 0.1.1   | 2023-07-13 | Added fdw stats collection                           |
 | 0.1.0   | 2022-11-30 | Initial version                                      |

--- a/wrappers/src/fdw/bigquery_fdw/README.md
+++ b/wrappers/src/fdw/bigquery_fdw/README.md
@@ -11,6 +11,7 @@ This is a foreign data wrapper for [BigQuery](https://cloud.google.com/bigquery)
 
 | Version | Date       | Notes                                                |
 | ------- | ---------- | ---------------------------------------------------- |
+| 0.1.4   | 2023-07-13 | Added fdw stats collection                           |
 | 0.1.3   | 2023-04-03 | Added support for `NUMERIC` type                     |
 | 0.1.2   | 2023-03-15 | Added subquery support for `table` option            |
 | 0.1.1   | 2023-02-15 | Upgrade bq client lib to v0.16.5, code improvement   |

--- a/wrappers/src/fdw/clickhouse_fdw/README.md
+++ b/wrappers/src/fdw/clickhouse_fdw/README.md
@@ -11,4 +11,6 @@ This is a foreign data wrapper for [ClickHouse](https://clickhouse.com/). It is 
 
 | Version | Date       | Notes                                                |
 | ------- | ---------- | ---------------------------------------------------- |
+| 0.1.2   | 2023-07-13 | Added fdw stats collection                           |
+| 0.1.1   | 2023-05-19 | Added custom sql support                             |
 | 0.1.0   | 2022-11-30 | Initial version                                      |

--- a/wrappers/src/fdw/firebase_fdw/README.md
+++ b/wrappers/src/fdw/firebase_fdw/README.md
@@ -159,5 +159,6 @@ Below are the options can be used in `CREATE FOREIGN TABLE`:
 
 | Version | Date       | Notes                                                |
 | ------- | ---------- | ---------------------------------------------------- |
+| 0.1.2   | 2023-07-13 | Added fdw stats collection                           |
 | 0.1.1   | 2022-12-07 | Added validator function                             |
 | 0.1.0   | 2022-11-30 | Initial version                                      |

--- a/wrappers/src/fdw/s3_fdw/README.md
+++ b/wrappers/src/fdw/s3_fdw/README.md
@@ -10,5 +10,6 @@ This is a foreign data wrapper for [AWS S3](https://aws.amazon.com/s3/). It is d
 
 | Version | Date       | Notes                                                |
 | ------- | ---------- | ---------------------------------------------------- |
+| 0.1.2   | 2023-07-13 | Added fdw stats collection                           |
 | 0.1.1   | 2023-06-05 | Added Parquet file support                           |
 | 0.1.0   | 2023-03-01 | Initial version                                      |

--- a/wrappers/src/fdw/stripe_fdw/README.md
+++ b/wrappers/src/fdw/stripe_fdw/README.md
@@ -10,6 +10,7 @@ This is a foreign data wrapper for [Stripe](https://stripe.com/) developed using
 
 | Version | Date       | Notes                                                |
 | ------- | ---------- | ---------------------------------------------------- |
+| 0.1.7   | 2023-07-13 | Added fdw stats collection                           |
 | 0.1.6   | 2023-05-30 | Added Checkout Session object                        |
 | 0.1.5   | 2023-05-01 | Added 'prices' object and empty result improvement   |
 | 0.1.4   | 2023-02-21 | Added Connect objects                                |

--- a/wrappers/src/lib.rs
+++ b/wrappers/src/lib.rs
@@ -1,8 +1,12 @@
-use pgrx::pg_module_magic;
+use pgrx::prelude::*;
 
 pg_module_magic!();
 
+extension_sql_file!("../sql/bootstrap.sql", bootstrap);
+extension_sql_file!("../sql/finalize.sql", finalize);
+
 mod fdw;
+mod stats;
 
 #[cfg(test)]
 pub mod pg_test {

--- a/wrappers/src/stats.rs
+++ b/wrappers/src/stats.rs
@@ -1,0 +1,98 @@
+use pgrx::{prelude::*, JsonB};
+use std::fmt;
+
+// fdw stats table name
+const FDW_STATS_TABLE: &str = "wrappers_fdw_stats";
+
+// metric list
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum Metric {
+    CreateTimes,
+    RowsIn,
+    RowsOut,
+    BytesIn,
+    BytesOut,
+}
+
+impl fmt::Display for Metric {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Metric::CreateTimes => write!(f, "create_times"),
+            Metric::RowsIn => write!(f, "rows_in"),
+            Metric::RowsOut => write!(f, "rows_out"),
+            Metric::BytesIn => write!(f, "bytes_in"),
+            Metric::BytesOut => write!(f, "bytes_out"),
+        }
+    }
+}
+
+// get stats table full qualified name
+fn get_stats_table() -> String {
+    let sql = format!(
+        "select b.nspname || '.{}'
+         from pg_catalog.pg_extension a join pg_namespace b on a.extnamespace = b.oid
+         where a.extname = 'wrappers'",
+        FDW_STATS_TABLE
+    );
+    Spi::get_one(&sql)
+        .unwrap()
+        .unwrap_or_else(|| panic!("cannot find fdw stats table '{}'", FDW_STATS_TABLE))
+}
+
+// increase stats value
+pub(crate) fn inc_stats(fdw_name: &str, metric: Metric, inc: i64) {
+    let sql = format!(
+        "insert into {} as s (fdw_name, {}) values($1, $2)
+         on conflict(fdw_name)
+         do update set
+            {} = coalesce(s.{}, 0) + excluded.{},
+            updated_at = timezone('utc'::text, now())",
+        get_stats_table(),
+        metric,
+        metric,
+        metric,
+        metric
+    );
+    Spi::run_with_args(
+        &sql,
+        Some(vec![
+            (PgBuiltInOids::TEXTOID.oid(), fdw_name.into_datum()),
+            (PgBuiltInOids::INT8OID.oid(), inc.into_datum()),
+        ]),
+    )
+    .unwrap();
+}
+
+// get metadata
+pub(crate) fn get_metadata(fdw_name: &str) -> Option<JsonB> {
+    let sql = format!(
+        "select metadata from {} where fdw_name = $1",
+        get_stats_table()
+    );
+    Spi::get_one_with_args(
+        &sql,
+        vec![(PgBuiltInOids::TEXTOID.oid(), fdw_name.into_datum())],
+    )
+    .unwrap()
+}
+
+// set metadata
+pub(crate) fn set_metadata(fdw_name: &str, metadata: Option<JsonB>) {
+    let sql = format!(
+        "insert into {} as s (fdw_name, metadata) values($1, $2)
+         on conflict(fdw_name)
+         do update set
+            metadata = $2,
+            updated_at = timezone('utc'::text, now())",
+        get_stats_table()
+    );
+    Spi::run_with_args(
+        &sql,
+        Some(vec![
+            (PgBuiltInOids::TEXTOID.oid(), fdw_name.into_datum()),
+            (PgBuiltInOids::JSONBOID.oid(), metadata.into_datum()),
+        ]),
+    )
+    .unwrap();
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is add stats collection facilities to all FDWs, which is to improve FDW usage observability.

A new stats table `wrappers_fdw_stats` will be created when Wrappers extension installed.

```sql
CREATE TABLE wrappers_fdw_stats (
  fdw_name          text NOT NULL PRIMARY KEY,
  create_times      bigint NULL,
  rows_in           bigint NULL,
  rows_out          bigint NULL,
  bytes_in          bigint NULL,
  bytes_out         bigint NULL,
  metadata          jsonb NULL,
  created_at        timestamptz NOT NULL DEFAULT timezone('utc'::text, now()),
  updated_at        timestamptz NOT NULL DEFAULT timezone('utc'::text, now())
);

COMMENT ON TABLE wrappers_fdw_stats IS 'Wrappers Foreign Data Wrapper statistics';
COMMENT ON COLUMN wrappers_fdw_stats.create_times IS 'Total number of times the FDW instacne has been created';
COMMENT ON COLUMN wrappers_fdw_stats.rows_in IS 'Total rows input from origin';
COMMENT ON COLUMN wrappers_fdw_stats.rows_out IS 'Total rows output to Postgres';
COMMENT ON COLUMN wrappers_fdw_stats.bytes_in IS 'Total bytes input from origin';
COMMENT ON COLUMN wrappers_fdw_stats.bytes_out IS 'Total bytes output to Postgres';
COMMENT ON COLUMN wrappers_fdw_stats.metadata IS 'Metadata specific for the FDW';
```

Each FDW can use functions exposed in `src/stats.rs` to update common metrics like `rows_in` and `bytes_in`, or write its own specific metrics in `metadata` column using JSON format.

Once those stats are collected, user can get better visibility of their FDWs' internal performance.

## What is the current behavior?

There is no stats collection facilities.

## What is the new behavior?

The new stats collection facilities will be added.

## Additional context

Note: for each FDW, it may not be possible to collect all those metrics, so refer to each individual FDW implementation to check if a specific metric is collected.
