### PR TITLE
Fix WHERE pushdown with parametrized SQL as table clickhouse FDW

### DIFF
--- a/wrappers/src/fdw/clickhouse_fdw/clickhouse_fdw.rs
+++ b/wrappers/src/fdw/clickhouse_fdw/clickhouse_fdw.rs
@@ -158,17 +158,17 @@ impl ClickHouseFdw {
                 .join(", ")
         };
 
-        let mut sql = if quals.is_empty() {
-            format!("select {} from {}", tgts, &table)
-        } else {
+        let mut sql = format!("select {} from {}", tgts, &table);
+
+        if !quals.is_empty() {
             let cond = quals
                 .iter()
                 .filter(|q| !self.params.iter().any(|p| p.field == q.field))
                 .map(|q| q.deparse())
                 .collect::<Vec<String>>()
                 .join(" and ");
-            format!("select {} from {} where {}", tgts, &table, cond)
-        };
+            sql.push_str(&format!(" where {}", cond));
+        }
 
         // push down sorts
         if !sorts.is_empty() {

--- a/wrappers/src/fdw/clickhouse_fdw/clickhouse_fdw.rs
+++ b/wrappers/src/fdw/clickhouse_fdw/clickhouse_fdw.rs
@@ -167,7 +167,10 @@ impl ClickHouseFdw {
                 .map(|q| q.deparse())
                 .collect::<Vec<String>>()
                 .join(" and ");
-            sql.push_str(&format!(" where {}", cond));
+
+            if !cond.is_empty() {
+                sql.push_str(&format!(" where {}", cond));
+            }
         }
 
         // push down sorts

--- a/wrappers/src/fdw/clickhouse_fdw/tests.rs
+++ b/wrappers/src/fdw/clickhouse_fdw/tests.rs
@@ -138,6 +138,40 @@ mod tests {
 
             assert_eq!(
                 c.select(
+                    "SELECT name FROM test_table WHERE name = $1",
+                    None,
+                    Some(vec![(
+                        PgOid::BuiltIn(PgBuiltInOids::TEXTOID),
+                        "test2".into_datum()
+                    )])
+                )
+                .unwrap()
+                .first()
+                .get_one::<&str>()
+                .unwrap()
+                .unwrap(),
+                "test2"
+            );
+
+            assert_eq!(
+                c.select(
+                    "SELECT name FROM test_cust_sql WHERE name = $1",
+                    None,
+                    Some(vec![(
+                        PgOid::BuiltIn(PgBuiltInOids::TEXTOID),
+                        "test2".into_datum()
+                    )])
+                )
+                .unwrap()
+                .first()
+                .get_one::<&str>()
+                .unwrap()
+                .unwrap(),
+                "test2"
+            );
+
+            assert_eq!(
+                c.select(
                     "SELECT name FROM test_table ORDER by name LIMIT 1 OFFSET 1",
                     None,
                     None


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

`SELECT`ing with `WHERE` clause that only contains the parameter from the parametrized SQL table definition was inserting a spurious `WHERE` without any clause. 

## What is the new behavior?

Checks for empty conditions and only adds `WHERE` when appropriate.

Also adds some tests.