### PR TITLE
fix unused warning

### DIFF
--- a/wrappers/src/stats.rs
+++ b/wrappers/src/stats.rs
@@ -41,6 +41,7 @@ fn get_stats_table() -> String {
 }
 
 // increase stats value
+#[allow(dead_code)]
 pub(crate) fn inc_stats(fdw_name: &str, metric: Metric, inc: i64) {
     let sql = format!(
         "insert into {} as s (fdw_name, {}) values($1, $2)


### PR DESCRIPTION
When running `cargo pgrx run --features helloworld_fdw` as described in `helloworld_fdw`'s README, got the following warning:

```
warning: function `inc_stats` is never used
  --> src/stats.rs:44:15
   |
44 | pub(crate) fn inc_stats(fdw_name: &str, metric: Metric, inc: i64) {
   |               ^^^^^^^^^
   |
   = note: `#[warn(dead_code)]` on by default
```

Added a `#[allow(dead_code)]` attribute to suppress this.