### PR TITLE
feat: return Row from iter_scan instead of mutating in-place

### DIFF
--- a/supabase-wrappers/src/interface.rs
+++ b/supabase-wrappers/src/interface.rs
@@ -13,7 +13,6 @@ use std::collections::HashMap;
 use std::ffi::CStr;
 use std::fmt;
 use std::iter::Zip;
-use std::mem;
 use std::slice::Iter;
 
 // fdw system catalog oids
@@ -229,12 +228,6 @@ impl Row {
         self.cols.retain(|_| *iter.next().unwrap());
         iter = keep.iter();
         self.cells.retain(|_| *iter.next().unwrap());
-    }
-
-    /// Replace `self` with the source row
-    #[inline]
-    pub fn replace_with(&mut self, src: Row) {
-        let _ = mem::replace(self, src);
     }
 
     /// Clear the row, removing all column names and cells
@@ -517,7 +510,7 @@ pub trait ForeignDataWrapper<E: Into<ErrorReport>> {
     /// FDW must save fetched foreign data into the [`Row`], or return `None` if no more rows to read.
     ///
     /// [See more details](https://www.postgresql.org/docs/current/fdw-callbacks.html#FDW-CALLBACKS-SCAN).
-    fn iter_scan(&mut self, row: &mut Row) -> Result<Option<()>, E>;
+    fn iter_scan(&mut self) -> Result<Option<Row>, E>;
 
     /// Called when restart the scan from the beginning.
     ///

--- a/supabase-wrappers/src/lib.rs
+++ b/supabase-wrappers/src/lib.rs
@@ -115,7 +115,7 @@
 //!         Ok(())
 //!     }
 //!
-//!     fn iter_scan(&mut self, row: &mut Row) -> HelloWorldFdwResult<Option<()>> {
+//!     fn iter_scan(&mut self) -> HelloWorldFdwResult<Option<Row>> {
 //!         // Return None when done
 //!         Ok(None)
 //!     }
@@ -195,7 +195,8 @@
 //!         Ok(())
 //!     }
 //!
-//!     fn iter_scan(&mut self, row: &mut Row) -> Result<Option<()>, HelloWorldFdwError> {
+//!     fn iter_scan(&mut self) -> Result<Option<Row>, HelloWorldFdwError> {
+//!         let mut row = Row::new();
 //!         // this is called on each row and we only return one row here
 //!         if self.row_cnt < 1 {
 //!             // add values to row if they are in target column list
@@ -210,7 +211,7 @@
 //!             self.row_cnt += 1;
 //!
 //!             // return the 'Some(())' to Postgres and continue data scan
-//!             return Ok(Some(()));
+//!             return Ok(Some(row));
 //!         }
 //!
 //!         // return 'None' to stop data scan

--- a/wrappers/src/fdw/airtable_fdw/airtable_fdw.rs
+++ b/wrappers/src/fdw/airtable_fdw/airtable_fdw.rs
@@ -7,7 +7,6 @@ use std::collections::HashMap;
 use url::Url;
 
 use supabase_wrappers::prelude::*;
-use thiserror::Error;
 
 use super::result::AirtableResponse;
 use super::{AirtableFdwError, AirtableFdwResult};
@@ -164,13 +163,10 @@ impl ForeignDataWrapper<AirtableFdwError> for AirtableFdw {
         Ok(())
     }
 
-    fn iter_scan(&mut self, row: &mut Row) -> AirtableFdwResult<Option<()>> {
+    fn iter_scan(&mut self) -> AirtableFdwResult<Option<Row>> {
         if let Some(ref mut result) = self.scan_result {
             if !result.is_empty() {
-                return Ok(result
-                    .drain(0..1)
-                    .last()
-                    .map(|src_row| row.replace_with(src_row)));
+                return Ok(result.drain(0..1).last());
             }
         }
         Ok(None)

--- a/wrappers/src/fdw/bigquery_fdw/bigquery_fdw.rs
+++ b/wrappers/src/fdw/bigquery_fdw/bigquery_fdw.rs
@@ -351,7 +351,8 @@ impl ForeignDataWrapper<BigQueryFdwError> for BigQueryFdw {
         Ok(())
     }
 
-    fn iter_scan(&mut self, row: &mut Row) -> Result<Option<()>, BigQueryFdwError> {
+    fn iter_scan(&mut self) -> Result<Option<Row>, BigQueryFdwError> {
+        let mut row = Row::new();
         if let Some(client) = &self.client {
             if let Some(ref mut rs) = self.scan_result {
                 let mut extract_row = |rs: &mut ResultSet| {
@@ -374,7 +375,7 @@ impl ForeignDataWrapper<BigQueryFdwError> for BigQueryFdw {
                 };
 
                 if extract_row(rs) {
-                    return Ok(Some(()));
+                    return Ok(Some(row));
                 }
 
                 // deal with pagination
@@ -394,7 +395,7 @@ impl ForeignDataWrapper<BigQueryFdwError> for BigQueryFdw {
                                     // replace result set with data from the new page
                                     *rs = ResultSet::new(QueryResponse::from(resp));
                                     if extract_row(rs) {
-                                        return Ok(Some(()));
+                                        return Ok(Some(row));
                                     }
                                 }
                                 Err(err) => {

--- a/wrappers/src/fdw/clickhouse_fdw/clickhouse_fdw.rs
+++ b/wrappers/src/fdw/clickhouse_fdw/clickhouse_fdw.rs
@@ -285,7 +285,8 @@ impl ForeignDataWrapper<ClickHouseFdwError> for ClickHouseFdw {
         Ok(())
     }
 
-    fn iter_scan(&mut self, row: &mut Row) -> Result<Option<()>, ClickHouseFdwError> {
+    fn iter_scan(&mut self) -> Result<Option<Row>, ClickHouseFdwError> {
+        let mut row = Row::new();
         if let Some(block) = &self.scan_blk {
             let mut rows = block.rows();
 
@@ -312,7 +313,7 @@ impl ForeignDataWrapper<ClickHouseFdwError> for ClickHouseFdw {
                     row.push(col_name, cell);
                 }
                 self.row_idx += 1;
-                return Ok(Some(()));
+                return Ok(Some(row));
             }
         }
         Ok(None)

--- a/wrappers/src/fdw/firebase_fdw/firebase_fdw.rs
+++ b/wrappers/src/fdw/firebase_fdw/firebase_fdw.rs
@@ -320,15 +320,11 @@ impl ForeignDataWrapper<FirebaseFdwError> for FirebaseFdw {
         Ok(())
     }
 
-    fn iter_scan(&mut self, row: &mut Row) -> FirebaseFdwResult<Option<()>> {
+    fn iter_scan(&mut self) -> FirebaseFdwResult<Option<Row>> {
         if self.scan_result.is_empty() {
             Ok(None)
         } else {
-            Ok(self
-                .scan_result
-                .drain(0..1)
-                .last()
-                .map(|src_row| row.replace_with(src_row)))
+            Ok(self.scan_result.drain(0..1).last())
         }
     }
 

--- a/wrappers/src/fdw/helloworld_fdw/helloworld_fdw.rs
+++ b/wrappers/src/fdw/helloworld_fdw/helloworld_fdw.rs
@@ -66,7 +66,8 @@ impl ForeignDataWrapper<HelloWorldFdwError> for HelloWorldFdw {
         Ok(())
     }
 
-    fn iter_scan(&mut self, row: &mut Row) -> HelloWorldFdwResult<Option<()>> {
+    fn iter_scan(&mut self) -> HelloWorldFdwResult<Option<Row>> {
+        let mut row = Row::new();
         // this is called on each row and we only return one row here
         if self.row_cnt < 1 {
             // add values to row if they are in target column list
@@ -81,7 +82,7 @@ impl ForeignDataWrapper<HelloWorldFdwError> for HelloWorldFdw {
             self.row_cnt += 1;
 
             // return Some(()) to Postgres and continue data scan
-            return Ok(Some(()));
+            return Ok(Some(row));
         }
 
         // return 'None' to stop data scan

--- a/wrappers/src/fdw/logflare_fdw/logflare_fdw.rs
+++ b/wrappers/src/fdw/logflare_fdw/logflare_fdw.rs
@@ -276,15 +276,11 @@ impl ForeignDataWrapper<LogflareFdwError> for LogflareFdw {
         Ok(())
     }
 
-    fn iter_scan(&mut self, row: &mut Row) -> LogflareFdwResult<Option<()>> {
+    fn iter_scan(&mut self) -> LogflareFdwResult<Option<Row>> {
         if self.scan_result.is_empty() {
             Ok(None)
         } else {
-            Ok(self
-                .scan_result
-                .drain(0..1)
-                .last()
-                .map(|src_row| row.replace_with(src_row)))
+            Ok(self.scan_result.drain(0..1).last())
         }
     }
 

--- a/wrappers/src/fdw/stripe_fdw/stripe_fdw.rs
+++ b/wrappers/src/fdw/stripe_fdw/stripe_fdw.rs
@@ -730,13 +730,10 @@ impl ForeignDataWrapper<StripeFdwError> for StripeFdw {
         Ok(())
     }
 
-    fn iter_scan(&mut self, row: &mut Row) -> StripeFdwResult<Option<()>> {
+    fn iter_scan(&mut self) -> StripeFdwResult<Option<Row>> {
         if let Some(ref mut result) = self.scan_result {
             if !result.is_empty() {
-                return Ok(result
-                    .drain(0..1)
-                    .last()
-                    .map(|src_row| row.replace_with(src_row)));
+                return Ok(result.drain(0..1).last());
             }
         }
         Ok(None)


### PR DESCRIPTION
This PR changes the `iter_scan` method signature from `fn iter_scan(&mut self, row: &mut Row) -> Result<Option<()>, E>` to `fn iter_scan(&mut self) -> Result<Option<Row>, E>`. The new signature is better in that the user is forced to return a `Row` instead of updating the incoming row in-place, which they can forget.