### PR TITLE
fix: incorrect stripe table join

### DIFF
--- a/docs/stripe.md
+++ b/docs/stripe.md
@@ -766,10 +766,6 @@ While any column is allowed in a where clause, it is most efficient to filter by
 - id
 - destination
 
-## Limitations
-
-Joining local data against a Stripe FDW returns incomplete or empty results. We're tracking the [issue on GitHub](https://github.com/supabase/wrappers/issues/113) and working towards a fix.
-
 ## Examples
 
 Some examples on how to use Stripe foreign tables.


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to fix #113 . It will keep remote scan result and add implementation for `re_scan()` callback to reset iteration index when in nested loop join.

## What is the current behavior?

If the query joins 2 Stripe foreign tables, the result data isn't correct.

## What is the new behavior?

Stripe foreign table join should work correctly.

## Additional context

We may need to implement the same `re_scan()` callback for other FDWs to support join on foreign tables, but this PR only deals with Stripe FDW for now.
