### PR TITLE
fix: compilation error for stripe and logflare fdw

### DIFF
--- a/wrappers/Cargo.lock
+++ b/wrappers/Cargo.lock
@@ -4321,7 +4321,7 @@ dependencies = [
 
 [[package]]
 name = "wrappers"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "arrow-array",
  "async-compression",

--- a/wrappers/Cargo.toml
+++ b/wrappers/Cargo.toml
@@ -26,6 +26,7 @@ bigquery_fdw = [
 ]
 clickhouse_fdw = ["clickhouse-rs", "chrono", "chrono-tz", "regex", "thiserror"]
 stripe_fdw = [
+    "http",
     "reqwest",
     "reqwest-middleware",
     "reqwest-retry",
@@ -72,6 +73,7 @@ airtable_fdw = [
     "thiserror",
 ]
 logflare_fdw = [
+    "http",
     "reqwest",
     "reqwest-middleware",
     "reqwest-retry",


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to add missing `http` dependency for stripe and logflare fdw, which caused compilation error when compile fdw individually like below:

`cargo pgrx run --features stripe_fdw`

## What is the current behavior?

Compile stripe and logflare fdw will fail.

## What is the new behavior?

Compile stripe and logflare fdw is okay.

## Additional context

N/A
