### PR TITLE
Fallible ForeignDataWrapper trait methods

### DIFF
--- a/supabase-wrappers-macros/src/lib.rs
+++ b/supabase-wrappers-macros/src/lib.rs
@@ -56,14 +56,14 @@ pub fn wrappers_fdw(attr: TokenStream, item: TokenStream) -> TokenStream {
         }
     }
 
-    if error_type.is_none() {
+    let error_type_ident = if let Some(error_type) = error_type {
+        format_ident!("{}", error_type)
+    } else {
         let quoted = quote! {
             compile_error!("Missing `error_type` in the `wrappers_fdw` attribute");
         };
         return quoted.into();
-    }
-
-    let error_type_ident = format_ident!("{}", error_type.unwrap());
+    };
 
     let item: ItemStruct = parse_macro_input!(item as ItemStruct);
     let item_tokens = item.to_token_stream();

--- a/supabase-wrappers-macros/src/lib.rs
+++ b/supabase-wrappers-macros/src/lib.rs
@@ -41,15 +41,29 @@ pub fn wrappers_fdw(attr: TokenStream, item: TokenStream) -> TokenStream {
     let mut metas = TokenStream2::new();
     let meta_attrs: Punctuated<MetaNameValue, Token![,]> =
         parse_macro_input!(attr with Punctuated::parse_terminated);
+    let mut error_type: Option<String> = None;
     for attr in meta_attrs {
         let name = format!("{}", attr.path.segments.first().unwrap().ident);
         if let Lit::Str(val) = attr.lit {
             let value = val.value();
-            metas.append_all(quote! {
-                meta.insert(#name.to_owned(), #value.to_owned());
-            });
+            if name == "version" || name == "author" || name == "website" {
+                metas.append_all(quote! {
+                    meta.insert(#name.to_owned(), #value.to_owned());
+                });
+            } else if name == "error_type" {
+                error_type = Some(value);
+            }
         }
     }
+
+    if error_type.is_none() {
+        let quoted = quote! {
+            compile_error!("Missing `error_type` in the `wrappers_fdw` attribute");
+        };
+        return quoted.into();
+    }
+
+    let error_type_ident = format_ident!("{}", error_type.unwrap());
 
     let item: ItemStruct = parse_macro_input!(item as ItemStruct);
     let item_tokens = item.to_token_stream();
@@ -68,6 +82,7 @@ pub fn wrappers_fdw(attr: TokenStream, item: TokenStream) -> TokenStream {
         mod #module_ident {
             use super::#ident;
             use std::collections::HashMap;
+            use pgrx::pg_sys::panic::{ErrorReport, ErrorReportable};
             use pgrx::prelude::*;
             use supabase_wrappers::prelude::*;
 
@@ -79,6 +94,8 @@ pub fn wrappers_fdw(attr: TokenStream, item: TokenStream) -> TokenStream {
             #[pg_extern(create_or_replace)]
             fn #fn_validator_ident(options: Vec<Option<String>>, catalog: Option<pg_sys::Oid>) {
                 #ident::validator(options, catalog)
+                    .map_err(|e| <super::#error_type_ident as Into<ErrorReport>>::into(e))
+                    .report();
             }
 
             #[pg_extern(create_or_replace)]

--- a/supabase-wrappers/src/instance.rs
+++ b/supabase-wrappers/src/instance.rs
@@ -1,12 +1,16 @@
 use crate::prelude::*;
+use pgrx::pg_sys::panic::{ErrorReport, ErrorReportable};
 use pgrx::prelude::*;
 
 use super::utils;
 
 // create a fdw instance
-pub(super) unsafe fn create_fdw_instance<W: ForeignDataWrapper>(ftable_id: pg_sys::Oid) -> W {
+pub(super) unsafe fn create_fdw_instance<E: Into<ErrorReport>, W: ForeignDataWrapper<E>>(
+    ftable_id: pg_sys::Oid,
+) -> W {
     let ftable = pg_sys::GetForeignTable(ftable_id);
     let fserver = pg_sys::GetForeignServer((*ftable).serverid);
     let fserver_opts = utils::options_to_hashmap((*fserver).options);
-    W::new(&fserver_opts)
+    let wrapper = W::new(&fserver_opts);
+    wrapper.map_err(|e| e.into()).report()
 }

--- a/supabase-wrappers/src/interface.rs
+++ b/supabase-wrappers/src/interface.rs
@@ -553,7 +553,9 @@ pub trait ForeignDataWrapper<E: Into<ErrorReport>> {
     /// ```
     ///
     /// [See more details](https://www.postgresql.org/docs/current/fdw-callbacks.html#FDW-CALLBACKS-UPDATE).
-    fn begin_modify(&mut self, _options: &HashMap<String, String>) {}
+    fn begin_modify(&mut self, _options: &HashMap<String, String>) -> Result<(), E> {
+        Ok(())
+    }
 
     /// Called when insert one row into the foreign table
     ///

--- a/supabase-wrappers/src/interface.rs
+++ b/supabase-wrappers/src/interface.rs
@@ -517,7 +517,7 @@ pub trait ForeignDataWrapper<E: Into<ErrorReport>> {
     /// FDW must save fetched foreign data into the [`Row`], or return `None` if no more rows to read.
     ///
     /// [See more details](https://www.postgresql.org/docs/current/fdw-callbacks.html#FDW-CALLBACKS-SCAN).
-    fn iter_scan(&mut self, row: &mut Row) -> Option<()>;
+    fn iter_scan(&mut self, row: &mut Row) -> Result<Option<()>, E>;
 
     /// Called when restart the scan from the beginning.
     ///

--- a/supabase-wrappers/src/interface.rs
+++ b/supabase-wrappers/src/interface.rs
@@ -522,7 +522,9 @@ pub trait ForeignDataWrapper<E: Into<ErrorReport>> {
     /// Called when restart the scan from the beginning.
     ///
     /// [See more details](https://www.postgresql.org/docs/current/fdw-callbacks.html#FDW-CALLBACKS-SCAN).
-    fn re_scan(&mut self) {}
+    fn re_scan(&mut self) -> Result<(), E> {
+        Ok(())
+    }
 
     /// Called when end the scan
     ///

--- a/supabase-wrappers/src/interface.rs
+++ b/supabase-wrappers/src/interface.rs
@@ -529,7 +529,7 @@ pub trait ForeignDataWrapper<E: Into<ErrorReport>> {
     /// Called when end the scan
     ///
     /// [See more details](https://www.postgresql.org/docs/current/fdw-callbacks.html#FDW-CALLBACKS-SCAN).
-    fn end_scan(&mut self);
+    fn end_scan(&mut self) -> Result<(), E>;
 
     /// Called when begin executing a foreign table modification operation.
     ///

--- a/supabase-wrappers/src/interface.rs
+++ b/supabase-wrappers/src/interface.rs
@@ -581,7 +581,9 @@ pub trait ForeignDataWrapper<E: Into<ErrorReport>> {
     /// - rowid - the `rowid_column` cell
     ///
     /// [See more details](https://www.postgresql.org/docs/current/fdw-callbacks.html#FDW-CALLBACKS-UPDATE).
-    fn delete(&mut self, _rowid: &Cell) {}
+    fn delete(&mut self, _rowid: &Cell) -> Result<(), E> {
+        Ok(())
+    }
 
     /// Called when end the table update
     ///

--- a/supabase-wrappers/src/interface.rs
+++ b/supabase-wrappers/src/interface.rs
@@ -510,7 +510,7 @@ pub trait ForeignDataWrapper<E: Into<ErrorReport>> {
         sorts: &[Sort],
         limit: &Option<Limit>,
         options: &HashMap<String, String>,
-    );
+    ) -> Result<(), E>;
 
     /// Called when fetch one row from the foreign source
     ///

--- a/supabase-wrappers/src/interface.rs
+++ b/supabase-wrappers/src/interface.rs
@@ -646,7 +646,27 @@ pub trait ForeignDataWrapper<E: Into<ErrorReport>> {
     /// use pgrx::pg_sys::Oid;
     /// use supabase_wrappers::prelude::check_options_contain;
     ///
-    /// fn validator(opt_list: Vec<Option<String>>, catalog: Option<Oid>) {
+    /// use pgrx::pg_sys::panic::ErrorReport;
+    /// use pgrx::PgSqlErrorCode;
+    ///
+    /// enum FdwError {
+    ///     InvalidFdwOption,
+    ///     InvalidServerOption,
+    ///     InvalidTableOption,
+    /// }
+    ///
+    /// impl From<FdwError> for ErrorReport {
+    ///     fn from(value: FdwError) -> Self {
+    ///         let error_message = match value {
+    ///             FdwError::InvalidFdwOption => "invalid foreign data wrapper option",
+    ///             FdwError::InvalidServerOption => "invalid foreign server option",
+    ///             FdwError::InvalidTableOption => "invalid foreign table option",
+    ///         };
+    ///         ErrorReport::new(PgSqlErrorCode::ERRCODE_FDW_ERROR, error_message, "")
+    ///     }
+    /// }
+    ///
+    /// fn validator(opt_list: Vec<Option<String>>, catalog: Option<Oid>) -> Result<(), FdwError> {
     ///     if let Some(oid) = catalog {
     ///         match oid {
     ///             FOREIGN_DATA_WRAPPER_RELATION_ID => {
@@ -664,7 +684,11 @@ pub trait ForeignDataWrapper<E: Into<ErrorReport>> {
     ///             _ => {}
     ///         }
     ///     }
+    ///
+    ///     Ok(())
     /// }
     /// ```
-    fn validator(_options: Vec<Option<String>>, _catalog: Option<Oid>) {}
+    fn validator(_options: Vec<Option<String>>, _catalog: Option<Oid>) -> Result<(), E> {
+        Ok(())
+    }
 }

--- a/supabase-wrappers/src/interface.rs
+++ b/supabase-wrappers/src/interface.rs
@@ -572,7 +572,9 @@ pub trait ForeignDataWrapper<E: Into<ErrorReport>> {
     /// - new_row - the new row with updated cells
     ///
     /// [See more details](https://www.postgresql.org/docs/current/fdw-callbacks.html#FDW-CALLBACKS-UPDATE).
-    fn update(&mut self, _rowid: &Cell, _new_row: &Row) {}
+    fn update(&mut self, _rowid: &Cell, _new_row: &Row) -> Result<(), E> {
+        Ok(())
+    }
 
     /// Called when delete one row into the foreign table
     ///

--- a/supabase-wrappers/src/interface.rs
+++ b/supabase-wrappers/src/interface.rs
@@ -562,7 +562,9 @@ pub trait ForeignDataWrapper<E: Into<ErrorReport>> {
     /// - row - the new row to be inserted
     ///
     /// [See more details](https://www.postgresql.org/docs/current/fdw-callbacks.html#FDW-CALLBACKS-UPDATE).
-    fn insert(&mut self, _row: &Row) {}
+    fn insert(&mut self, _row: &Row) -> Result<(), E> {
+        Ok(())
+    }
 
     /// Called when update one row into the foreign table
     ///

--- a/supabase-wrappers/src/interface.rs
+++ b/supabase-wrappers/src/interface.rs
@@ -588,7 +588,9 @@ pub trait ForeignDataWrapper<E: Into<ErrorReport>> {
     /// Called when end the table update
     ///
     /// [See more details](https://www.postgresql.org/docs/current/fdw-callbacks.html#FDW-CALLBACKS-UPDATE).
-    fn end_modify(&mut self) {}
+    fn end_modify(&mut self) -> Result<(), E> {
+        Ok(())
+    }
 
     /// Returns a FdwRoutine for the FDW
     ///

--- a/supabase-wrappers/src/interface.rs
+++ b/supabase-wrappers/src/interface.rs
@@ -490,8 +490,8 @@ pub trait ForeignDataWrapper<E: Into<ErrorReport>> {
         _sorts: &[Sort],
         _limit: &Option<Limit>,
         _options: &HashMap<String, String>,
-    ) -> (i64, i32) {
-        (0, 0)
+    ) -> Result<(i64, i32), E> {
+        Ok((0, 0))
     }
 
     /// Called when begin executing a foreign scan

--- a/supabase-wrappers/src/lib.rs
+++ b/supabase-wrappers/src/lib.rs
@@ -62,11 +62,14 @@
 //! ```rust,no_run
 //! # mod wrapper {
 //! use std::collections::HashMap;
+//! use pgrx::pg_sys::panic::ErrorReport;
+//! use pgrx::PgSqlErrorCode;
 //! use supabase_wrappers::prelude::*;
 //! #[wrappers_fdw(
 //!    version = "0.1.0",
 //!    author = "Supabase",
-//!    website = "https://github.com/supabase/wrappers/tree/main/wrappers/src/fdw/helloworld_fdw"
+//!    website = "https://github.com/supabase/wrappers/tree/main/wrappers/src/fdw/helloworld_fdw",
+//!    error_type = "HelloWorldFdwError"
 //! )]
 //! pub struct HelloWorldFdw {
 //!     //row counter
@@ -76,8 +79,16 @@
 //!     tgt_cols: Vec<Column>,
 //! }
 //!
-//! impl ForeignDataWrapper for HelloWorldFdw {
-//!     fn new(options: &HashMap<String, String>) -> Self {
+//! enum HelloWorldFdwError {}
+//!
+//! impl From<HelloWorldFdwError> for ErrorReport {
+//!     fn from(_value: HelloWorldFdwError) -> Self {
+//!         ErrorReport::new(PgSqlErrorCode::ERRCODE_FDW_ERROR, "", "")
+//!     }
+//! }
+//!
+//! impl ForeignDataWrapper<HelloWorldFdwError> for HelloWorldFdw {
+//!     fn new(options: &HashMap<String, String>) -> Result<Self, HelloWorldFdwError> {
 //!         // 'options' is the key-value pairs defined in `CREATE SERVER` SQL, for example,
 //!         //
 //!         // create server my_helloworld_server
@@ -91,23 +102,25 @@
 //!         // You can do any initalization in this new() function, like saving connection
 //!         // info or API url in an variable, but don't do heavy works like database
 //!         // connection or API call.
-//!         Self {
+//!         Ok(Self {
 //!             row_cnt: 0,
 //!             tgt_cols: Vec::new(),
-//!         }
+//!         })
 //!     }
 //!
-//!     fn begin_scan(&mut self, quals: &[Qual], columns: &[Column], sorts: &[Sort], limit: &Option<Limit>, options: &HashMap<String, String>) {
+//!     fn begin_scan(&mut self, quals: &[Qual], columns: &[Column], sorts: &[Sort], limit: &Option<Limit>, options: &HashMap<String, String>) -> Result<(), HelloWorldFdwError> {
 //!         // Do any initilization
+//!         Ok(())
 //!     }
 //!
-//!     fn iter_scan(&mut self, row: &mut Row) -> Option<()> {
+//!     fn iter_scan(&mut self, row: &mut Row) -> Result<Option<()>, HelloWorldFdwError> {
 //!         // Return None when done
-//!         None
+//!         Ok(None)
 //!     }
 //!
-//!     fn end_scan(&mut self) {
+//!     fn end_scan(&mut self) -> Result<(), HelloWorldFdwError> {
 //!         // Cleanup any resources
+//!         Ok(())
 //!     }
 //! }
 //! # }
@@ -136,6 +149,8 @@
 //!
 //! ```rust,no_run
 //! use std::collections::HashMap;
+//! use pgrx::pg_sys::panic::ErrorReport;
+//! use pgrx::PgSqlErrorCode;
 //! use supabase_wrappers::prelude::*;
 //!
 //! pub(crate) struct HelloWorldFdw {
@@ -145,12 +160,21 @@
 //!     // target column name list
 //!     tgt_cols: Vec<Column>,
 //! }
-//! impl ForeignDataWrapper for HelloWorldFdw {
-//!     fn new(options: &HashMap<String, String>) -> Self {
-//!         Self {
+//!
+//! enum HelloWorldFdwError {}
+//!
+//! impl From<HelloWorldFdwError> for ErrorReport {
+//!     fn from(_value: HelloWorldFdwError) -> Self {
+//!         ErrorReport::new(PgSqlErrorCode::ERRCODE_FDW_ERROR, "", "")
+//!     }
+//! }
+//!
+//! impl ForeignDataWrapper<HelloWorldFdwError> for HelloWorldFdw {
+//!     fn new(options: &HashMap<String, String>) -> Result<Self, HelloWorldFdwError> {
+//!         Ok(Self {
 //!             row_cnt: 0,
 //!             tgt_cols: Vec::new(),
-//!         }
+//!         })
 //!     }
 //!
 //!     fn begin_scan(
@@ -160,15 +184,16 @@
 //!         _sorts: &[Sort],
 //!         _limit: &Option<Limit>,
 //!         _options: &HashMap<String, String>,
-//!     ) {
+//!     ) -> Result<(), HelloWorldFdwError> {
 //!         // reset row count
 //!         self.row_cnt = 0;
 //!
 //!         // save a copy of target columns
 //!         self.tgt_cols = columns.to_vec();
+//!         Ok(())
 //!     }
 //!
-//!     fn iter_scan(&mut self, row: &mut Row) -> Option<()> {
+//!     fn iter_scan(&mut self, row: &mut Row) -> Result<Option<()>, HelloWorldFdwError> {
 //!         // this is called on each row and we only return one row here
 //!         if self.row_cnt < 1 {
 //!             // add values to row if they are in target column list
@@ -183,15 +208,16 @@
 //!             self.row_cnt += 1;
 //!
 //!             // return the 'Some(())' to Postgres and continue data scan
-//!             return Some(());
+//!             return Ok(Some(()));
 //!         }
 //!
 //!         // return 'None' to stop data scan
-//!         None
+//!         Ok(None)
 //!     }
 //!
-//!     fn end_scan(&mut self) {
+//!     fn end_scan(&mut self) -> Result<(), HelloWorldFdwError> {
 //!         // we do nothing here, but you can do things like resource cleanup and etc.
+//!         Ok(())
 //!     }
 //! }
 //! ```

--- a/supabase-wrappers/src/modify.rs
+++ b/supabase-wrappers/src/modify.rs
@@ -55,8 +55,8 @@ impl<E: Into<ErrorReport>, W: ForeignDataWrapper<E>> FdwModifyState<E, W> {
         self.instance.insert(row)
     }
 
-    fn update(&mut self, rowid: &Cell, new_row: &Row) {
-        self.instance.update(rowid, new_row);
+    fn update(&mut self, rowid: &Cell, new_row: &Row) -> Result<(), E> {
+        self.instance.update(rowid, new_row)
     }
 
     fn delete(&mut self, rowid: &Cell) {
@@ -292,7 +292,10 @@ pub(super) extern "C" fn exec_foreign_update<E: Into<ErrorReport>, W: ForeignDat
                 }) && state.rowid_name != col.as_str()
             });
 
-            state.update(&rowid, &new_row);
+            state
+                .update(&rowid, &new_row)
+                .map_err(|e| e.into())
+                .report();
         }
     }
 

--- a/supabase-wrappers/src/modify.rs
+++ b/supabase-wrappers/src/modify.rs
@@ -51,8 +51,8 @@ impl<E: Into<ErrorReport>, W: ForeignDataWrapper<E>> FdwModifyState<E, W> {
         self.instance.begin_modify(&self.opts)
     }
 
-    fn insert(&mut self, row: &Row) {
-        self.instance.insert(row);
+    fn insert(&mut self, row: &Row) -> Result<(), E> {
+        self.instance.insert(row)
     }
 
     fn update(&mut self, rowid: &Cell, new_row: &Row) {
@@ -228,7 +228,7 @@ pub(super) extern "C" fn exec_foreign_insert<E: Into<ErrorReport>, W: ForeignDat
         );
 
         let row = utils::tuple_table_slot_to_row(slot);
-        state.insert(&row);
+        state.insert(&row).map_err(|e| e.into()).report();
     }
 
     slot

--- a/supabase-wrappers/src/modify.rs
+++ b/supabase-wrappers/src/modify.rs
@@ -59,8 +59,8 @@ impl<E: Into<ErrorReport>, W: ForeignDataWrapper<E>> FdwModifyState<E, W> {
         self.instance.update(rowid, new_row)
     }
 
-    fn delete(&mut self, rowid: &Cell) {
-        self.instance.delete(rowid);
+    fn delete(&mut self, rowid: &Cell) -> Result<(), E> {
+        self.instance.delete(rowid)
     }
 
     fn end_modify(&mut self) {
@@ -258,7 +258,7 @@ pub(super) extern "C" fn exec_foreign_delete<E: Into<ErrorReport>, W: ForeignDat
 
         let cell = get_rowid_cell(&state, plan_slot);
         if let Some(rowid) = cell {
-            state.delete(&rowid);
+            state.delete(&rowid).map_err(|e| e.into()).report();
         }
     }
 

--- a/supabase-wrappers/src/modify.rs
+++ b/supabase-wrappers/src/modify.rs
@@ -63,8 +63,8 @@ impl<E: Into<ErrorReport>, W: ForeignDataWrapper<E>> FdwModifyState<E, W> {
         self.instance.delete(rowid)
     }
 
-    fn end_modify(&mut self) {
-        self.instance.end_modify();
+    fn end_modify(&mut self) -> Result<(), E> {
+        self.instance.end_modify()
     }
 }
 
@@ -312,7 +312,7 @@ pub(super) extern "C" fn end_foreign_modify<E: Into<ErrorReport>, W: ForeignData
         let fdw_state = (*rinfo).ri_FdwState as *mut FdwModifyState<E, W>;
         if !fdw_state.is_null() {
             let mut state = PgBox::<FdwModifyState<E, W>>::from_pg(fdw_state);
-            state.end_modify();
+            state.end_modify().map_err(|e| e.into()).report();
         }
     }
 }

--- a/supabase-wrappers/src/scan.rs
+++ b/supabase-wrappers/src/scan.rs
@@ -80,7 +80,7 @@ impl<E: Into<ErrorReport>, W: ForeignDataWrapper<E>> FdwState<E, W> {
     }
 
     #[inline]
-    fn begin_scan(&mut self) {
+    fn begin_scan(&mut self) -> Result<(), E> {
         self.instance.begin_scan(
             &self.quals,
             &self.tgts,
@@ -305,7 +305,7 @@ pub(super) extern "C" fn begin_foreign_scan<E: Into<ErrorReport>, W: ForeignData
 
         // begin scan if it is not EXPLAIN statement
         if eflags & pg_sys::EXEC_FLAG_EXPLAIN_ONLY as c_int <= 0 {
-            state.begin_scan();
+            state.begin_scan().map_err(|e| e.into()).report();
 
             let rel = scan_state.ss_currentRelation;
             let tup_desc = (*rel).rd_att;

--- a/supabase-wrappers/src/scan.rs
+++ b/supabase-wrappers/src/scan.rs
@@ -96,7 +96,7 @@ impl<E: Into<ErrorReport>, W: ForeignDataWrapper<E>> FdwState<E, W> {
     }
 
     #[inline]
-    fn re_scan(&mut self) {
+    fn re_scan(&mut self) -> Result<(), E> {
         self.instance.re_scan()
     }
 
@@ -375,7 +375,7 @@ pub(super) extern "C" fn re_scan_foreign_scan<E: Into<ErrorReport>, W: ForeignDa
         let fdw_state = (*node).fdw_state as *mut FdwState<E, W>;
         if !fdw_state.is_null() {
             let mut state = PgBox::<FdwState<E, W>>::from_pg(fdw_state);
-            state.re_scan();
+            state.re_scan().map_err(|e| e.into()).report();
         }
     }
 }

--- a/supabase-wrappers/src/scan.rs
+++ b/supabase-wrappers/src/scan.rs
@@ -101,8 +101,8 @@ impl<E: Into<ErrorReport>, W: ForeignDataWrapper<E>> FdwState<E, W> {
     }
 
     #[inline]
-    fn end_scan(&mut self) {
-        self.instance.end_scan();
+    fn end_scan(&mut self) -> Result<(), E> {
+        self.instance.end_scan()
     }
 }
 
@@ -392,6 +392,6 @@ pub(super) extern "C" fn end_foreign_scan<E: Into<ErrorReport>, W: ForeignDataWr
         }
 
         let mut state = PgBox::<FdwState<E, W>>::from_pg(fdw_state);
-        state.end_scan();
+        state.end_scan().map_err(|e| e.into()).report();
     }
 }

--- a/supabase-wrappers/src/scan.rs
+++ b/supabase-wrappers/src/scan.rs
@@ -4,7 +4,9 @@ use pgrx::{
     PgSqlErrorCode,
 };
 use std::collections::HashMap;
+use std::marker::PhantomData;
 
+use pgrx::pg_sys::panic::ErrorReport;
 use std::os::raw::c_int;
 use std::ptr;
 
@@ -19,7 +21,7 @@ use crate::sort::*;
 use crate::utils::{self, report_error, SerdeList};
 
 // Fdw private state for scan
-struct FdwState<W: ForeignDataWrapper> {
+struct FdwState<E: Into<ErrorReport>, W: ForeignDataWrapper<E>> {
     // foreign data wrapper instance
     instance: W,
 
@@ -46,9 +48,10 @@ struct FdwState<W: ForeignDataWrapper> {
     values: Vec<Datum>,
     nulls: Vec<bool>,
     row: Row,
+    _phantom: PhantomData<E>,
 }
 
-impl<W: ForeignDataWrapper> FdwState<W> {
+impl<E: Into<ErrorReport>, W: ForeignDataWrapper<E>> FdwState<E, W> {
     unsafe fn new(foreigntableid: Oid, tmp_ctx: PgMemoryContexts) -> Self {
         Self {
             instance: instance::create_fdw_instance(foreigntableid),
@@ -61,6 +64,7 @@ impl<W: ForeignDataWrapper> FdwState<W> {
             values: Vec::new(),
             nulls: Vec::new(),
             row: Row::new(),
+            _phantom: PhantomData,
         }
     }
 
@@ -102,10 +106,10 @@ impl<W: ForeignDataWrapper> FdwState<W> {
     }
 }
 
-impl<W: ForeignDataWrapper> utils::SerdeList for FdwState<W> {}
+impl<E: Into<ErrorReport>, W: ForeignDataWrapper<E>> utils::SerdeList for FdwState<E, W> {}
 
 #[pg_guard]
-pub(super) extern "C" fn get_foreign_rel_size<W: ForeignDataWrapper>(
+pub(super) extern "C" fn get_foreign_rel_size<E: Into<ErrorReport>, W: ForeignDataWrapper<E>>(
     root: *mut pg_sys::PlannerInfo,
     baserel: *mut pg_sys::RelOptInfo,
     foreigntableid: pg_sys::Oid,
@@ -117,7 +121,7 @@ pub(super) extern "C" fn get_foreign_rel_size<W: ForeignDataWrapper>(
         let ctx = memctx::refresh_wrappers_memctx(&ctx_name);
 
         // create scan state
-        let mut state = FdwState::<W>::new(foreigntableid, ctx);
+        let mut state = FdwState::<E, W>::new(foreigntableid, ctx);
 
         // extract qual list
         state.quals = extract_quals(root, baserel, foreigntableid);
@@ -147,14 +151,14 @@ pub(super) extern "C" fn get_foreign_rel_size<W: ForeignDataWrapper>(
 }
 
 #[pg_guard]
-pub(super) extern "C" fn get_foreign_paths<W: ForeignDataWrapper>(
+pub(super) extern "C" fn get_foreign_paths<E: Into<ErrorReport>, W: ForeignDataWrapper<E>>(
     root: *mut pg_sys::PlannerInfo,
     baserel: *mut pg_sys::RelOptInfo,
     _foreigntableid: pg_sys::Oid,
 ) {
     debug2!("---> get_foreign_paths");
     unsafe {
-        let state = PgBox::<FdwState<W>>::from_pg((*baserel).fdw_private as _);
+        let state = PgBox::<FdwState<E, W>>::from_pg((*baserel).fdw_private as _);
 
         // get startup cost from foreign table options
         let startup_cost = state
@@ -187,7 +191,7 @@ pub(super) extern "C" fn get_foreign_paths<W: ForeignDataWrapper>(
 }
 
 #[pg_guard]
-pub(super) extern "C" fn get_foreign_plan<W: ForeignDataWrapper>(
+pub(super) extern "C" fn get_foreign_plan<E: Into<ErrorReport>, W: ForeignDataWrapper<E>>(
     _root: *mut pg_sys::PlannerInfo,
     baserel: *mut pg_sys::RelOptInfo,
     _foreigntableid: pg_sys::Oid,
@@ -198,7 +202,7 @@ pub(super) extern "C" fn get_foreign_plan<W: ForeignDataWrapper>(
 ) -> *mut pg_sys::ForeignScan {
     debug2!("---> get_foreign_plan");
     unsafe {
-        let state = PgBox::<FdwState<W>>::from_pg((*baserel).fdw_private as _);
+        let state = PgBox::<FdwState<E, W>>::from_pg((*baserel).fdw_private as _);
 
         // make foreign scan plan
         let scan_clauses = pg_sys::extract_actual_clauses(scan_clauses, false);
@@ -227,18 +231,18 @@ pub(super) extern "C" fn get_foreign_plan<W: ForeignDataWrapper>(
 }
 
 #[pg_guard]
-pub(super) extern "C" fn explain_foreign_scan<W: ForeignDataWrapper>(
+pub(super) extern "C" fn explain_foreign_scan<E: Into<ErrorReport>, W: ForeignDataWrapper<E>>(
     node: *mut pg_sys::ForeignScanState,
     es: *mut pg_sys::ExplainState,
 ) {
     debug2!("---> explain_foreign_scan");
     unsafe {
-        let fdw_state = (*node).fdw_state as *mut FdwState<W>;
+        let fdw_state = (*node).fdw_state as *mut FdwState<E, W>;
         if fdw_state.is_null() {
             return;
         }
 
-        let state = PgBox::<FdwState<W>>::from_pg(fdw_state);
+        let state = PgBox::<FdwState<E, W>>::from_pg(fdw_state);
 
         let ctx = PgMemoryContexts::CurrentMemoryContext;
 
@@ -259,9 +263,9 @@ pub(super) extern "C" fn explain_foreign_scan<W: ForeignDataWrapper>(
 }
 
 // extract paramter value and assign it to qual in scan state
-unsafe fn assign_paramenter_value<W: ForeignDataWrapper>(
+unsafe fn assign_paramenter_value<E: Into<ErrorReport>, W: ForeignDataWrapper<E>>(
     node: *mut pg_sys::ForeignScanState,
-    state: &mut FdwState<W>,
+    state: &mut FdwState<E, W>,
 ) {
     // get parameter list in execution state
     let estate = (*node).ss.ps.state;
@@ -285,7 +289,7 @@ unsafe fn assign_paramenter_value<W: ForeignDataWrapper>(
 }
 
 #[pg_guard]
-pub(super) extern "C" fn begin_foreign_scan<W: ForeignDataWrapper>(
+pub(super) extern "C" fn begin_foreign_scan<E: Into<ErrorReport>, W: ForeignDataWrapper<E>>(
     node: *mut pg_sys::ForeignScanState,
     eflags: c_int,
 ) {
@@ -293,7 +297,7 @@ pub(super) extern "C" fn begin_foreign_scan<W: ForeignDataWrapper>(
     unsafe {
         let scan_state = (*node).ss;
         let plan = scan_state.ps.plan as *mut pg_sys::ForeignScan;
-        let mut state = FdwState::<W>::deserialize_from_list((*plan).fdw_private as _);
+        let mut state = FdwState::<E, W>::deserialize_from_list((*plan).fdw_private as _);
         assert!(!state.is_null());
 
         // assign parameter values to qual
@@ -319,13 +323,13 @@ pub(super) extern "C" fn begin_foreign_scan<W: ForeignDataWrapper>(
 }
 
 #[pg_guard]
-pub(super) extern "C" fn iterate_foreign_scan<W: ForeignDataWrapper>(
+pub(super) extern "C" fn iterate_foreign_scan<E: Into<ErrorReport>, W: ForeignDataWrapper<E>>(
     node: *mut pg_sys::ForeignScanState,
 ) -> *mut pg_sys::TupleTableSlot {
     // `debug!` macros are quite expensive at the moment, so avoid logging in the inner loop
     // debug2!("---> iterate_foreign_scan");
     unsafe {
-        let mut state = PgBox::<FdwState<W>>::from_pg((*node).fdw_state as _);
+        let mut state = PgBox::<FdwState<E, W>>::from_pg((*node).fdw_state as _);
 
         // clear slot
         let slot = (*node).ss.ss_ScanTupleSlot;
@@ -363,31 +367,31 @@ pub(super) extern "C" fn iterate_foreign_scan<W: ForeignDataWrapper>(
 }
 
 #[pg_guard]
-pub(super) extern "C" fn re_scan_foreign_scan<W: ForeignDataWrapper>(
+pub(super) extern "C" fn re_scan_foreign_scan<E: Into<ErrorReport>, W: ForeignDataWrapper<E>>(
     node: *mut pg_sys::ForeignScanState,
 ) {
     debug2!("---> re_scan_foreign_scan");
     unsafe {
-        let fdw_state = (*node).fdw_state as *mut FdwState<W>;
+        let fdw_state = (*node).fdw_state as *mut FdwState<E, W>;
         if !fdw_state.is_null() {
-            let mut state = PgBox::<FdwState<W>>::from_pg(fdw_state);
+            let mut state = PgBox::<FdwState<E, W>>::from_pg(fdw_state);
             state.re_scan();
         }
     }
 }
 
 #[pg_guard]
-pub(super) extern "C" fn end_foreign_scan<W: ForeignDataWrapper>(
+pub(super) extern "C" fn end_foreign_scan<E: Into<ErrorReport>, W: ForeignDataWrapper<E>>(
     node: *mut pg_sys::ForeignScanState,
 ) {
     debug2!("---> end_foreign_scan");
     unsafe {
-        let fdw_state = (*node).fdw_state as *mut FdwState<W>;
+        let fdw_state = (*node).fdw_state as *mut FdwState<E, W>;
         if fdw_state.is_null() {
             return;
         }
 
-        let mut state = PgBox::<FdwState<W>>::from_pg(fdw_state);
+        let mut state = PgBox::<FdwState<E, W>>::from_pg(fdw_state);
         state.end_scan();
     }
 }

--- a/supabase-wrappers/src/scan.rs
+++ b/supabase-wrappers/src/scan.rs
@@ -91,7 +91,7 @@ impl<E: Into<ErrorReport>, W: ForeignDataWrapper<E>> FdwState<E, W> {
     }
 
     #[inline]
-    fn iter_scan(&mut self) -> Option<()> {
+    fn iter_scan(&mut self) -> Result<Option<()>, E> {
         self.instance.iter_scan(&mut self.row)
     }
 
@@ -336,7 +336,7 @@ pub(super) extern "C" fn iterate_foreign_scan<E: Into<ErrorReport>, W: ForeignDa
         polyfill::exec_clear_tuple(slot);
 
         state.row.clear();
-        if state.iter_scan().is_some() {
+        if state.iter_scan().map_err(|e| e.into()).report().is_some() {
             if state.row.cols.len() != state.tgts.len() {
                 report_error(
                     PgSqlErrorCode::ERRCODE_FDW_INVALID_COLUMN_NUMBER,

--- a/wrappers/src/fdw/airtable_fdw/airtable_fdw.rs
+++ b/wrappers/src/fdw/airtable_fdw/airtable_fdw.rs
@@ -31,7 +31,8 @@ fn create_client(api_key: &str) -> ClientWithMiddleware {
 #[wrappers_fdw(
     version = "0.1.2",
     author = "Ankur Goyal",
-    website = "https://github.com/supabase/wrappers/tree/main/wrappers/src/fdw/airtable_fdw"
+    website = "https://github.com/supabase/wrappers/tree/main/wrappers/src/fdw/airtable_fdw",
+    error_type = "AirtableFdwError"
 )]
 pub(crate) struct AirtableFdw {
     rt: Runtime,
@@ -212,12 +213,17 @@ impl ForeignDataWrapper<AirtableFdwError> for AirtableFdw {
         Ok(())
     }
 
-    fn validator(options: Vec<Option<String>>, catalog: Option<pg_sys::Oid>) {
+    fn validator(
+        options: Vec<Option<String>>,
+        catalog: Option<pg_sys::Oid>,
+    ) -> Result<(), AirtableFdwError> {
         if let Some(oid) = catalog {
             if oid == FOREIGN_TABLE_RELATION_ID {
                 check_options_contain(&options, "base_id");
                 check_options_contain(&options, "table_id");
             }
         }
+
+        Ok(())
     }
 }

--- a/wrappers/src/fdw/airtable_fdw/airtable_fdw.rs
+++ b/wrappers/src/fdw/airtable_fdw/airtable_fdw.rs
@@ -207,8 +207,9 @@ impl ForeignDataWrapper<AirtableFdwError> for AirtableFdw {
         Ok(None)
     }
 
-    fn end_scan(&mut self) {
+    fn end_scan(&mut self) -> Result<(), AirtableFdwError> {
         self.scan_result.take();
+        Ok(())
     }
 
     fn validator(options: Vec<Option<String>>, catalog: Option<pg_sys::Oid>) {

--- a/wrappers/src/fdw/airtable_fdw/airtable_fdw.rs
+++ b/wrappers/src/fdw/airtable_fdw/airtable_fdw.rs
@@ -195,16 +195,16 @@ impl ForeignDataWrapper<AirtableFdwError> for AirtableFdw {
         Ok(())
     }
 
-    fn iter_scan(&mut self, row: &mut Row) -> Option<()> {
+    fn iter_scan(&mut self, row: &mut Row) -> Result<Option<()>, AirtableFdwError> {
         if let Some(ref mut result) = self.scan_result {
             if !result.is_empty() {
-                return result
+                return Ok(result
                     .drain(0..1)
                     .last()
-                    .map(|src_row| row.replace_with(src_row));
+                    .map(|src_row| row.replace_with(src_row)));
             }
         }
-        None
+        Ok(None)
     }
 
     fn end_scan(&mut self) {

--- a/wrappers/src/fdw/bigquery_fdw/bigquery_fdw.rs
+++ b/wrappers/src/fdw/bigquery_fdw/bigquery_fdw.rs
@@ -435,7 +435,7 @@ impl ForeignDataWrapper<BigQueryFdwError> for BigQueryFdw {
         Ok(())
     }
 
-    fn insert(&mut self, src: &Row) {
+    fn insert(&mut self, src: &Row) -> Result<(), BigQueryFdwError> {
         if let Some(ref mut client) = self.client {
             let mut insert_request = TableDataInsertAllRequest::new();
             let mut row_json = json!({});
@@ -474,6 +474,8 @@ impl ForeignDataWrapper<BigQueryFdwError> for BigQueryFdw {
                 );
             }
         }
+
+        Ok(())
     }
 
     fn update(&mut self, rowid: &Cell, new_row: &Row) {

--- a/wrappers/src/fdw/bigquery_fdw/bigquery_fdw.rs
+++ b/wrappers/src/fdw/bigquery_fdw/bigquery_fdw.rs
@@ -86,7 +86,8 @@ fn field_to_cell(rs: &ResultSet, field: &TableFieldSchema) -> Option<Cell> {
 #[wrappers_fdw(
     version = "0.1.4",
     author = "Supabase",
-    website = "https://github.com/supabase/wrappers/tree/main/wrappers/src/fdw/bigquery_fdw"
+    website = "https://github.com/supabase/wrappers/tree/main/wrappers/src/fdw/bigquery_fdw",
+    error_type = "BigQueryFdwError"
 )]
 pub(crate) struct BigQueryFdw {
     rt: Runtime,

--- a/wrappers/src/fdw/bigquery_fdw/bigquery_fdw.rs
+++ b/wrappers/src/fdw/bigquery_fdw/bigquery_fdw.rs
@@ -276,10 +276,10 @@ impl ForeignDataWrapper<BigQueryFdwError> for BigQueryFdw {
         sorts: &[Sort],
         limit: &Option<Limit>,
         options: &HashMap<String, String>,
-    ) {
+    ) -> Result<(), BigQueryFdwError> {
         let table = require_option("table", options);
         if table.is_none() {
-            return;
+            return Ok(());
         }
         self.table = table.unwrap();
         self.tgt_cols = columns.to_vec();
@@ -352,6 +352,8 @@ impl ForeignDataWrapper<BigQueryFdwError> for BigQueryFdw {
                 }
             }
         }
+
+        Ok(())
     }
 
     fn iter_scan(&mut self, row: &mut Row) -> Option<()> {

--- a/wrappers/src/fdw/bigquery_fdw/bigquery_fdw.rs
+++ b/wrappers/src/fdw/bigquery_fdw/bigquery_fdw.rs
@@ -514,7 +514,7 @@ impl ForeignDataWrapper<BigQueryFdwError> for BigQueryFdw {
         Ok(())
     }
 
-    fn delete(&mut self, rowid: &Cell) {
+    fn delete(&mut self, rowid: &Cell) -> Result<(), BigQueryFdwError> {
         if let Some(ref mut client) = self.client {
             let sql = format!(
                 "delete from `{}.{}.{}` where {} = {}",
@@ -531,6 +531,7 @@ impl ForeignDataWrapper<BigQueryFdwError> for BigQueryFdw {
                 );
             }
         }
+        Ok(())
     }
 
     fn end_modify(&mut self) {}

--- a/wrappers/src/fdw/bigquery_fdw/bigquery_fdw.rs
+++ b/wrappers/src/fdw/bigquery_fdw/bigquery_fdw.rs
@@ -478,7 +478,7 @@ impl ForeignDataWrapper<BigQueryFdwError> for BigQueryFdw {
         Ok(())
     }
 
-    fn update(&mut self, rowid: &Cell, new_row: &Row) {
+    fn update(&mut self, rowid: &Cell, new_row: &Row) -> Result<(), BigQueryFdwError> {
         if let Some(ref mut client) = self.client {
             let mut sets = Vec::new();
             for (col, cell) in new_row.iter() {
@@ -511,6 +511,7 @@ impl ForeignDataWrapper<BigQueryFdwError> for BigQueryFdw {
                 );
             }
         }
+        Ok(())
     }
 
     fn delete(&mut self, rowid: &Cell) {

--- a/wrappers/src/fdw/bigquery_fdw/bigquery_fdw.rs
+++ b/wrappers/src/fdw/bigquery_fdw/bigquery_fdw.rs
@@ -423,14 +423,16 @@ impl ForeignDataWrapper<BigQueryFdwError> for BigQueryFdw {
         Ok(())
     }
 
-    fn begin_modify(&mut self, options: &HashMap<String, String>) {
+    fn begin_modify(&mut self, options: &HashMap<String, String>) -> Result<(), BigQueryFdwError> {
         let table = require_option("table", options);
         let rowid_col = require_option("rowid_column", options);
         if table.is_none() || rowid_col.is_none() {
-            return;
+            return Ok(());
         }
         self.table = table.unwrap();
         self.rowid_col = rowid_col.unwrap();
+
+        Ok(())
     }
 
     fn insert(&mut self, src: &Row) {

--- a/wrappers/src/fdw/bigquery_fdw/bigquery_fdw.rs
+++ b/wrappers/src/fdw/bigquery_fdw/bigquery_fdw.rs
@@ -533,8 +533,6 @@ impl ForeignDataWrapper<BigQueryFdwError> for BigQueryFdw {
         }
         Ok(())
     }
-
-    fn end_modify(&mut self) {}
 }
 
 use auth_mock::GoogleAuthMock;

--- a/wrappers/src/fdw/bigquery_fdw/bigquery_fdw.rs
+++ b/wrappers/src/fdw/bigquery_fdw/bigquery_fdw.rs
@@ -356,7 +356,7 @@ impl ForeignDataWrapper<BigQueryFdwError> for BigQueryFdw {
         Ok(())
     }
 
-    fn iter_scan(&mut self, row: &mut Row) -> Option<()> {
+    fn iter_scan(&mut self, row: &mut Row) -> Result<Option<()>, BigQueryFdwError> {
         if let Some(client) = &self.client {
             if let Some(ref mut rs) = self.scan_result {
                 let mut extract_row = |rs: &mut ResultSet| {
@@ -379,7 +379,7 @@ impl ForeignDataWrapper<BigQueryFdwError> for BigQueryFdw {
                 };
 
                 if extract_row(rs) {
-                    return Some(());
+                    return Ok(Some(()));
                 }
 
                 // deal with pagination
@@ -399,7 +399,7 @@ impl ForeignDataWrapper<BigQueryFdwError> for BigQueryFdw {
                                     // replace result set with data from the new page
                                     *rs = ResultSet::new(QueryResponse::from(resp));
                                     if extract_row(rs) {
-                                        return Some(());
+                                        return Ok(Some(()));
                                     }
                                 }
                                 Err(err) => {
@@ -415,7 +415,7 @@ impl ForeignDataWrapper<BigQueryFdwError> for BigQueryFdw {
                 }
             }
         }
-        None
+        Ok(None)
     }
 
     fn end_scan(&mut self) {

--- a/wrappers/src/fdw/bigquery_fdw/bigquery_fdw.rs
+++ b/wrappers/src/fdw/bigquery_fdw/bigquery_fdw.rs
@@ -265,8 +265,8 @@ impl ForeignDataWrapper<BigQueryFdwError> for BigQueryFdw {
         _sorts: &[Sort],
         _limit: &Option<Limit>,
         _options: &HashMap<String, String>,
-    ) -> (i64, i32) {
-        (0, 0)
+    ) -> Result<(i64, i32), BigQueryFdwError> {
+        Ok((0, 0))
     }
 
     fn begin_scan(

--- a/wrappers/src/fdw/bigquery_fdw/bigquery_fdw.rs
+++ b/wrappers/src/fdw/bigquery_fdw/bigquery_fdw.rs
@@ -418,8 +418,9 @@ impl ForeignDataWrapper<BigQueryFdwError> for BigQueryFdw {
         Ok(None)
     }
 
-    fn end_scan(&mut self) {
+    fn end_scan(&mut self) -> Result<(), BigQueryFdwError> {
         self.scan_result.take();
+        Ok(())
     }
 
     fn begin_modify(&mut self, options: &HashMap<String, String>) {

--- a/wrappers/src/fdw/clickhouse_fdw/clickhouse_fdw.rs
+++ b/wrappers/src/fdw/clickhouse_fdw/clickhouse_fdw.rs
@@ -438,6 +438,4 @@ impl ForeignDataWrapper<ClickhouseFdwError> for ClickHouseFdw {
         }
         Ok(())
     }
-
-    fn end_modify(&mut self) {}
 }

--- a/wrappers/src/fdw/clickhouse_fdw/clickhouse_fdw.rs
+++ b/wrappers/src/fdw/clickhouse_fdw/clickhouse_fdw.rs
@@ -237,12 +237,12 @@ impl ForeignDataWrapper<ClickhouseFdwError> for ClickHouseFdw {
         sorts: &[Sort],
         limit: &Option<Limit>,
         options: &HashMap<String, String>,
-    ) {
+    ) -> Result<(), ClickhouseFdwError> {
         self.create_client();
 
         let table = require_option("table", options);
         if table.is_none() {
-            return;
+            return Ok(());
         }
         self.table = table.unwrap();
         self.tgt_cols = columns.to_vec();
@@ -273,6 +273,8 @@ impl ForeignDataWrapper<ClickhouseFdwError> for ClickHouseFdw {
                 ),
             }
         }
+
+        Ok(())
     }
 
     fn iter_scan(&mut self, row: &mut Row) -> Option<()> {

--- a/wrappers/src/fdw/clickhouse_fdw/clickhouse_fdw.rs
+++ b/wrappers/src/fdw/clickhouse_fdw/clickhouse_fdw.rs
@@ -331,7 +331,7 @@ impl ForeignDataWrapper<ClickhouseFdwError> for ClickHouseFdw {
         Ok(())
     }
 
-    fn insert(&mut self, src: &Row) {
+    fn insert(&mut self, src: &Row) -> Result<(), ClickhouseFdwError> {
         if let Some(ref mut client) = self.client {
             let mut row = Vec::new();
             for (col_name, cell) in src.iter() {
@@ -386,6 +386,7 @@ impl ForeignDataWrapper<ClickhouseFdwError> for ClickHouseFdw {
                 );
             }
         }
+        Ok(())
     }
 
     fn update(&mut self, rowid: &Cell, new_row: &Row) {

--- a/wrappers/src/fdw/clickhouse_fdw/clickhouse_fdw.rs
+++ b/wrappers/src/fdw/clickhouse_fdw/clickhouse_fdw.rs
@@ -310,8 +310,9 @@ impl ForeignDataWrapper<ClickhouseFdwError> for ClickHouseFdw {
         Ok(None)
     }
 
-    fn end_scan(&mut self) {
+    fn end_scan(&mut self) -> Result<(), ClickhouseFdwError> {
         self.scan_blk.take();
+        Ok(())
     }
 
     fn begin_modify(&mut self, options: &HashMap<String, String>) {

--- a/wrappers/src/fdw/clickhouse_fdw/clickhouse_fdw.rs
+++ b/wrappers/src/fdw/clickhouse_fdw/clickhouse_fdw.rs
@@ -277,7 +277,7 @@ impl ForeignDataWrapper<ClickhouseFdwError> for ClickHouseFdw {
         Ok(())
     }
 
-    fn iter_scan(&mut self, row: &mut Row) -> Option<()> {
+    fn iter_scan(&mut self, row: &mut Row) -> Result<Option<()>, ClickhouseFdwError> {
         if let Some(block) = &self.scan_blk {
             let mut rows = block.rows();
 
@@ -298,14 +298,16 @@ impl ForeignDataWrapper<ClickhouseFdwError> for ClickHouseFdw {
                         .unwrap();
                     let cell = field_to_cell(&src_row, i);
                     let col_name = src_row.name(i).unwrap();
-                    cell.as_ref()?;
+                    if cell.as_ref().is_none() {
+                        return Ok(None);
+                    }
                     row.push(col_name, cell);
                 }
                 self.row_idx += 1;
-                return Some(());
+                return Ok(Some(()));
             }
         }
-        None
+        Ok(None)
     }
 
     fn end_scan(&mut self) {

--- a/wrappers/src/fdw/clickhouse_fdw/clickhouse_fdw.rs
+++ b/wrappers/src/fdw/clickhouse_fdw/clickhouse_fdw.rs
@@ -421,7 +421,7 @@ impl ForeignDataWrapper<ClickhouseFdwError> for ClickHouseFdw {
         Ok(())
     }
 
-    fn delete(&mut self, rowid: &Cell) {
+    fn delete(&mut self, rowid: &Cell) -> Result<(), ClickhouseFdwError> {
         if let Some(ref mut client) = self.client {
             let sql = format!(
                 "alter table {} delete where {} = {}",
@@ -436,6 +436,7 @@ impl ForeignDataWrapper<ClickhouseFdwError> for ClickHouseFdw {
                 );
             }
         }
+        Ok(())
     }
 
     fn end_modify(&mut self) {}

--- a/wrappers/src/fdw/clickhouse_fdw/clickhouse_fdw.rs
+++ b/wrappers/src/fdw/clickhouse_fdw/clickhouse_fdw.rs
@@ -78,7 +78,8 @@ fn field_to_cell(row: &types::Row<types::Complex>, i: usize) -> Option<Cell> {
 #[wrappers_fdw(
     version = "0.1.3",
     author = "Supabase",
-    website = "https://github.com/supabase/wrappers/tree/main/wrappers/src/fdw/clickhouse_fdw"
+    website = "https://github.com/supabase/wrappers/tree/main/wrappers/src/fdw/clickhouse_fdw",
+    error_type = "ClickHouseFdwError"
 )]
 pub(crate) struct ClickHouseFdw {
     rt: Runtime,
@@ -197,16 +198,16 @@ impl ClickHouseFdw {
     }
 }
 
-enum ClickhouseFdwError {}
+enum ClickHouseFdwError {}
 
-impl From<ClickhouseFdwError> for ErrorReport {
-    fn from(_value: ClickhouseFdwError) -> Self {
+impl From<ClickHouseFdwError> for ErrorReport {
+    fn from(_value: ClickHouseFdwError) -> Self {
         ErrorReport::new(PgSqlErrorCode::ERRCODE_FDW_ERROR, "", "")
     }
 }
 
-impl ForeignDataWrapper<ClickhouseFdwError> for ClickHouseFdw {
-    fn new(options: &HashMap<String, String>) -> Result<Self, ClickhouseFdwError> {
+impl ForeignDataWrapper<ClickHouseFdwError> for ClickHouseFdw {
+    fn new(options: &HashMap<String, String>) -> Result<Self, ClickHouseFdwError> {
         let rt = create_async_runtime();
         let conn_str = match options.get("conn_string") {
             Some(conn_str) => conn_str.to_owned(),
@@ -237,7 +238,7 @@ impl ForeignDataWrapper<ClickhouseFdwError> for ClickHouseFdw {
         sorts: &[Sort],
         limit: &Option<Limit>,
         options: &HashMap<String, String>,
-    ) -> Result<(), ClickhouseFdwError> {
+    ) -> Result<(), ClickHouseFdwError> {
         self.create_client();
 
         let table = require_option("table", options);
@@ -277,7 +278,7 @@ impl ForeignDataWrapper<ClickhouseFdwError> for ClickHouseFdw {
         Ok(())
     }
 
-    fn iter_scan(&mut self, row: &mut Row) -> Result<Option<()>, ClickhouseFdwError> {
+    fn iter_scan(&mut self, row: &mut Row) -> Result<Option<()>, ClickHouseFdwError> {
         if let Some(block) = &self.scan_blk {
             let mut rows = block.rows();
 
@@ -310,7 +311,7 @@ impl ForeignDataWrapper<ClickhouseFdwError> for ClickHouseFdw {
         Ok(None)
     }
 
-    fn end_scan(&mut self) -> Result<(), ClickhouseFdwError> {
+    fn end_scan(&mut self) -> Result<(), ClickHouseFdwError> {
         self.scan_blk.take();
         Ok(())
     }
@@ -318,7 +319,7 @@ impl ForeignDataWrapper<ClickhouseFdwError> for ClickHouseFdw {
     fn begin_modify(
         &mut self,
         options: &HashMap<String, String>,
-    ) -> Result<(), ClickhouseFdwError> {
+    ) -> Result<(), ClickHouseFdwError> {
         self.create_client();
 
         let table = require_option("table", options);
@@ -331,7 +332,7 @@ impl ForeignDataWrapper<ClickhouseFdwError> for ClickHouseFdw {
         Ok(())
     }
 
-    fn insert(&mut self, src: &Row) -> Result<(), ClickhouseFdwError> {
+    fn insert(&mut self, src: &Row) -> Result<(), ClickHouseFdwError> {
         if let Some(ref mut client) = self.client {
             let mut row = Vec::new();
             for (col_name, cell) in src.iter() {
@@ -389,7 +390,7 @@ impl ForeignDataWrapper<ClickhouseFdwError> for ClickHouseFdw {
         Ok(())
     }
 
-    fn update(&mut self, rowid: &Cell, new_row: &Row) -> Result<(), ClickhouseFdwError> {
+    fn update(&mut self, rowid: &Cell, new_row: &Row) -> Result<(), ClickHouseFdwError> {
         if let Some(ref mut client) = self.client {
             let mut sets = Vec::new();
             for (col, cell) in new_row.iter() {
@@ -421,7 +422,7 @@ impl ForeignDataWrapper<ClickhouseFdwError> for ClickHouseFdw {
         Ok(())
     }
 
-    fn delete(&mut self, rowid: &Cell) -> Result<(), ClickhouseFdwError> {
+    fn delete(&mut self, rowid: &Cell) -> Result<(), ClickHouseFdwError> {
         if let Some(ref mut client) = self.client {
             let sql = format!(
                 "alter table {} delete where {} = {}",

--- a/wrappers/src/fdw/clickhouse_fdw/clickhouse_fdw.rs
+++ b/wrappers/src/fdw/clickhouse_fdw/clickhouse_fdw.rs
@@ -389,7 +389,7 @@ impl ForeignDataWrapper<ClickhouseFdwError> for ClickHouseFdw {
         Ok(())
     }
 
-    fn update(&mut self, rowid: &Cell, new_row: &Row) {
+    fn update(&mut self, rowid: &Cell, new_row: &Row) -> Result<(), ClickhouseFdwError> {
         if let Some(ref mut client) = self.client {
             let mut sets = Vec::new();
             for (col, cell) in new_row.iter() {
@@ -418,6 +418,7 @@ impl ForeignDataWrapper<ClickhouseFdwError> for ClickHouseFdw {
                 );
             }
         }
+        Ok(())
     }
 
     fn delete(&mut self, rowid: &Cell) {

--- a/wrappers/src/fdw/clickhouse_fdw/clickhouse_fdw.rs
+++ b/wrappers/src/fdw/clickhouse_fdw/clickhouse_fdw.rs
@@ -315,16 +315,20 @@ impl ForeignDataWrapper<ClickhouseFdwError> for ClickHouseFdw {
         Ok(())
     }
 
-    fn begin_modify(&mut self, options: &HashMap<String, String>) {
+    fn begin_modify(
+        &mut self,
+        options: &HashMap<String, String>,
+    ) -> Result<(), ClickhouseFdwError> {
         self.create_client();
 
         let table = require_option("table", options);
         let rowid_col = require_option("rowid_column", options);
         if table.is_none() || rowid_col.is_none() {
-            return;
+            return Ok(());
         }
         self.table = table.unwrap();
         self.rowid_col = rowid_col.unwrap();
+        Ok(())
     }
 
     fn insert(&mut self, src: &Row) {

--- a/wrappers/src/fdw/firebase_fdw/firebase_fdw.rs
+++ b/wrappers/src/fdw/firebase_fdw/firebase_fdw.rs
@@ -168,7 +168,8 @@ fn resp_to_rows(obj: &str, resp: &JsonValue, tgt_cols: &[Column]) -> Vec<Row> {
 #[wrappers_fdw(
     version = "0.1.2",
     author = "Supabase",
-    website = "https://github.com/supabase/wrappers/tree/main/wrappers/src/fdw/firebase_fdw"
+    website = "https://github.com/supabase/wrappers/tree/main/wrappers/src/fdw/firebase_fdw",
+    error_type = "FirebaseFdwError"
 )]
 pub(crate) struct FirebaseFdw {
     rt: Runtime,
@@ -404,11 +405,16 @@ impl ForeignDataWrapper<FirebaseFdwError> for FirebaseFdw {
         Ok(())
     }
 
-    fn validator(options: Vec<Option<String>>, catalog: Option<pg_sys::Oid>) {
+    fn validator(
+        options: Vec<Option<String>>,
+        catalog: Option<pg_sys::Oid>,
+    ) -> Result<(), FirebaseFdwError> {
         if let Some(oid) = catalog {
             if oid == FOREIGN_TABLE_RELATION_ID {
                 check_options_contain(&options, "object");
             }
         }
+
+        Ok(())
     }
 }

--- a/wrappers/src/fdw/firebase_fdw/firebase_fdw.rs
+++ b/wrappers/src/fdw/firebase_fdw/firebase_fdw.rs
@@ -321,10 +321,10 @@ impl ForeignDataWrapper<FirebaseFdwError> for FirebaseFdw {
         _sorts: &[Sort],
         _limit: &Option<Limit>,
         options: &HashMap<String, String>,
-    ) {
+    ) -> Result<(), FirebaseFdwError> {
         let obj = match require_option("object", options) {
             Some(obj) => obj,
-            None => return,
+            None => return Ok(()),
         };
         let row_cnt_limit = options
             .get("limit")
@@ -383,6 +383,8 @@ impl ForeignDataWrapper<FirebaseFdwError> for FirebaseFdw {
 
             self.scan_result = Some(result);
         }
+
+        Ok(())
     }
 
     fn iter_scan(&mut self, row: &mut Row) -> Option<()> {

--- a/wrappers/src/fdw/firebase_fdw/firebase_fdw.rs
+++ b/wrappers/src/fdw/firebase_fdw/firebase_fdw.rs
@@ -399,8 +399,9 @@ impl ForeignDataWrapper<FirebaseFdwError> for FirebaseFdw {
         Ok(None)
     }
 
-    fn end_scan(&mut self) {
+    fn end_scan(&mut self) -> Result<(), FirebaseFdwError> {
         self.scan_result.take();
+        Ok(())
     }
 
     fn validator(options: Vec<Option<String>>, catalog: Option<pg_sys::Oid>) {

--- a/wrappers/src/fdw/firebase_fdw/firebase_fdw.rs
+++ b/wrappers/src/fdw/firebase_fdw/firebase_fdw.rs
@@ -387,16 +387,16 @@ impl ForeignDataWrapper<FirebaseFdwError> for FirebaseFdw {
         Ok(())
     }
 
-    fn iter_scan(&mut self, row: &mut Row) -> Option<()> {
+    fn iter_scan(&mut self, row: &mut Row) -> Result<Option<()>, FirebaseFdwError> {
         if let Some(ref mut result) = self.scan_result {
             if !result.is_empty() {
-                return result
+                return Ok(result
                     .drain(0..1)
                     .last()
-                    .map(|src_row| row.replace_with(src_row));
+                    .map(|src_row| row.replace_with(src_row)));
             }
         }
-        None
+        Ok(None)
     }
 
     fn end_scan(&mut self) {

--- a/wrappers/src/fdw/helloworld_fdw/helloworld_fdw.rs
+++ b/wrappers/src/fdw/helloworld_fdw/helloworld_fdw.rs
@@ -53,12 +53,14 @@ impl ForeignDataWrapper<HelloWorldFdwError> for HelloWorldFdw {
         _sorts: &[Sort],
         _limit: &Option<Limit>,
         _options: &HashMap<String, String>,
-    ) {
+    ) -> Result<(), HelloWorldFdwError> {
         // reset row counter
         self.row_cnt = 0;
 
         // save a copy of target columns
         self.tgt_cols = columns.to_vec();
+
+        Ok(())
     }
 
     fn iter_scan(&mut self, row: &mut Row) -> Option<()> {

--- a/wrappers/src/fdw/helloworld_fdw/helloworld_fdw.rs
+++ b/wrappers/src/fdw/helloworld_fdw/helloworld_fdw.rs
@@ -85,7 +85,8 @@ impl ForeignDataWrapper<HelloWorldFdwError> for HelloWorldFdw {
         Ok(None)
     }
 
-    fn end_scan(&mut self) {
+    fn end_scan(&mut self) -> Result<(), HelloWorldFdwError> {
         // we do nothing here, but you can do things like resource cleanup and etc.
+        Ok(())
     }
 }

--- a/wrappers/src/fdw/helloworld_fdw/helloworld_fdw.rs
+++ b/wrappers/src/fdw/helloworld_fdw/helloworld_fdw.rs
@@ -63,7 +63,7 @@ impl ForeignDataWrapper<HelloWorldFdwError> for HelloWorldFdw {
         Ok(())
     }
 
-    fn iter_scan(&mut self, row: &mut Row) -> Option<()> {
+    fn iter_scan(&mut self, row: &mut Row) -> Result<Option<()>, HelloWorldFdwError> {
         // this is called on each row and we only return one row here
         if self.row_cnt < 1 {
             // add values to row if they are in target column list
@@ -78,11 +78,11 @@ impl ForeignDataWrapper<HelloWorldFdwError> for HelloWorldFdw {
             self.row_cnt += 1;
 
             // return Some(()) to Postgres and continue data scan
-            return Some(());
+            return Ok(Some(()));
         }
 
         // return 'None' to stop data scan
-        None
+        Ok(None)
     }
 
     fn end_scan(&mut self) {

--- a/wrappers/src/fdw/helloworld_fdw/helloworld_fdw.rs
+++ b/wrappers/src/fdw/helloworld_fdw/helloworld_fdw.rs
@@ -7,7 +7,8 @@ use supabase_wrappers::prelude::*;
 #[wrappers_fdw(
     version = "0.1.0",
     author = "Supabase",
-    website = "https://github.com/supabase/wrappers/tree/main/wrappers/src/fdw/helloworld_fdw"
+    website = "https://github.com/supabase/wrappers/tree/main/wrappers/src/fdw/helloworld_fdw",
+    error_type = "HelloWorldFdwError"
 )]
 pub(crate) struct HelloWorldFdw {
     // row counter

--- a/wrappers/src/fdw/logflare_fdw/logflare_fdw.rs
+++ b/wrappers/src/fdw/logflare_fdw/logflare_fdw.rs
@@ -337,8 +337,9 @@ impl ForeignDataWrapper<LogflareFdwError> for LogflareFdw {
         Ok(None)
     }
 
-    fn end_scan(&mut self) {
+    fn end_scan(&mut self) -> Result<(), LogflareFdwError> {
         self.scan_result.take();
+        Ok(())
     }
 
     fn validator(options: Vec<Option<String>>, catalog: Option<pg_sys::Oid>) {

--- a/wrappers/src/fdw/logflare_fdw/logflare_fdw.rs
+++ b/wrappers/src/fdw/logflare_fdw/logflare_fdw.rs
@@ -125,7 +125,8 @@ fn json_value_to_cell(tgt_col: &Column, v: &JsonValue) -> Cell {
 #[wrappers_fdw(
     version = "0.1.0",
     author = "Supabase",
-    website = "https://github.com/supabase/wrappers/tree/main/wrappers/src/fdw/logflare_fdw"
+    website = "https://github.com/supabase/wrappers/tree/main/wrappers/src/fdw/logflare_fdw",
+    error_type = "LogflareFdwError"
 )]
 pub(crate) struct LogflareFdw {
     rt: Runtime,
@@ -342,11 +343,16 @@ impl ForeignDataWrapper<LogflareFdwError> for LogflareFdw {
         Ok(())
     }
 
-    fn validator(options: Vec<Option<String>>, catalog: Option<pg_sys::Oid>) {
+    fn validator(
+        options: Vec<Option<String>>,
+        catalog: Option<pg_sys::Oid>,
+    ) -> Result<(), LogflareFdwError> {
         if let Some(oid) = catalog {
             if oid == FOREIGN_TABLE_RELATION_ID {
                 check_options_contain(&options, "endpoint");
             }
         }
+
+        Ok(())
     }
 }

--- a/wrappers/src/fdw/logflare_fdw/logflare_fdw.rs
+++ b/wrappers/src/fdw/logflare_fdw/logflare_fdw.rs
@@ -325,16 +325,16 @@ impl ForeignDataWrapper<LogflareFdwError> for LogflareFdw {
         Ok(())
     }
 
-    fn iter_scan(&mut self, row: &mut Row) -> Option<()> {
+    fn iter_scan(&mut self, row: &mut Row) -> Result<Option<()>, LogflareFdwError> {
         if let Some(ref mut result) = self.scan_result {
             if !result.is_empty() {
-                return result
+                return Ok(result
                     .drain(0..1)
                     .last()
-                    .map(|src_row| row.replace_with(src_row));
+                    .map(|src_row| row.replace_with(src_row)));
             }
         }
-        None
+        Ok(None)
     }
 
     fn end_scan(&mut self) {

--- a/wrappers/src/fdw/s3_fdw/s3_fdw.rs
+++ b/wrappers/src/fdw/s3_fdw/s3_fdw.rs
@@ -26,7 +26,8 @@ enum Parser {
 #[wrappers_fdw(
     version = "0.1.2",
     author = "Supabase",
-    website = "https://github.com/supabase/wrappers/tree/main/wrappers/src/fdw/s3_fdw"
+    website = "https://github.com/supabase/wrappers/tree/main/wrappers/src/fdw/s3_fdw",
+    error_type = "S3FdwError"
 )]
 pub(crate) struct S3Fdw {
     rt: Runtime,
@@ -456,12 +457,17 @@ impl ForeignDataWrapper<S3FdwError> for S3Fdw {
         Ok(())
     }
 
-    fn validator(options: Vec<Option<String>>, catalog: Option<pg_sys::Oid>) {
+    fn validator(
+        options: Vec<Option<String>>,
+        catalog: Option<pg_sys::Oid>,
+    ) -> Result<(), S3FdwError> {
         if let Some(oid) = catalog {
             if oid == FOREIGN_TABLE_RELATION_ID {
                 check_options_contain(&options, "uri");
                 check_options_contain(&options, "format");
             }
         }
+
+        Ok(())
     }
 }

--- a/wrappers/src/fdw/s3_fdw/s3_fdw.rs
+++ b/wrappers/src/fdw/s3_fdw/s3_fdw.rs
@@ -449,10 +449,11 @@ impl ForeignDataWrapper<S3FdwError> for S3Fdw {
         Ok(None)
     }
 
-    fn end_scan(&mut self) {
+    fn end_scan(&mut self) -> Result<(), S3FdwError> {
         // release local resources
         self.rdr.take();
         self.parser = Parser::JsonLine(VecDeque::new());
+        Ok(())
     }
 
     fn validator(options: Vec<Option<String>>, catalog: Option<pg_sys::Oid>) {

--- a/wrappers/src/fdw/stripe_fdw/stripe_fdw.rs
+++ b/wrappers/src/fdw/stripe_fdw/stripe_fdw.rs
@@ -783,9 +783,10 @@ impl ForeignDataWrapper<StripeFdwError> for StripeFdw {
         Ok(())
     }
 
-    fn begin_modify(&mut self, options: &HashMap<String, String>) {
+    fn begin_modify(&mut self, options: &HashMap<String, String>) -> Result<(), StripeFdwError> {
         self.obj = require_option("object", options).unwrap_or_default();
         self.rowid_col = require_option("rowid_column", options).unwrap_or_default();
+        Ok(())
     }
 
     fn insert(&mut self, src: &Row) {

--- a/wrappers/src/fdw/stripe_fdw/stripe_fdw.rs
+++ b/wrappers/src/fdw/stripe_fdw/stripe_fdw.rs
@@ -883,7 +883,7 @@ impl ForeignDataWrapper<StripeFdwError> for StripeFdw {
         Ok(())
     }
 
-    fn delete(&mut self, rowid: &Cell) {
+    fn delete(&mut self, rowid: &Cell) -> Result<(), StripeFdwError> {
         if let Some(ref mut client) = self.client {
             let mut stats_metadata = get_stats_metadata();
 
@@ -914,12 +914,12 @@ impl ForeignDataWrapper<StripeFdwError> for StripeFdw {
                             }
                             Err(err) => {
                                 report_request_error!(err);
-                                return;
+                                return Ok(());
                             }
                         },
                         Err(err) => {
                             report_request_error!(err);
-                            return;
+                            return Ok(());
                         }
                     }
                 }
@@ -928,6 +928,7 @@ impl ForeignDataWrapper<StripeFdwError> for StripeFdw {
 
             set_stats_metadata(stats_metadata);
         }
+        Ok(())
     }
 
     fn end_modify(&mut self) {}

--- a/wrappers/src/fdw/stripe_fdw/stripe_fdw.rs
+++ b/wrappers/src/fdw/stripe_fdw/stripe_fdw.rs
@@ -789,12 +789,12 @@ impl ForeignDataWrapper<StripeFdwError> for StripeFdw {
         Ok(())
     }
 
-    fn insert(&mut self, src: &Row) {
+    fn insert(&mut self, src: &Row) -> Result<(), StripeFdwError> {
         if let Some(ref mut client) = self.client {
             let url = self.base_url.join(&self.obj).unwrap();
             let body = row_to_body(src);
             if body.is_null() {
-                return;
+                return Ok(());
             }
 
             let mut stats_metadata = get_stats_metadata();
@@ -817,17 +817,18 @@ impl ForeignDataWrapper<StripeFdwError> for StripeFdw {
                     }
                     Err(err) => {
                         report_request_error!(err);
-                        return;
+                        return Ok(());
                     }
                 },
                 Err(err) => {
                     report_request_error!(err);
-                    return;
+                    return Ok(());
                 }
             }
 
             set_stats_metadata(stats_metadata);
         }
+        Ok(())
     }
 
     fn update(&mut self, rowid: &Cell, new_row: &Row) {

--- a/wrappers/src/fdw/stripe_fdw/stripe_fdw.rs
+++ b/wrappers/src/fdw/stripe_fdw/stripe_fdw.rs
@@ -831,7 +831,7 @@ impl ForeignDataWrapper<StripeFdwError> for StripeFdw {
         Ok(())
     }
 
-    fn update(&mut self, rowid: &Cell, new_row: &Row) {
+    fn update(&mut self, rowid: &Cell, new_row: &Row) -> Result<(), StripeFdwError> {
         if let Some(ref mut client) = self.client {
             let mut stats_metadata = get_stats_metadata();
 
@@ -845,7 +845,7 @@ impl ForeignDataWrapper<StripeFdwError> for StripeFdw {
                         .unwrap();
                     let body = row_to_body(new_row);
                     if body.is_null() {
-                        return;
+                        return Ok(());
                     }
 
                     // call Stripe API
@@ -866,12 +866,12 @@ impl ForeignDataWrapper<StripeFdwError> for StripeFdw {
                             }
                             Err(err) => {
                                 report_request_error!(err);
-                                return;
+                                return Ok(());
                             }
                         },
                         Err(err) => {
                             report_request_error!(err);
-                            return;
+                            return Ok(());
                         }
                     }
                 }
@@ -880,6 +880,7 @@ impl ForeignDataWrapper<StripeFdwError> for StripeFdw {
 
             set_stats_metadata(stats_metadata);
         }
+        Ok(())
     }
 
     fn delete(&mut self, rowid: &Cell) {

--- a/wrappers/src/fdw/stripe_fdw/stripe_fdw.rs
+++ b/wrappers/src/fdw/stripe_fdw/stripe_fdw.rs
@@ -778,8 +778,9 @@ impl ForeignDataWrapper<StripeFdwError> for StripeFdw {
         Ok(None)
     }
 
-    fn end_scan(&mut self) {
+    fn end_scan(&mut self) -> Result<(), StripeFdwError> {
         self.scan_result.take();
+        Ok(())
     }
 
     fn begin_modify(&mut self, options: &HashMap<String, String>) {

--- a/wrappers/src/fdw/stripe_fdw/stripe_fdw.rs
+++ b/wrappers/src/fdw/stripe_fdw/stripe_fdw.rs
@@ -255,7 +255,8 @@ macro_rules! report_request_error {
 #[wrappers_fdw(
     version = "0.1.7",
     author = "Supabase",
-    website = "https://github.com/supabase/wrappers/tree/main/wrappers/src/fdw/stripe_fdw"
+    website = "https://github.com/supabase/wrappers/tree/main/wrappers/src/fdw/stripe_fdw",
+    error_type = "StripeFdwError"
 )]
 pub(crate) struct StripeFdw {
     rt: Runtime,
@@ -931,11 +932,16 @@ impl ForeignDataWrapper<StripeFdwError> for StripeFdw {
         Ok(())
     }
 
-    fn validator(options: Vec<Option<String>>, catalog: Option<pg_sys::Oid>) {
+    fn validator(
+        options: Vec<Option<String>>,
+        catalog: Option<pg_sys::Oid>,
+    ) -> Result<(), StripeFdwError> {
         if let Some(oid) = catalog {
             if oid == FOREIGN_TABLE_RELATION_ID {
                 check_options_contain(&options, "object");
             }
         }
+
+        Ok(())
     }
 }

--- a/wrappers/src/fdw/stripe_fdw/stripe_fdw.rs
+++ b/wrappers/src/fdw/stripe_fdw/stripe_fdw.rs
@@ -931,8 +931,6 @@ impl ForeignDataWrapper<StripeFdwError> for StripeFdw {
         Ok(())
     }
 
-    fn end_modify(&mut self) {}
-
     fn validator(options: Vec<Option<String>>, catalog: Option<pg_sys::Oid>) {
         if let Some(oid) = catalog {
             if oid == FOREIGN_TABLE_RELATION_ID {

--- a/wrappers/src/fdw/stripe_fdw/stripe_fdw.rs
+++ b/wrappers/src/fdw/stripe_fdw/stripe_fdw.rs
@@ -766,16 +766,16 @@ impl ForeignDataWrapper<StripeFdwError> for StripeFdw {
         Ok(())
     }
 
-    fn iter_scan(&mut self, row: &mut Row) -> Option<()> {
+    fn iter_scan(&mut self, row: &mut Row) -> Result<Option<()>, StripeFdwError> {
         if let Some(ref mut result) = self.scan_result {
             if !result.is_empty() {
-                return result
+                return Ok(result
                     .drain(0..1)
                     .last()
-                    .map(|src_row| row.replace_with(src_row));
+                    .map(|src_row| row.replace_with(src_row)));
             }
         }
-        None
+        Ok(None)
     }
 
     fn end_scan(&mut self) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Refactoring

## What is the current behavior?

The `ForeignDataWrapper` trait's methods do not return `Result`s even though they are fallible. This results in forcing the user to call `unwrap` or `expect`, instead of the more ergonomic alternative of returning an `Err`.

## What is the new behavior?

The `ForeignDataWrapper` trait's methods will now return a `Result`. The error types should be convertible into an `ErrorReport`, i.e. they should `impl From<ErrorType> for ErrorReport` for the FDW's `ErrorType`. An `ErrorReport` is a `pgrx` type to represent errors which can be reported to Postgres. The errors returned by the trait's methods will be automatically reported to Postgres by the `supabase-wrappers` framework.

An example FDW with the new API looks something like this:

```rust
/// The error type has to be specified in the `error_type` field of the proc macro
#[wrappers_fdw(
    version = "0.1.0",
    author = "Supabase",
    website = "https://github.com/supabase/wrappers/tree/main/wrappers/src/fdw/helloworld_fdw",
    error_type = "HelloWorldFdwError"
)]
pub(crate) struct HelloWorldFdw {}

/// A type representing the errors returned from the ForeignDataWrapper trait's methods
enum HelloWorldFdwError {
    InvalidFoo,
    MissingBar,
}

/// A required impl for the error type to convert into ErrorReport
impl From<HelloWorldFdwError> for ErrorReport {
    fn from(value: HelloWorldFdwError) -> Self {
        let error_message = match value {
            HelloWorldFdwError::InvalidFoo => "foo is invalid",
            HelloWorldFdwError::MissingBar => "bar is missing",
        };
        // The error code and error message to return to Postgres
        ErrorReport::new(PgSqlErrorCode::ERRCODE_FDW_ERROR, error_message, "")
    }
}

impl ForeignDataWrapper<HelloWorldFdwError> for HelloWorldFdwError {
    fn new(options: &HashMap<String, String>) -> Result<Self, HelloWorldFdwError>
    where
        Self: Sized,
    {
        // Return errors from your methods, these will be automatically reported by `supabase-wrappers`
        Err(HelloWorldFdwError::InvalidFoo)
    }

    fn begin_scan(
        &mut self,
        _quals: &[Qual],
        _columns: &[Column],
        _sorts: &[Sort],
        _limit: &Option<Limit>,
        _options: &HashMap<String, String>,
    ) -> Result<(), HelloWorldFdwError> {
        // Return another error
        Err(HelloWorldFdwError::MissingBar)
    }

    fn iter_scan(&mut self, row: &mut Row) -> Result<Option<()>, HelloWorldFdwError> {
        // Return ok if no error
        Ok(None)
    }

    fn end_scan(&mut self) -> Result<(), HelloWorldFdwError> {
        // Return ok if no error
        Ok(())
    }
}

```

## Additional context

This impl is similar to but not exactly the same as suggested in https://github.com/supabase/wrappers/issues/81. The major difference is the there is no `WrappersError` but instead each FDW can define it's own error type. A type similar to `WrappersError` can be introduced later if needed.

This PR just lays the groundwork for all FDWs to better report and handle errors. But the FDWs haven't been updated with this PR. They will be done in separate, later PRs.
