### PR TITLE
chore: bump version to 0.1.18

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,6 +102,7 @@ jobs:
           cp ${extension_dir}/${{ matrix.extension_name }}--${deb_version}.sql ${extension_dir}/${{ matrix.extension_name }}--0.1.15--${deb_version}.sql
           cp ${extension_dir}/${{ matrix.extension_name }}--${deb_version}.sql ${extension_dir}/${{ matrix.extension_name }}--0.1.16--${deb_version}.sql
           cp ${extension_dir}/${{ matrix.extension_name }}--${deb_version}.sql ${extension_dir}/${{ matrix.extension_name }}--0.1.17--${deb_version}.sql
+          cp ${extension_dir}/${{ matrix.extension_name }}--${deb_version}.sql ${extension_dir}/${{ matrix.extension_name }}--0.1.18--${deb_version}.sql
 
           # Create installable package
           mkdir archive

--- a/wrappers/Cargo.lock
+++ b/wrappers/Cargo.lock
@@ -4321,7 +4321,7 @@ dependencies = [
 
 [[package]]
 name = "wrappers"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "arrow-array",
  "async-compression",

--- a/wrappers/Cargo.toml
+++ b/wrappers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wrappers"
-version = "0.1.18"
+version = "0.1.19"
 edition = "2021"
 
 [lib]


### PR DESCRIPTION
To prepare a release which includes [this fix](https://github.com/supabase/wrappers/pull/188).