### PR TITLE
remove redundant word

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 `Wrappers` is a development framework for Postgres Foreign Data Wrappers ([FDW](https://wiki.postgresql.org/wiki/Foreign_data_wrappers)), written in Rust. Its goal is to make Postgres FDW development easier while keeping Rust language's modern capabilities, such as high performance, strong types, and safety.
 
-`Wrappers` is also a collection of FDWs built by [Supabase](https://www.supabase.com). We currently support the following FDWs, with more are under development:
+`Wrappers` is also a collection of FDWs built by [Supabase](https://www.supabase.com). We currently support the following FDWs, with more under development:
 
 | FDW | Description | Data Read | Data Modify | 
 |----------------|---------------|---------------|----------------|


### PR DESCRIPTION
Remove a redundant word in README