### PR TITLE
docs: add clickhouse connection string examples and doc link

### DIFF
--- a/docs/clickhouse.md
+++ b/docs/clickhouse.md
@@ -82,6 +82,13 @@ We need to provide Postgres with the credentials to connect to ClickHouse, and a
       );
     ```
 
+Some connection string examples:
+
+- `tcp://user:password@host:9000/clicks?compression=lz4&ping_timeout=42ms`
+- `tcp://default:PASSWORD@abc.eu-west-1.aws.clickhouse.cloud:9440/default?connection_timeout=30s&ping_before_query=false`
+
+Check [more connection string parameters](https://github.com/suharev7/clickhouse-rs#dns).
+
 ## Creating Foreign Tables
 
 The ClickHouse Wrapper supports data reads and writes from ClickHouse.


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to add connection string examples and doc link for ClickHouse FDW server option.

## What is the current behavior?

N/A

## What is the new behavior?

N/A

## Additional context

N/A
