### PR TITLE
chore: format clickhouse fdw code and bump version

### DIFF
--- a/wrappers/src/fdw/clickhouse_fdw/README.md
+++ b/wrappers/src/fdw/clickhouse_fdw/README.md
@@ -11,6 +11,7 @@ This is a foreign data wrapper for [ClickHouse](https://clickhouse.com/). It is 
 
 | Version | Date       | Notes                                                |
 | ------- | ---------- | ---------------------------------------------------- |
+| 0.1.3   | 2023-07-17 | Added sort and limit pushdown suppport               |
 | 0.1.2   | 2023-07-13 | Added fdw stats collection                           |
 | 0.1.1   | 2023-05-19 | Added custom sql support                             |
 | 0.1.0   | 2022-11-30 | Initial version                                      |

--- a/wrappers/src/fdw/clickhouse_fdw/clickhouse_fdw.rs
+++ b/wrappers/src/fdw/clickhouse_fdw/clickhouse_fdw.rs
@@ -75,7 +75,7 @@ fn field_to_cell(row: &types::Row<types::Complex>, i: usize) -> Option<Cell> {
 }
 
 #[wrappers_fdw(
-    version = "0.1.2",
+    version = "0.1.3",
     author = "Supabase",
     website = "https://github.com/supabase/wrappers/tree/main/wrappers/src/fdw/clickhouse_fdw"
 )]
@@ -108,7 +108,13 @@ impl ClickHouseFdw {
         );
     }
 
-    fn deparse(&mut self, quals: &[Qual], columns: &[Column], sorts: &[Sort], limit: &Option<Limit>,) -> String {
+    fn deparse(
+        &mut self,
+        quals: &[Qual],
+        columns: &[Column],
+        sorts: &[Sort],
+        limit: &Option<Limit>,
+    ) -> String {
         let table = if self.table.starts_with('(') {
             let re = Regex::new(r"\$\{(\w+)\}").unwrap();
             re.replace_all(&self.table, |caps: &Captures| {
@@ -161,7 +167,7 @@ impl ClickHouseFdw {
                 .map(|q| q.deparse())
                 .collect::<Vec<String>>()
                 .join(" and ");
-            format!( "select {} from {} where {}", tgts, &table, cond)
+            format!("select {} from {} where {}", tgts, &table, cond)
         };
 
         // push down sorts
@@ -186,7 +192,6 @@ impl ClickHouseFdw {
         sql
     }
 }
-
 
 impl ForeignDataWrapper for ClickHouseFdw {
     fn new(options: &HashMap<String, String>) -> Self {

--- a/wrappers/src/fdw/clickhouse_fdw/tests.rs
+++ b/wrappers/src/fdw/clickhouse_fdw/tests.rs
@@ -137,21 +137,29 @@ mod tests {
             );
 
             assert_eq!(
-                c.select("SELECT name FROM test_table ORDER by name LIMIT 1 OFFSET 1", None, None)
-                    .unwrap()
-                    .first()
-                    .get_one::<&str>()
-                    .unwrap()
-                    .unwrap(),
+                c.select(
+                    "SELECT name FROM test_table ORDER by name LIMIT 1 OFFSET 1",
+                    None,
+                    None
+                )
+                .unwrap()
+                .first()
+                .get_one::<&str>()
+                .unwrap()
+                .unwrap(),
                 "test2"
             );
             assert_eq!(
-                c.select("SELECT name FROM test_cust_sql ORDER BY name LIMIT 2 OFFSET 2", None, None)
-                    .unwrap()
-                    .first()
-                    .get_one::<&str>()
-                    .unwrap()
-                    .unwrap(),
+                c.select(
+                    "SELECT name FROM test_cust_sql ORDER BY name LIMIT 2 OFFSET 2",
+                    None,
+                    None
+                )
+                .unwrap()
+                .first()
+                .get_one::<&str>()
+                .unwrap()
+                .unwrap(),
                 "test3"
             );
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to clean clickhouse fdw source and bump version.

## What is the current behavior?

N/A

## What is the new behavior?

N/A

## Additional context

N/A
