### PR TITLE
Bump release timeout due to failed arm builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
           - { runner: ubuntu-20.04, arch: amd64 }
           - { runner: arm-runner, arch: arm64 }
     runs-on: ${{ matrix.box.runner }}
-    timeout-minutes: 45
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
ARM runner is not able to build pgrx extensions in 45 minutes anymore. Bumping to 90