### PR TITLE
set workspace resolver version to 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,4 @@
 [workspace]
-members = [
-    "supabase-wrappers",
-]
-exclude = [
-    "wrappers",
-]
+members = ["supabase-wrappers"]
+exclude = ["wrappers"]
+resolver = "2"


### PR DESCRIPTION
Set [workspace resolver version](https://doc.rust-lang.org/cargo/reference/resolver.html#feature-resolver-version-2) to 2 to fix the following warning while `cargo build`ing:

```
warning: some crates are on edition 2021 which defaults to `resolver = "2"`, but virtual workspaces default to `resolver = "1"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
```