### PR TITLE
docs: add extension creation schema

### DIFF
--- a/docs/airtable.md
+++ b/docs/airtable.md
@@ -7,7 +7,7 @@ The Airtable Wrapper allows you to read data from your Airtable bases/tables wit
 Before you get started, make sure the `wrappers` extension is installed on your database:
 
 ```sql
-create extension if not exists wrappers;
+create extension if not exists wrappers with schema extensions;
 ```
 
 and then create the foreign data wrapper:

--- a/docs/bigquery.md
+++ b/docs/bigquery.md
@@ -21,7 +21,7 @@ The BigQuery Wrapper allows you to read and write data from BigQuery within your
 Before you get started, make sure the `wrappers` extension is installed on your database:
 
 ```sql
-create extension if not exists wrappers;
+create extension if not exists wrappers with schema extensions;
 ```
 
 and then create the foreign data wrapper:

--- a/docs/clickhouse.md
+++ b/docs/clickhouse.md
@@ -24,7 +24,7 @@ The ClickHouse Wrapper allows you to read and write data from ClickHouse within 
 Before you get started, make sure the `wrappers` extension is installed on your database:
 
 ```sql
-create extension if not exists wrappers;
+create extension if not exists wrappers with schema extensions;
 ```
 
 and then create the foreign data wrapper:

--- a/docs/firebase.md
+++ b/docs/firebase.md
@@ -8,7 +8,7 @@
 Before you get started, make sure the `wrappers` extension is installed on your database:
 
 ```sql
-create extension if not exists wrappers;
+create extension if not exists wrappers with schema extensions;
 ```
 
 and then create the foreign data wrapper:

--- a/docs/logflare.md
+++ b/docs/logflare.md
@@ -7,7 +7,7 @@ The Logflare Wrapper allows you to read data from Logflare endpoints within your
 Before you get started, make sure the `wrappers` extension is installed on your database:
 
 ```sql
-create extension if not exists wrappers;
+create extension if not exists wrappers with schema extensions;
 ```
 
 and then create the foreign data wrapper:

--- a/docs/s3.md
+++ b/docs/s3.md
@@ -40,7 +40,7 @@ The S3 Wrapper uses Parquet file data types from [arrow_array::types](https://do
 Before you get started, make sure the `wrappers` extension is installed on your database:
 
 ```sql
-create extension if not exists wrappers;
+create extension if not exists wrappers with schema extensions;
 ```
 
 and then create the foreign data wrapper:

--- a/docs/stripe.md
+++ b/docs/stripe.md
@@ -5,7 +5,7 @@
 Before you get started, make sure the `wrappers` extension is installed on your database:
 
 ```sql
-create extension if not exists wrappers;
+create extension if not exists wrappers with schema extensions;
 ```
 
 and then create the foreign data wrapper:


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to add schema name when creating wrappers extension, which is required on Supabase platform.

## What is the current behavior?

There is no schema specified when creating wrappers extension, so the default schema `public` is used but that caused RLS warning on Supabase platform.

## What is the new behavior?

The wrappers extension should be created in `extensions` schema.

## Additional context

N/A
