### PR TITLE
Foreign data wrapper with stripe docs update

### DIFF
--- a/docs/stripe.md
+++ b/docs/stripe.md
@@ -528,7 +528,7 @@ create foreign table stripe.prices (
 )
   server stripe_server
   options (
-    object 'pricing'
+    object 'prices'
   );
 ```
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

Cannot query stripe prices table after creating the table following the guide from supabase docs. When querying the following error is returned.

```object "pricing" not implemented.```

## What is the new behavior?

The table can now be queried and stripe price data are returned.

## Additional context

I am developing in stripe test mode with strip test api keys.
