### PR TITLE
fix: only update `wrappers_fdw_stats` table in a read-write transaction

### DIFF
--- a/wrappers/Cargo.lock
+++ b/wrappers/Cargo.lock
@@ -4321,7 +4321,7 @@ dependencies = [
 
 [[package]]
 name = "wrappers"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "arrow-array",
  "async-compression",

--- a/wrappers/src/stats.rs
+++ b/wrappers/src/stats.rs
@@ -43,26 +43,35 @@ fn get_stats_table() -> String {
 // increase stats value
 #[allow(dead_code)]
 pub(crate) fn inc_stats(fdw_name: &str, metric: Metric, inc: i64) {
-    let sql = format!(
-        "insert into {} as s (fdw_name, {}) values($1, $2)
+    if !is_txn_read_only() {
+        let sql = format!(
+            "insert into {} as s (fdw_name, {}) values($1, $2)
          on conflict(fdw_name)
          do update set
             {} = coalesce(s.{}, 0) + excluded.{},
             updated_at = timezone('utc'::text, now())",
-        get_stats_table(),
-        metric,
-        metric,
-        metric,
-        metric
-    );
-    Spi::run_with_args(
-        &sql,
-        Some(vec![
-            (PgBuiltInOids::TEXTOID.oid(), fdw_name.into_datum()),
-            (PgBuiltInOids::INT8OID.oid(), inc.into_datum()),
-        ]),
-    )
-    .unwrap();
+            get_stats_table(),
+            metric,
+            metric,
+            metric,
+            metric
+        );
+        Spi::run_with_args(
+            &sql,
+            Some(vec![
+                (PgBuiltInOids::TEXTOID.oid(), fdw_name.into_datum()),
+                (PgBuiltInOids::INT8OID.oid(), inc.into_datum()),
+            ]),
+        )
+        .unwrap();
+    }
+}
+
+fn is_txn_read_only() -> bool {
+    let read_only_txn = Spi::get_one("show transaction_read_only")
+        .unwrap_or(Some("on"))
+        .unwrap_or("on");
+    read_only_txn == "on"
 }
 
 // get metadata
@@ -82,20 +91,22 @@ pub(crate) fn get_metadata(fdw_name: &str) -> Option<JsonB> {
 // set metadata
 #[allow(dead_code)]
 pub(crate) fn set_metadata(fdw_name: &str, metadata: Option<JsonB>) {
-    let sql = format!(
-        "insert into {} as s (fdw_name, metadata) values($1, $2)
+    if !is_txn_read_only() {
+        let sql = format!(
+            "insert into {} as s (fdw_name, metadata) values($1, $2)
          on conflict(fdw_name)
          do update set
             metadata = $2,
             updated_at = timezone('utc'::text, now())",
-        get_stats_table()
-    );
-    Spi::run_with_args(
-        &sql,
-        Some(vec![
-            (PgBuiltInOids::TEXTOID.oid(), fdw_name.into_datum()),
-            (PgBuiltInOids::JSONBOID.oid(), metadata.into_datum()),
-        ]),
-    )
-    .unwrap();
+            get_stats_table()
+        );
+        Spi::run_with_args(
+            &sql,
+            Some(vec![
+                (PgBuiltInOids::TEXTOID.oid(), fdw_name.into_datum()),
+                (PgBuiltInOids::JSONBOID.oid(), metadata.into_datum()),
+            ]),
+        )
+        .unwrap();
+    }
 }

--- a/wrappers/src/stats.rs
+++ b/wrappers/src/stats.rs
@@ -40,38 +40,37 @@ fn get_stats_table() -> String {
         .unwrap_or_else(|| panic!("cannot find fdw stats table '{}'", FDW_STATS_TABLE))
 }
 
+fn is_txn_read_only() -> bool {
+    Spi::get_one("show transaction_read_only") == Ok(Some("on"))
+}
+
 // increase stats value
 #[allow(dead_code)]
 pub(crate) fn inc_stats(fdw_name: &str, metric: Metric, inc: i64) {
-    if !is_txn_read_only() {
-        let sql = format!(
-            "insert into {} as s (fdw_name, {}) values($1, $2)
+    if is_txn_read_only() {
+        return;
+    }
+
+    let sql = format!(
+        "insert into {} as s (fdw_name, {}) values($1, $2)
          on conflict(fdw_name)
          do update set
             {} = coalesce(s.{}, 0) + excluded.{},
             updated_at = timezone('utc'::text, now())",
-            get_stats_table(),
-            metric,
-            metric,
-            metric,
-            metric
-        );
-        Spi::run_with_args(
-            &sql,
-            Some(vec![
-                (PgBuiltInOids::TEXTOID.oid(), fdw_name.into_datum()),
-                (PgBuiltInOids::INT8OID.oid(), inc.into_datum()),
-            ]),
-        )
-        .unwrap();
-    }
-}
-
-fn is_txn_read_only() -> bool {
-    let read_only_txn = Spi::get_one("show transaction_read_only")
-        .unwrap_or(Some("on"))
-        .unwrap_or("on");
-    read_only_txn == "on"
+        get_stats_table(),
+        metric,
+        metric,
+        metric,
+        metric
+    );
+    Spi::run_with_args(
+        &sql,
+        Some(vec![
+            (PgBuiltInOids::TEXTOID.oid(), fdw_name.into_datum()),
+            (PgBuiltInOids::INT8OID.oid(), inc.into_datum()),
+        ]),
+    )
+    .unwrap();
 }
 
 // get metadata
@@ -91,22 +90,24 @@ pub(crate) fn get_metadata(fdw_name: &str) -> Option<JsonB> {
 // set metadata
 #[allow(dead_code)]
 pub(crate) fn set_metadata(fdw_name: &str, metadata: Option<JsonB>) {
-    if !is_txn_read_only() {
-        let sql = format!(
-            "insert into {} as s (fdw_name, metadata) values($1, $2)
+    if is_txn_read_only() {
+        return;
+    }
+
+    let sql = format!(
+        "insert into {} as s (fdw_name, metadata) values($1, $2)
          on conflict(fdw_name)
          do update set
             metadata = $2,
             updated_at = timezone('utc'::text, now())",
-            get_stats_table()
-        );
-        Spi::run_with_args(
-            &sql,
-            Some(vec![
-                (PgBuiltInOids::TEXTOID.oid(), fdw_name.into_datum()),
-                (PgBuiltInOids::JSONBOID.oid(), metadata.into_datum()),
-            ]),
-        )
-        .unwrap();
-    }
+        get_stats_table()
+    );
+    Spi::run_with_args(
+        &sql,
+        Some(vec![
+            (PgBuiltInOids::TEXTOID.oid(), fdw_name.into_datum()),
+            (PgBuiltInOids::JSONBOID.oid(), metadata.into_datum()),
+        ]),
+    )
+    .unwrap();
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

If a query on a foreign table was done in a read-only transaction, it failed with this error:

```
ERROR:  cannot execute INSERT in a read-only transaction
CONTEXT:  SQL statement "insert into public.wrappers_fdw_stats as s (fdw_name, create_times) values($1, $2)
         on conflict(fdw_name)
         do update set
            create_times = coalesce(s.create_times, 0) + excluded.create_times,
            updated_at = timezone('utc'::text, now())"
```

## What is the new behavior?

This error occurred because `wrappers` updated `wrappers_fdw_stats` table for each query on a foreign table. `wrappers` will now update the `wrappers_fdw_stats` table only if the transaction is read-write.

## Additional context

N/A
