### PR TITLE
Implement sort and limit pushdown for clickhouse

### DIFF
--- a/wrappers/src/fdw/clickhouse_fdw/tests.rs
+++ b/wrappers/src/fdw/clickhouse_fdw/tests.rs
@@ -90,8 +90,35 @@ mod tests {
                 )]),
             )
             .unwrap();
+            c.update(
+                "INSERT INTO test_table (name) VALUES ($1)",
+                None,
+                Some(vec![(
+                    PgOid::BuiltIn(PgBuiltInOids::TEXTOID),
+                    "test2".into_datum(),
+                )]),
+            )
+            .unwrap();
+            c.update(
+                "INSERT INTO test_table (name) VALUES ($1)",
+                None,
+                Some(vec![(
+                    PgOid::BuiltIn(PgBuiltInOids::TEXTOID),
+                    "test3".into_datum(),
+                )]),
+            )
+            .unwrap();
+            c.update(
+                "INSERT INTO test_table (name) VALUES ($1)",
+                None,
+                Some(vec![(
+                    PgOid::BuiltIn(PgBuiltInOids::TEXTOID),
+                    "test4".into_datum(),
+                )]),
+            )
+            .unwrap();
             assert_eq!(
-                c.select("SELECT name FROM test_table", None, None)
+                c.select("SELECT name FROM test_table ORDER BY name", None, None)
                     .unwrap()
                     .first()
                     .get_one::<&str>()
@@ -100,7 +127,7 @@ mod tests {
                 "test"
             );
             assert_eq!(
-                c.select("SELECT name FROM test_cust_sql", None, None)
+                c.select("SELECT name FROM test_cust_sql ORDER BY name", None, None)
                     .unwrap()
                     .first()
                     .get_one::<&str>()
@@ -109,10 +136,29 @@ mod tests {
                 "test"
             );
 
+            assert_eq!(
+                c.select("SELECT name FROM test_table ORDER by name LIMIT 1 OFFSET 1", None, None)
+                    .unwrap()
+                    .first()
+                    .get_one::<&str>()
+                    .unwrap()
+                    .unwrap(),
+                "test2"
+            );
+            assert_eq!(
+                c.select("SELECT name FROM test_cust_sql ORDER BY name LIMIT 2 OFFSET 2", None, None)
+                    .unwrap()
+                    .first()
+                    .get_one::<&str>()
+                    .unwrap()
+                    .unwrap(),
+                "test3"
+            );
+
             let remote_value: String = rt
                 .block_on(async {
                     handle
-                        .query("SELECT name FROM supa.test_table")
+                        .query("SELECT name FROM supa.test_table ORDER BY name LIMIT 1")
                         .fetch_all()
                         .await?
                         .rows()


### PR DESCRIPTION
## What kind of change does this PR introduce?

This implements pushdown for `ORDER BY` and `LIMIT` (and `OFFSET`) mostly taken from the bigquery FDW.


