### PR TITLE
docs: update vault credentials docs

### DIFF
--- a/docs/airtable.md
+++ b/docs/airtable.md
@@ -23,14 +23,11 @@ create foreign data wrapper airtable_wrapper
 By default, Postgres stores FDW credentials inide `pg_catalog.pg_foreign_server` in plain text. Anyone with access to this table will be able to view these credentials. Wrappers is designed to work with [Vault](https://supabase.com/docs/guides/database/vault), which provides an additional level of security for storing credentials. We recommend using Vault to store your credentials.
 
 ```sql
--- Create a secure key using pgsodium:
-select pgsodium.create_key(name := 'airtable');
-
 -- Save your Airtable API key in Vault and retrieve the `key_id`
-insert into vault.secrets (secret, key_id)
+insert into vault.secrets (name, secret)
 values (
-  'YOUR_SECRET',
-  (select id from pgsodium.valid_key where name = 'airtable')
+  'airtable',
+  'YOUR_SECRET'
 )
 returning key_id;
 ```
@@ -43,10 +40,10 @@ We need to provide Postgres with the credentials to connect to Airtable, and any
 
     ```sql
     create server airtable_server
-    foreign data wrapper airtable_wrapper
-    options (
-      api_key_id '<key_ID>' -- The Key ID from above.
-    );
+      foreign data wrapper airtable_wrapper
+      options (
+        api_key_id '<key_ID>' -- The Key ID from above.
+      );
     ```
 
 === "Without Vault"

--- a/docs/firebase.md
+++ b/docs/firebase.md
@@ -24,21 +24,16 @@ create foreign data wrapper firebase_wrapper
 By default, Postgres stores FDW credentials inide `pg_catalog.pg_foreign_server` in plain text. Anyone with access to this table will be able to view these credentials. Wrappers is designed to work with [Vault](https://supabase.com/docs/guides/database/vault), which provides an additional level of security for storing credentials. We recommend using Vault to store your credentials.
 
 ```sql
--- Create a secure key using pgsodium:
-select pgsodium.create_key(name := 'firebase');
-
 -- Save your Firebase credentials in Vault and retrieve the `key_id`
-insert into
-  vault.secrets (secret, key_id)
-values 
-  (
-    '{
+insert into vault.secrets (name, secret)
+values (
+  'firebase',
+  '{
       "type": "service_account",
       "project_id": "your_gcp_project_id",
       ...
-    }',
-    (select id from pgsodium.valid_key where name = 'firebase')
-  )
+  }'
+)
 returning key_id;
 ```
 
@@ -52,7 +47,7 @@ We need to provide Postgres with the credentials to connect to Firebase, and any
     create server firebase_server
       foreign data wrapper firebase_wrapper
       options (
-        sa_key_id '<your key_id from above>'
+        sa_key_id '<key_ID>', -- The Key ID from above.
         project_id '<firebase_project_id>'
     );
     ```
@@ -70,7 +65,7 @@ We need to provide Postgres with the credentials to connect to Firebase, and any
             ...
          }
         ',
-         project_id 'firebase_project_id',
+         project_id 'firebase_project_id'
        );
     ```
 

--- a/docs/logflare.md
+++ b/docs/logflare.md
@@ -23,14 +23,11 @@ create foreign data wrapper logflare_wrapper
 By default, Postgres stores FDW credentials inide `pg_catalog.pg_foreign_server` in plain text. Anyone with access to this table will be able to view these credentials. Wrappers is designed to work with [Vault](https://supabase.com/docs/guides/database/vault), which provides an additional level of security for storing credentials. We recommend using Vault to store your credentials.
 
 ```sql
--- Create a secure key using pgsodium:
-select pgsodium.create_key(name := 'logflare');
-
 -- Save your Logflare API key in Vault and retrieve the `key_id`
-insert into vault.secrets (secret, key_id)
+insert into vault.secrets (name, secret)
 values (
-  'YOUR_SECRET',
-  (select id from pgsodium.valid_key where name = 'logflare')
+  'logflare',
+  'YOUR_SECRET'
 )
 returning key_id;
 ```

--- a/docs/s3.md
+++ b/docs/s3.md
@@ -56,22 +56,18 @@ create foreign data wrapper s3_wrapper
 By default, Postgres stores FDW credentials inide `pg_catalog.pg_foreign_server` in plain text. Anyone with access to this table will be able to view these credentials. Wrappers is designed to work with [Vault](https://supabase.com/docs/guides/database/vault), which provides an additional level of security for storing credentials. We recommend using Vault to store your credentials.
 
 ```sql
--- Create a secure key using pgsodium:
-select pgsodium.create_key(name := 'vault_access_key_id');
-select pgsodium.create_key(name := 'vault_secret_access_key');
-
 -- Save your AWS credential in Vault and retrieve the `key_id`
-insert into vault.secrets (secret, key_id)
+insert into vault.secrets (name, secret)
 values (
-  '<access key id>',
-  (select id from pgsodium.valid_key where name = 'vault_access_key_id')
+  'vault_access_key_id',
+  '<access key id>'
 )
 returning key_id;
 
-insert into vault.secrets (secret, key_id)
+insert into vault.secrets (name, secret)
 values (
-  '<secret access key>',
-  (select id from pgsodium.valid_key where name = 'vault_secret_access_key')
+  'vault_secret_access_key',
+  '<secret access key>'
 )
 returning key_id;
 ```
@@ -87,7 +83,7 @@ We need to provide Postgres with the credentials to connect to S3, and any addit
       foreign data wrapper s3_wrapper
       options (
         vault_access_key_id '<your vault_access_key_id from above>',
-        vault_secret_access_key '<your vault_secret_access_key_id from above>',
+        vault_secret_access_key '<your vault_secret_access_key from above>',
         aws_region 'us-east-1'
       );
     ```

--- a/docs/stripe.md
+++ b/docs/stripe.md
@@ -21,14 +21,11 @@ create foreign data wrapper stripe_wrapper
 By default, Postgres stores FDW credentials inide `pg_catalog.pg_foreign_server` in plain text. Anyone with access to this table will be able to view these credentials. Wrappers is designed to work with [Vault](https://supabase.com/docs/guides/database/vault), which provides an additional level of security for storing credentials. We recommend using Vault to store your credentials.
 
 ```sql
--- Create a secure key using pgsodium:
-select pgsodium.create_key(name := 'stripe');
-
 -- Save your Stripe API key in Vault and retrieve the `key_id`
-insert into vault.secrets (secret, key_id)
+insert into vault.secrets (name, secret)
 values (
-  'YOUR_SECRET',
-  (select id from pgsodium.valid_key where name = 'stripe')
+  'stripe',
+  'YOUR_SECRET'
 )
 returning key_id;
 ```


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to update docs for storing FDW credentials in line with latest Supabase Vault.

## What is the current behavior?

Currently the docs are still using `pgsodium` to store FDW credentials.

## What is the new behavior?

Use latest `Vault` to store FDW credentials.

## Additional context

N/A
