### PR TITLE
fix: remove unwrap in `create_async_runtime`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,7 @@ checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -82,7 +82,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.16",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -207,7 +207,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -360,7 +360,7 @@ checksum = "ccb14d927583dd5c2eac0f2cf264fc4762aefe1ae14c47a8a20fc1939d3a5fc0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -430,7 +430,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -1221,7 +1221,7 @@ checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -1346,6 +1346,7 @@ dependencies = [
  "pgrx",
  "pgrx-tests",
  "supabase-wrappers-macros",
+ "thiserror",
  "tokio",
  "uuid",
 ]
@@ -1372,9 +1373,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.16"
+version = "2.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6f671d4b5ffdb8eadec19c0ae67fe2639df8684bd7bc4b83d986b8db549cf01"
+checksum = "239814284fd6f1a4ffe4ca893952cdd93c224b6a1571c9a9eadd670295c0c9e2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1404,22 +1405,22 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "thiserror"
-version = "1.0.40"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+checksum = "9d6d7a740b8a666a7e828dd00da9c0dc290dff53154ea77ac109281de90589b7"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.40"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+checksum = "49922ecae66cc8a249b77e68d1d0623c1b2c514f0060c27cdc68bd62a1219d35"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.32",
 ]
 
 [[package]]

--- a/supabase-wrappers/Cargo.toml
+++ b/supabase-wrappers/Cargo.toml
@@ -22,6 +22,7 @@ pg_test = []
 
 [dependencies]
 pgrx = {version = "=0.9.8", default-features = false }
+thiserror = "1.0.48"
 tokio = { version = "1.24", features = ["rt"] }
 uuid = { version = "1.2.2" }
 supabase-wrappers-macros = { version = "0.1", path = "../supabase-wrappers-macros" }

--- a/supabase-wrappers/src/utils.rs
+++ b/supabase-wrappers/src/utils.rs
@@ -130,6 +130,8 @@ impl From<CreateRuntimeError> for ErrorReport {
 /// For example,
 ///
 /// ```rust,no_run
+/// # use supabase_wrappers::utils::CreateRuntimeError;
+/// # fn main() -> Result<(), CreateRuntimeError> {
 /// # use supabase_wrappers::prelude::create_async_runtime;
 /// # struct Client {
 /// # }
@@ -138,13 +140,15 @@ impl From<CreateRuntimeError> for ErrorReport {
 /// # }
 /// # let client = Client {};
 /// # let sql = "";
-/// let rt = create_async_runtime();
+/// let rt = create_async_runtime()?;
 ///
 /// // client.query() is an async function returning a Result
 /// match rt.block_on(client.query(&sql)) {
 ///     Ok(result) => { }
 ///     Err(err) => { }
 /// }
+/// # Ok(())
+/// # }
 /// ```
 #[inline]
 pub fn create_async_runtime() -> Result<Runtime, CreateRuntimeError> {

--- a/supabase-wrappers/src/utils.rs
+++ b/supabase-wrappers/src/utils.rs
@@ -2,6 +2,7 @@
 //!
 
 use crate::interface::{Cell, Column, Row};
+use pgrx::pg_sys::panic::ErrorReport;
 use pgrx::prelude::PgBuiltInOids;
 use pgrx::spi::Spi;
 use pgrx::IntoDatum;
@@ -10,6 +11,7 @@ use std::collections::HashMap;
 use std::ffi::CStr;
 use std::num::NonZeroUsize;
 use std::ptr;
+use thiserror::Error;
 use tokio::runtime::{Builder, Runtime};
 use uuid::Uuid;
 
@@ -106,6 +108,19 @@ pub fn report_error(code: PgSqlErrorCode, msg: &str) {
     ereport!(PgLogLevel::ERROR, code, msg, "Wrappers");
 }
 
+#[derive(Error, Debug)]
+pub enum CreateRuntimeError {
+    #[error("failed to create async runtime")]
+    FailedToCreateAsyncRuntime,
+}
+
+impl From<CreateRuntimeError> for ErrorReport {
+    fn from(value: CreateRuntimeError) -> Self {
+        let error_message = format!("{value}");
+        ErrorReport::new(PgSqlErrorCode::ERRCODE_FDW_ERROR, error_message, "")
+    }
+}
+
 /// Create a Tokio async runtime
 ///
 /// Use this runtime to run async code in `block` mode. Run blocked code is
@@ -132,8 +147,11 @@ pub fn report_error(code: PgSqlErrorCode, msg: &str) {
 /// }
 /// ```
 #[inline]
-pub fn create_async_runtime() -> Runtime {
-    Builder::new_current_thread().enable_all().build().unwrap()
+pub fn create_async_runtime() -> Result<Runtime, CreateRuntimeError> {
+    Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|_| CreateRuntimeError::FailedToCreateAsyncRuntime)
 }
 
 /// Get required option value from the `options` map

--- a/supabase-wrappers/src/utils.rs
+++ b/supabase-wrappers/src/utils.rs
@@ -110,8 +110,8 @@ pub fn report_error(code: PgSqlErrorCode, msg: &str) {
 
 #[derive(Error, Debug)]
 pub enum CreateRuntimeError {
-    #[error("failed to create async runtime")]
-    FailedToCreateAsyncRuntime,
+    #[error("failed to create async runtime: {0}")]
+    FailedToCreateAsyncRuntime(#[from] std::io::Error),
 }
 
 impl From<CreateRuntimeError> for ErrorReport {
@@ -148,10 +148,7 @@ impl From<CreateRuntimeError> for ErrorReport {
 /// ```
 #[inline]
 pub fn create_async_runtime() -> Result<Runtime, CreateRuntimeError> {
-    Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .map_err(|_| CreateRuntimeError::FailedToCreateAsyncRuntime)
+    Ok(Builder::new_current_thread().enable_all().build()?)
 }
 
 /// Get required option value from the `options` map

--- a/wrappers/Cargo.lock
+++ b/wrappers/Cargo.lock
@@ -3450,6 +3450,7 @@ version = "0.1.15"
 dependencies = [
  "pgrx",
  "supabase-wrappers-macros",
+ "thiserror",
  "tokio",
  "uuid 1.4.1",
 ]
@@ -3530,18 +3531,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.47"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a802ec30afc17eee47b2855fc72e0c4cd62be9b4efe6591edde0ec5bd68d8f"
+checksum = "9d6d7a740b8a666a7e828dd00da9c0dc290dff53154ea77ac109281de90589b7"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.47"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bb623b56e39ab7dcd4b1b98bb6c8f8d907ed255b18de254088016b27a8ee19b"
+checksum = "49922ecae66cc8a249b77e68d1d0623c1b2c514f0060c27cdc68bd62a1219d35"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4259,6 +4260,7 @@ dependencies = [
  "serde",
  "serde_json",
  "supabase-wrappers",
+ "thiserror",
  "tokio",
  "tokio-util",
  "url",

--- a/wrappers/Cargo.toml
+++ b/wrappers/Cargo.toml
@@ -17,17 +17,17 @@ pg15 = ["pgrx/pg15", "pgrx-tests/pg15", "supabase-wrappers/pg15" ]
 pg_test = []
 
 helloworld_fdw = []
-bigquery_fdw = ["gcp-bigquery-client", "serde_json", "serde", "wiremock", "futures", "yup-oauth2"]
-clickhouse_fdw = ["clickhouse-rs", "chrono", "chrono-tz", "regex"]
-stripe_fdw = ["reqwest", "reqwest-middleware", "reqwest-retry", "serde_json"]
-firebase_fdw = ["reqwest", "reqwest-middleware", "reqwest-retry", "serde_json", "yup-oauth2", "regex"]
+bigquery_fdw = ["gcp-bigquery-client", "serde_json", "serde", "wiremock", "futures", "yup-oauth2", "thiserror"]
+clickhouse_fdw = ["clickhouse-rs", "chrono", "chrono-tz", "regex", "thiserror"]
+stripe_fdw = ["reqwest", "reqwest-middleware", "reqwest-retry", "serde_json", "thiserror"]
+firebase_fdw = ["reqwest", "reqwest-middleware", "reqwest-retry", "serde_json", "yup-oauth2", "regex", "thiserror"]
 s3_fdw = [
     "reqwest", "reqwest-middleware", "reqwest-retry", "aws-config", "aws-sdk-s3",
     "tokio", "tokio-util", "csv", "async-compression", "serde_json",
     "http", "parquet", "futures", "arrow-array", "chrono"
 ]
-airtable_fdw = ["reqwest", "reqwest-middleware", "reqwest-retry", "serde_json", "serde", "url"]
-logflare_fdw = ["reqwest", "reqwest-middleware", "reqwest-retry", "serde_json"]
+airtable_fdw = ["reqwest", "reqwest-middleware", "reqwest-retry", "serde_json", "serde", "url", "thiserror"]
+logflare_fdw = ["reqwest", "reqwest-middleware", "reqwest-retry", "serde_json", "thiserror"]
 
 # Does not include helloworld_fdw because of its general uselessness
 all_fdws = ["airtable_fdw", "bigquery_fdw", "clickhouse_fdw", "stripe_fdw", "firebase_fdw", "s3_fdw", "logflare_fdw"]
@@ -71,6 +71,8 @@ async-compression = { version = "0.3.15", features = ["tokio", "bzip2", "gzip", 
 http = { version = "0.2", optional = true }
 parquet = { version = "41.0.0", features = ["async"], optional = true }
 arrow-array = { version = "41.0.0", optional = true }
+
+thiserror = { version = "1.0.48", optional = true }
 
 [dev-dependencies]
 pgrx-tests = "=0.9.8"

--- a/wrappers/src/fdw/clickhouse_fdw/tests.rs
+++ b/wrappers/src/fdw/clickhouse_fdw/tests.rs
@@ -11,7 +11,7 @@ mod tests {
         Spi::connect(|mut c| {
             let clickhouse_pool = ch::Pool::new("tcp://default:@localhost:9000/supa");
 
-            let rt = create_async_runtime();
+            let rt = create_async_runtime().expect("failed to create runtime");
             let mut handle = rt
                 .block_on(async { clickhouse_pool.get_handle().await })
                 .expect("handle");


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix

## What is the current behavior?

The `create_async_runtime` method calls `unwrap` which swallows the real error.

## What is the new behavior?

The `create_async_runtime` method not longer calls `unwrap`. Full error is no preserved and reported.

## Additional context

This is the first of many PRs which will benefit from the change in API introduced in #144. `thiserror` has also been added to make errors easier to handle.
