### PR TITLE
Update pgrx deps to 0.11.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
         extension_name:
           - wrappers
         pgrx_version:
-          - 0.10.2
+          - 0.11.0
         postgres: [14, 15, 16]
         features:
           - "all_fdws"

--- a/.github/workflows/test_supabase_wrappers.yml
+++ b/.github/workflows/test_supabase_wrappers.yml
@@ -40,6 +40,6 @@ jobs:
           postgresql-server-dev-15
         sudo chmod a+rwx `/usr/lib/postgresql/15/bin/pg_config --pkglibdir` `/usr/lib/postgresql/15/bin/pg_config --sharedir`/extension /var/run/postgresql/
 
-    - run: cargo install cargo-pgrx --version 0.10.2
+    - run: cargo install cargo-pgrx --version 0.11.0
     - run: cargo pgrx init --pg15 /usr/lib/postgresql/15/bin/pg_config
     - run: cd supabase-wrappers && cargo test

--- a/.github/workflows/test_wrappers.yml
+++ b/.github/workflows/test_wrappers.yml
@@ -44,6 +44,6 @@ jobs:
           postgresql-server-dev-15
         sudo chmod a+rwx `/usr/lib/postgresql/15/bin/pg_config --pkglibdir` `/usr/lib/postgresql/15/bin/pg_config --sharedir`/extension /var/run/postgresql/
 
-    - run: cargo install cargo-pgrx --version 0.10.2
+    - run: cargo install cargo-pgrx --version 0.11.0
     - run: cargo pgrx init --pg15 /usr/lib/postgresql/15/bin/pg_config
     - run: cd wrappers && cargo pgrx test --features all_fdws,pg15

--- a/supabase-wrappers/Cargo.toml
+++ b/supabase-wrappers/Cargo.toml
@@ -19,14 +19,14 @@ pg16 = ["pgrx/pg16", "pgrx-tests/pg16"]
 pg_test = []
 
 [dependencies]
-pgrx = { version = "=0.10.2", default-features = false }
+pgrx = { version = "=0.11.0", default-features = false }
 thiserror = "1.0.48"
 tokio = { version = "1.24", features = ["rt"] }
 uuid = { version = "1.2.2" }
 supabase-wrappers-macros = { version = "0.1", path = "../supabase-wrappers-macros" }
 
 [dev-dependencies]
-pgrx-tests = "=0.10.2"
+pgrx-tests = "=0.11.0"
 
 [package.metadata.docs.rs]
 features = ["pg15", "cshim"]

--- a/supabase-wrappers/src/interface.rs
+++ b/supabase-wrappers/src/interface.rs
@@ -602,7 +602,7 @@ pub trait ForeignDataWrapper<E: Into<ErrorReport>> {
         unsafe {
             use crate::{modify, scan};
             let mut fdw_routine =
-                FdwRoutine::<AllocatedByRust>::alloc_node(pg_sys::NodeTag_T_FdwRoutine);
+                FdwRoutine::<AllocatedByRust>::alloc_node(pg_sys::NodeTag::T_FdwRoutine);
 
             // plan phase
             fdw_routine.GetForeignRelSize = Some(scan::get_foreign_rel_size::<E, Self>);

--- a/supabase-wrappers/src/limit.rs
+++ b/supabase-wrappers/src/limit.rs
@@ -16,7 +16,7 @@ pub(crate) unsafe fn extract_limit(
 
     // only push down constant LIMITs that are not NULL
     let limit_count = (*parse).limitCount as *mut pg_sys::Const;
-    if limit_count.is_null() || !is_a(limit_count as *mut pg_sys::Node, pg_sys::NodeTag_T_Const) {
+    if limit_count.is_null() || !is_a(limit_count as *mut pg_sys::Node, pg_sys::NodeTag::T_Const) {
         return None;
     }
 
@@ -34,7 +34,7 @@ pub(crate) unsafe fn extract_limit(
 
     // only consider OFFSETS that are non-NULL constants
     let limit_offset = (*parse).limitOffset as *mut pg_sys::Const;
-    if !limit_offset.is_null() && is_a(limit_offset as *mut pg_sys::Node, pg_sys::NodeTag_T_Const) {
+    if !limit_offset.is_null() && is_a(limit_offset as *mut pg_sys::Node, pg_sys::NodeTag::T_Const) {
         if let Some(offset) = i64::from_polymorphic_datum(
             (*limit_offset).constvalue,
             (*limit_offset).constisnull,

--- a/supabase-wrappers/src/qual.rs
+++ b/supabase-wrappers/src/qual.rs
@@ -70,9 +70,9 @@ pub(crate) unsafe fn get_operator(opno: pg_sys::Oid) -> pg_sys::Form_pg_operator
 }
 
 pub(crate) unsafe fn unnest_clause(node: *mut pg_sys::Node) -> *mut pg_sys::Node {
-    if is_a(node, pg_sys::NodeTag_T_RelabelType) {
+    if is_a(node, pg_sys::NodeTag::T_RelabelType) {
         (*(node as *mut pg_sys::RelabelType)).arg as _
-    } else if is_a(node, pg_sys::NodeTag_T_ArrayCoerceExpr) {
+    } else if is_a(node, pg_sys::NodeTag::T_ArrayCoerceExpr) {
         (*(node as *mut pg_sys::ArrayCoerceExpr)).arg as _
     } else {
         node
@@ -105,20 +105,20 @@ pub(crate) unsafe fn extract_from_op_expr(
     let mut right = unnest_clause(args.tail().unwrap());
 
     // swap operands if needed
-    if is_a(right, pg_sys::NodeTag_T_Var)
-        && !is_a(left, pg_sys::NodeTag_T_Var)
+    if is_a(right, pg_sys::NodeTag::T_Var)
+        && !is_a(left, pg_sys::NodeTag::T_Var)
         && (*opr).oprcom != Oid::INVALID
     {
         std::mem::swap(&mut left, &mut right);
     }
 
-    if is_a(left, pg_sys::NodeTag_T_Var) {
+    if is_a(left, pg_sys::NodeTag::T_Var) {
         let left = left as *mut pg_sys::Var;
 
         if pg_sys::bms_is_member((*left).varno as c_int, baserel_ids) && (*left).varattno >= 1 {
             let field = pg_sys::get_attname(baserel_id, (*left).varattno, false);
 
-            let (value, param) = if is_a(right, pg_sys::NodeTag_T_Const) {
+            let (value, param) = if is_a(right, pg_sys::NodeTag::T_Const) {
                 let right = right as *mut pg_sys::Const;
                 (
                     Cell::from_polymorphic_datum(
@@ -128,7 +128,7 @@ pub(crate) unsafe fn extract_from_op_expr(
                     ),
                     None,
                 )
-            } else if is_a(right, pg_sys::NodeTag_T_Param) {
+            } else if is_a(right, pg_sys::NodeTag::T_Param) {
                 // add a dummy value if this is query parameter, the actual value
                 // will be extracted from execution state
                 let right = right as *mut pg_sys::Param;
@@ -166,7 +166,7 @@ pub(crate) unsafe fn extract_from_null_test(
     expr: *mut pg_sys::NullTest,
 ) -> Option<Qual> {
     let var = (*expr).arg as *mut pg_sys::Var;
-    if !is_a(var as _, pg_sys::NodeTag_T_Var) || (*var).varattno < 1 {
+    if !is_a(var as _, pg_sys::NodeTag::T_Var) || (*var).varattno < 1 {
         return None;
     }
 
@@ -212,7 +212,7 @@ pub(crate) unsafe fn extract_from_scalar_array_op_expr(
     let left = unnest_clause(args.head().unwrap());
     let right = unnest_clause(args.tail().unwrap());
 
-    if is_a(left, pg_sys::NodeTag_T_Var) && is_a(right, pg_sys::NodeTag_T_Const) {
+    if is_a(left, pg_sys::NodeTag::T_Var) && is_a(right, pg_sys::NodeTag::T_Const) {
         let left = left as *mut pg_sys::Var;
         let right = right as *mut pg_sys::Const;
 
@@ -313,15 +313,15 @@ pub(crate) unsafe fn extract_quals(
     let conds = PgList::<pg_sys::RestrictInfo>::from_pg((*baserel).baserestrictinfo);
     for cond in conds.iter_ptr() {
         let expr = (*cond).clause as *mut pg_sys::Node;
-        let extracted = if is_a(expr, pg_sys::NodeTag_T_OpExpr) {
+        let extracted = if is_a(expr, pg_sys::NodeTag::T_OpExpr) {
             extract_from_op_expr(root, baserel_id, (*baserel).relids, expr as _)
-        } else if is_a(expr, pg_sys::NodeTag_T_NullTest) {
+        } else if is_a(expr, pg_sys::NodeTag::T_NullTest) {
             extract_from_null_test(baserel_id, expr as _)
-        } else if is_a(expr, pg_sys::NodeTag_T_ScalarArrayOpExpr) {
+        } else if is_a(expr, pg_sys::NodeTag::T_ScalarArrayOpExpr) {
             extract_from_scalar_array_op_expr(root, baserel_id, (*baserel).relids, expr as _)
-        } else if is_a(expr, pg_sys::NodeTag_T_Var) {
+        } else if is_a(expr, pg_sys::NodeTag::T_Var) {
             extract_from_var(root, baserel_id, (*baserel).relids, expr as _)
-        } else if is_a(expr, pg_sys::NodeTag_T_BoolExpr) {
+        } else if is_a(expr, pg_sys::NodeTag::T_BoolExpr) {
             extract_from_bool_expr(root, baserel_id, (*baserel).relids, expr as _)
         } else {
             if let Some(stm) = pgrx::nodes::node_to_string(expr) {

--- a/supabase-wrappers/src/sort.rs
+++ b/supabase-wrappers/src/sort.rs
@@ -44,17 +44,17 @@ pub(crate) unsafe fn extract_sorts(
             .and_then(|em| {
                 let expr = (*em).em_expr as *mut pg_sys::Node;
 
-                if is_a(expr, pg_sys::NodeTag_T_Var) {
+                if is_a(expr, pg_sys::NodeTag::T_Var) {
                     let var = expr as *mut pg_sys::Var;
                     let sort = create_sort(pathkey, var, baserel_id);
                     if let Some(sort) = sort {
                         ret.push(sort);
                     }
-                } else if is_a(expr, pg_sys::NodeTag_T_RelabelType) {
+                } else if is_a(expr, pg_sys::NodeTag::T_RelabelType) {
                     // ORDER BY clauses having a COLLATE option will be RelabelType
                     let expr = expr as *mut pg_sys::RelabelType;
                     let var = (*expr).arg as *mut pg_sys::Var;
-                    if is_a(var as *mut pg_sys::Node, pg_sys::NodeTag_T_Var) {
+                    if is_a(var as *mut pg_sys::Node, pg_sys::NodeTag::T_Var) {
                         let sort = create_sort(pathkey, var, baserel_id);
                         if let Some(mut sort) = sort {
                             let coll_id = (*expr).resultcollid;

--- a/wrappers/Cargo.lock
+++ b/wrappers/Cargo.lock
@@ -827,9 +827,9 @@ dependencies = [
 
 [[package]]
 name = "cargo_toml"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a1f1117a8ff2f3547295da90f473c392d8d1107c90cea1ea82b1a544a97a4a"
+checksum = "e3f9629bc6c4388ea699781dc988c2b99766d7679b151c81990b4fa1208fafd3"
 dependencies = [
  "serde",
  "toml",
@@ -2031,9 +2031,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.148"
+version = "0.2.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
+checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
 
 [[package]]
 name = "libloading"
@@ -2544,9 +2544,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dde2cf81d16772f2e75c91edd2e868de1bd67a79d6c45c3d25c62b2ed3851d70"
+checksum = "bd3c4b36fbe84329b86c83bfd33b9514a50606f00074f47085f99062a7dd8c9c"
 dependencies = [
  "atomic-traits",
  "bitflags 2.4.0",
@@ -2569,9 +2569,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-macros"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9c035c16a41b126f8c2b37307f2c717b5ee72ff8e7495ff502ad35471a0b38"
+checksum = "9c6a41e021321a814fac1aa27bd4266208b4507709ecbc28fc99693adfbd0c41"
 dependencies = [
  "pgrx-sql-entity-graph",
  "proc-macro2",
@@ -2581,9 +2581,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-config"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f9d9b6310ea9f13570d773d173bbcfe47ac844075bf6a3e207e7209786c631"
+checksum = "17da1e26800e747d501b8d8bb8aeee4530a07d93a39c3fb2c4229a8feff213b2"
 dependencies = [
  "cargo_toml",
  "dirs",
@@ -2599,9 +2599,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-sys"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f821614646963302a8499b8ac8332cc0e2ae3f8715a0220986984443d8880f74"
+checksum = "f9032b517525ec71579cc68e92905b5f5f63e892c094834202313c42f2f1a669"
 dependencies = [
  "bindgen",
  "eyre",
@@ -2621,9 +2621,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-sql-entity-graph"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4743b5b23fd418cded0c2dbe4b1529628f7fa59b8d68426eafdde0cb51541c96"
+checksum = "2e4a88203974b887bca8bfdea17ab9936411fb7e84957763dc0124df78d07907"
 dependencies = [
  "convert_case",
  "eyre",
@@ -2636,9 +2636,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-tests"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "177bb8f6811bd65180c5a24a33666baed0ed5c08cc584c4bdb78f7fe19304363"
+checksum = "c80deb4310538e6ef14f4cbb30b56eb24b6d7aae66bfd4e516f153987159e65e"
 dependencies = [
  "clap-cargo",
  "eyre",
@@ -2792,9 +2792,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.67"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
+checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
 dependencies = [
  "unicode-ident",
 ]
@@ -2973,25 +2973,25 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.5"
+version = "1.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "697061221ea1b4a94a624f67d0ae2bfe4e22b8a17b6a192afb11046542cc8c47"
+checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
 dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata",
- "regex-syntax 0.7.5",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
 name = "regex-automata"
-version = "0.3.8"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2f401f4955220693b56f8ec66ee9c78abffd8d1c4f23dc41a23839eb88f0795"
+checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.5",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -3002,9 +3002,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.5"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "reqwest"
@@ -3361,9 +3361,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96426c9936fd7a0124915f9185ea1d20aa9445cc9821142f0a73bc9207a2e186"
+checksum = "12022b835073e5b11e90a14f86838ceb1c8fb0325b72416845c487ac0fa95e80"
 dependencies = [
  "serde",
 ]
@@ -3797,9 +3797,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.0"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c226a7bba6d859b63c92c4b4fe69c5b6b72d0cb897dbc8e6012298e6154cb56e"
+checksum = "a1a195ec8c9da26928f773888e0742ca3ca1040c6cd859c919c9f59c1954ab35"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -3809,18 +3809,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ff63e60a958cefbb518ae1fd6566af80d9d4be430a33f3723dfc47d1d411d95"
+checksum = "d34d383cd00a163b4a5b85053df514d45bc330f6de7737edfe0a93311d1eaa03"
 dependencies = [
  "indexmap 2.0.0",
  "serde",

--- a/wrappers/Cargo.toml
+++ b/wrappers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wrappers"
-version = "0.1.19"
+version = "0.1.20"
 edition = "2021"
 
 [lib]
@@ -94,7 +94,7 @@ all_fdws = [
 ]
 
 [dependencies]
-pgrx = { version = "=0.10.2" }
+pgrx = { version = "=0.11.0" }
 #supabase-wrappers = "0.1"
 supabase-wrappers = { path = "../supabase-wrappers", default-features = false }
 
@@ -146,7 +146,7 @@ arrow-array = { version = "41.0.0", optional = true }
 thiserror = { version = "1.0.48", optional = true }
 
 [dev-dependencies]
-pgrx-tests = "=0.10.2"
+pgrx-tests = "=0.11.0"
 
 [profile.dev]
 panic = "unwind"

--- a/wrappers/Cargo.toml
+++ b/wrappers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wrappers"
-version = "0.1.20"
+version = "0.1.19"
 edition = "2021"
 
 [lib]


### PR DESCRIPTION
## What kind of change does this PR introduce?

pgrx 0.11 introduced a new API for the node type tags; they're enum members now.
this change replaces the old references with the enum refs
