### PR TITLE
fix a clippy warning

### DIFF
--- a/supabase-wrappers/src/scan.rs
+++ b/supabase-wrappers/src/scan.rs
@@ -264,7 +264,7 @@ unsafe fn assign_paramenter_value<W: ForeignDataWrapper>(
     state: &mut FdwState<W>,
 ) {
     // get parameter list in execution state
-    let estate = (*node).ss.ps.state as *mut pg_sys::EState;
+    let estate = (*node).ss.ps.state;
     let plist_info = (*estate).es_param_list_info;
     if plist_info.is_null() {
         return;


### PR DESCRIPTION
Fixed following warning:

```
warning: casting raw pointers to the same type and constness is unnecessary (`*mut pgrx::pgrx_pg_sys::EState` -> `*mut pgrx::pgrx_pg_sys::EState`)
```