### PR TITLE
Remove cfg_if dependency

### DIFF
--- a/wrappers/Cargo.lock
+++ b/wrappers/Cargo.lock
@@ -4242,7 +4242,6 @@ dependencies = [
  "async-compression",
  "aws-config",
  "aws-sdk-s3",
- "cfg-if",
  "chrono",
  "chrono-tz",
  "clickhouse-rs",

--- a/wrappers/Cargo.toml
+++ b/wrappers/Cargo.toml
@@ -34,7 +34,6 @@ all_fdws = ["airtable_fdw", "bigquery_fdw", "clickhouse_fdw", "stripe_fdw", "fir
 
 [dependencies]
 pgrx = { version = "=0.9.8" }
-cfg-if = "1.0"
 #supabase-wrappers = "0.1"
 supabase-wrappers = { path = "../supabase-wrappers", default-features = false }
 

--- a/wrappers/src/fdw/mod.rs
+++ b/wrappers/src/fdw/mod.rs
@@ -1,49 +1,23 @@
-use cfg_if::cfg_if;
+#[cfg(feature = "helloworld_fdw")]
+mod helloworld_fdw;
 
-cfg_if! {
-    if #[cfg(feature = "helloworld_fdw")] {
-        mod helloworld_fdw;
-    }
-}
+#[cfg(feature = "bigquery_fdw")]
+mod bigquery_fdw;
 
-cfg_if! {
-    if #[cfg(feature = "bigquery_fdw")] {
-        mod bigquery_fdw;
-    }
-}
+#[cfg(feature = "clickhouse_fdw")]
+mod clickhouse_fdw;
 
-cfg_if! {
-    if #[cfg(feature = "clickhouse_fdw")] {
-        mod clickhouse_fdw;
-    }
-}
+#[cfg(feature = "stripe_fdw")]
+mod stripe_fdw;
 
-cfg_if! {
-    if #[cfg(feature = "stripe_fdw")] {
-        mod stripe_fdw;
-    }
-}
+#[cfg(feature = "firebase_fdw")]
+mod firebase_fdw;
 
-cfg_if! {
-    if #[cfg(feature = "firebase_fdw")] {
-        mod firebase_fdw;
-    }
-}
+#[cfg(feature = "airtable_fdw")]
+mod airtable_fdw;
 
-cfg_if! {
-    if #[cfg(feature = "airtable_fdw")] {
-        mod airtable_fdw;
-    }
-}
+#[cfg(feature = "s3_fdw")]
+mod s3_fdw;
 
-cfg_if! {
-    if #[cfg(feature = "s3_fdw")] {
-        mod s3_fdw;
-    }
-}
-
-cfg_if! {
-    if #[cfg(feature = "logflare_fdw")] {
-        mod logflare_fdw;
-    }
-}
+#[cfg(feature = "logflare_fdw")]
+mod logflare_fdw;


### PR DESCRIPTION
This PR removes dependency on `cfg-if` crate because it is not needed.