### PR TITLE
fix: static str compilation warning

### DIFF
--- a/wrappers/src/fdw/airtable_fdw/airtable_fdw.rs
+++ b/wrappers/src/fdw/airtable_fdw/airtable_fdw.rs
@@ -41,7 +41,7 @@ pub(crate) struct AirtableFdw {
 }
 
 impl AirtableFdw {
-    const FDW_NAME: &str = "AirtableFdw";
+    const FDW_NAME: &'static str = "AirtableFdw";
 
     #[inline]
     fn build_url(&self, base_id: &str, table_id: &str, view_id: Option<&String>) -> String {

--- a/wrappers/src/fdw/bigquery_fdw/bigquery_fdw.rs
+++ b/wrappers/src/fdw/bigquery_fdw/bigquery_fdw.rs
@@ -66,7 +66,7 @@ pub(crate) struct BigQueryFdw {
 }
 
 impl BigQueryFdw {
-    const FDW_NAME: &str = "BigQueryFdw";
+    const FDW_NAME: &'static str = "BigQueryFdw";
 
     fn deparse(
         &self,
@@ -186,7 +186,7 @@ impl ForeignDataWrapper<BigQueryFdwError> for BigQueryFdw {
                 Some(sa_key) => sa_key.to_owned(),
                 None => {
                     let sa_key_id = require_option("sa_key_id", options)?;
-                    match get_vault_secret(&sa_key_id) {
+                    match get_vault_secret(sa_key_id) {
                         Some(sa_key) => sa_key,
                         None => return Ok(ret),
                     }

--- a/wrappers/src/fdw/clickhouse_fdw/clickhouse_fdw.rs
+++ b/wrappers/src/fdw/clickhouse_fdw/clickhouse_fdw.rs
@@ -91,7 +91,7 @@ pub(crate) struct ClickHouseFdw {
 }
 
 impl ClickHouseFdw {
-    const FDW_NAME: &str = "ClickHouseFdw";
+    const FDW_NAME: &'static str = "ClickHouseFdw";
 
     fn create_client(&mut self) -> ClickHouseFdwResult<()> {
         let pool = Pool::new(self.conn_str.as_str());

--- a/wrappers/src/fdw/firebase_fdw/firebase_fdw.rs
+++ b/wrappers/src/fdw/firebase_fdw/firebase_fdw.rs
@@ -142,7 +142,7 @@ pub(crate) struct FirebaseFdw {
 }
 
 impl FirebaseFdw {
-    const FDW_NAME: &str = "FirebaseFdw";
+    const FDW_NAME: &'static str = "FirebaseFdw";
 
     const DEFAULT_AUTH_BASE_URL: &'static str =
         "https://identitytoolkit.googleapis.com/v1/projects";

--- a/wrappers/src/fdw/logflare_fdw/logflare_fdw.rs
+++ b/wrappers/src/fdw/logflare_fdw/logflare_fdw.rs
@@ -99,8 +99,8 @@ pub(crate) struct LogflareFdw {
 }
 
 impl LogflareFdw {
-    const FDW_NAME: &str = "LogflareFdw";
-    const BASE_URL: &str = "https://api.logflare.app/api/endpoints/query/";
+    const FDW_NAME: &'static str = "LogflareFdw";
+    const BASE_URL: &'static str = "https://api.logflare.app/api/endpoints/query/";
 
     fn build_url(&self, endpoint: &str) -> LogflareFdwResult<Option<Url>> {
         let mut url = self.base_url.join(endpoint)?;

--- a/wrappers/src/fdw/s3_fdw/parquet.rs
+++ b/wrappers/src/fdw/s3_fdw/parquet.rs
@@ -142,7 +142,7 @@ pub(super) struct S3Parquet {
 }
 
 impl S3Parquet {
-    const FDW_NAME: &str = "S3Fdw";
+    const FDW_NAME: &'static str = "S3Fdw";
 
     // open batch stream from local buffer
     pub(super) async fn open_local_stream(&mut self, buf: Vec<u8>) -> S3FdwResult<()> {

--- a/wrappers/src/fdw/s3_fdw/s3_fdw.rs
+++ b/wrappers/src/fdw/s3_fdw/s3_fdw.rs
@@ -42,7 +42,7 @@ pub(crate) struct S3Fdw {
 }
 
 impl S3Fdw {
-    const FDW_NAME: &str = "S3Fdw";
+    const FDW_NAME: &'static str = "S3Fdw";
 
     // local string line buffer size, in bytes
     // Note: this is not a hard limit, just an indication of full buffer

--- a/wrappers/src/fdw/stripe_fdw/stripe_fdw.rs
+++ b/wrappers/src/fdw/stripe_fdw/stripe_fdw.rs
@@ -265,7 +265,7 @@ pub(crate) struct StripeFdw {
 }
 
 impl StripeFdw {
-    const FDW_NAME: &str = "StripeFdw";
+    const FDW_NAME: &'static str = "StripeFdw";
 
     fn build_url(
         &self,


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to fix compilation warning for static string, which became warning since Rust 1.74.0.

## What is the current behavior?

N/A

## What is the new behavior?

N/A

## Additional context

N/A
