### PR TITLE
feat: Auth0 add pagination

### DIFF
--- a/docs/auth0.md
+++ b/docs/auth0.md
@@ -1,0 +1,119 @@
+# [Auth0](https://auth0.com/) is a flexible, drop-in solution to add authentication and authorization services to your applications
+
+The Auth0 Wrapper allows you to read data from your Auth0 tenant for use within your Postgres database.
+
+## Preparation
+
+Before you get started, make sure the `wrappers` extension is installed on your database:
+
+```sql
+create extension if not exists wrappers with schema extensions;
+```
+
+and then create the foreign data wrapper:
+
+```sql
+create foreign data wrapper auth0_wrapper
+  handler auth0_fdw_handler
+  validator auth0_fdw_validator;
+```
+
+### Secure your credentials (optional)
+
+By default, Postgres stores FDW credentials inide `pg_catalog.pg_foreign_server` in plain text. Anyone with access to this table will be able to view these credentials. Wrappers is designed to work with [Vault](https://supabase.com/docs/guides/database/vault), which provides an additional level of security for storing credentials. We recommend using Vault to store your credentials.
+
+```sql
+-- Save your Auth0 API key in Vault and retrieve the `key_id`
+insert into vault.secrets (name, secret)
+values (
+  'auth0',
+  '<Auth0 API Key or PAT>' -- Auth0 API key or Personal Access Token (PAT)
+)
+returning key_id;
+```
+
+### Connecting to Auth0
+
+We need to provide Postgres with the credentials to connect to Airtable, and any additional options. We can do this using the `create server` command:
+
+=== "With Vault"
+
+    ```sql
+    create server auth0_server
+      foreign data wrapper auth0_wrapper
+      options (
+        api_key_id '<key_ID>' -- The Key ID from above.
+      );
+    ```
+
+=== "Without Vault"
+
+    ```sql
+    -- create server and specify custom options
+    create server auth0_server
+    foreign data wrapper auth0_wrapper
+    options (
+        url 'https://dev-<tenant-id>.us.auth0.com/api/v2/users',
+        api_key '<your_api_key>'
+    );
+    ```
+
+## Creating Foreign Tables
+
+The Auth0 Wrapper supports data reads from Auth0's [Management API List users endpoint](https://auth0.com/docs/api/management/v2/users/get-users) endpoint (_read only_).
+
+| Auth0 | Select | Insert | Update | Delete | Truncate |
+| -------- | :----: | :----: | :----: | :----: | :------: |
+| Records  |   ✅   |   ❌   |   ❌   |   ❌   |    ❌    |
+
+For example:
+
+```sql
+create foreign table my_foreign_table (
+  name text
+  -- other fields
+)
+server auth0_server
+options (
+  object 'users',
+);
+```
+
+### Foreign table options
+
+The full list of foreign table options are below:
+
+- `objects` - Auth0 object to select from. Currently only supports `users`
+
+## Query Pushdown Support
+
+This FDW doesn't support query pushdown.
+
+## Examples
+
+Some examples on how to use Auth0 foreign tables.
+
+### Basic example
+
+This will create a "foreign table" inside your Postgres database called `auth0_table`:
+
+```sql
+create foreign table auth0_table (
+  created_at text,
+  email text,
+  email_verified bool,
+  identities jsonb
+)
+  server auth0_server
+  options (
+    object 'users'
+  );
+
+```
+
+You can now fetch your Auth0 data from within your Postgres database:
+
+```sql
+select * from auth0;
+```
+

--- a/wrappers/dockerfiles/auth0/server.py
+++ b/wrappers/dockerfiles/auth0/server.py
@@ -6,14 +6,14 @@ import json
 
 class MockServerHandler(http.server.SimpleHTTPRequestHandler):
     def do_GET(self):
-        response_data = [{
+        response_data = {"start":0,"limit":50,"length":2, "users": [{
             "email": "example@gmail.com",
             "identities": [{
                 'provider': 'google-oauth2'
             }],
             "email_verified": False,
             "created_at": "2023-05-16T07:41:08.028Z"
-        }]
+        }]}
 
         # Set response code and headers
         self.send_response(200)

--- a/wrappers/src/fdw/auth0_fdw/README.md
+++ b/wrappers/src/fdw/auth0_fdw/README.md
@@ -70,10 +70,12 @@ create foreign table auth0 (
 
 ```sql
 wrappers=# select * from auth0;
-               user_id               |        created_at
--------------------------------------+--------------------------
- google-oauth2|101232059018005339936 | 2023-05-16T07:41:08.028Z
-(1 row)
+
+created_at     | 2023-11-22T09:52:17.326Z
+email          | myname@supabase.io
+email_verified | t
+identities     | [{"user_id": "<my_user_id>", "isSocial": false, "provider": "auth0", "connection": "Username-Password-Authentication"}]
+
 ```
 
 ## Changelog

--- a/wrappers/src/fdw/auth0_fdw/auth0_client/mod.rs
+++ b/wrappers/src/fdw/auth0_fdw/auth0_client/mod.rs
@@ -51,16 +51,14 @@ impl Auth0Client {
 
     pub(crate) fn fetch_users(
         &self,
-        page: Option<u64>,
+        page: u64,
         per_page: Option<u64>,
     ) -> Result<ResultPayload, Auth0ClientError> {
         let rt = create_async_runtime()?;
 
         rt.block_on(async {
             let mut url = self.url.clone();
-            if let Some(page) = page {
-                url.query_pairs_mut().append_pair("page", &page.to_string());
-            }
+            url.query_pairs_mut().append_pair("page", &page.to_string());
             if let Some(per_page) = per_page {
                 url.query_pairs_mut()
                     .append_pair("per_page", &per_page.to_string());
@@ -95,17 +93,13 @@ pub(crate) enum Auth0ClientError {
 
     #[error("failed to parse url: {0}")]
     UrlParseError(#[from] ParseError),
-
-    #[error("missing page offset")]
-    MissingPageOffset,
 }
 
 impl From<Auth0ClientError> for ErrorReport {
     fn from(value: Auth0ClientError) -> Self {
         match value {
             Auth0ClientError::CreateRuntimeError(e) => e.into(),
-            Auth0ClientError::MissingPageOffset
-            | Auth0ClientError::UrlParseError(_)
+            Auth0ClientError::UrlParseError(_)
             | Auth0ClientError::InvalidApiKeyHeader
             | Auth0ClientError::ReqwestError(_)
             | Auth0ClientError::ReqwestMiddlewareError(_)

--- a/wrappers/src/fdw/auth0_fdw/auth0_client/mod.rs
+++ b/wrappers/src/fdw/auth0_fdw/auth0_client/mod.rs
@@ -66,6 +66,8 @@ impl Auth0Client {
                     .append_pair("per_page", &per_page.to_string());
             }
 
+            url.query_pairs_mut().append_pair("include_totals", "true");
+
             let response = self.get_client().get(url.as_str()).send().await?;
             let response = response.error_for_status()?;
             let payload = response.json::<ResultPayload>().await?;

--- a/wrappers/src/fdw/auth0_fdw/auth0_client/mod.rs
+++ b/wrappers/src/fdw/auth0_fdw/auth0_client/mod.rs
@@ -93,13 +93,17 @@ pub(crate) enum Auth0ClientError {
 
     #[error("failed to parse url: {0}")]
     UrlParseError(#[from] ParseError),
+
+    #[error("missing page offset")]
+    MissingPageOffset,
 }
 
 impl From<Auth0ClientError> for ErrorReport {
     fn from(value: Auth0ClientError) -> Self {
         match value {
             Auth0ClientError::CreateRuntimeError(e) => e.into(),
-            Auth0ClientError::UrlParseError(_)
+            Auth0ClientError::MissingPageOffset
+            | Auth0ClientError::UrlParseError(_)
             | Auth0ClientError::InvalidApiKeyHeader
             | Auth0ClientError::ReqwestError(_)
             | Auth0ClientError::ReqwestMiddlewareError(_)

--- a/wrappers/src/fdw/auth0_fdw/auth0_client/row.rs
+++ b/wrappers/src/fdw/auth0_fdw/auth0_client/row.rs
@@ -13,8 +13,11 @@ pub(crate) struct UserRequest {
 
 #[derive(Debug, Deserialize, PartialEq)]
 pub struct ResultPayload {
-    pub(crate) users: Vec<Auth0User>,
-    pub(crate) next_page_offset: Option<u64>,
+    users: Vec<Auth0User>,
+    start: Option<u64>,
+    limit: Option<u64>,
+    length: Option<u64>,
+    total: Option<u64>,
 }
 
 #[derive(Debug, Deserialize, PartialEq)]
@@ -30,6 +33,15 @@ pub struct Auth0User {
     pub email: String,
     pub email_verified: bool,
     pub identities: Option<serde_json::Value>,
+}
+
+impl ResultPayload {
+    pub fn into_users(self) -> Vec<Auth0User> {
+        self.users
+    }
+    pub fn into_total(&self) -> Option<u64> {
+        self.total
+    }
 }
 
 impl Auth0User {

--- a/wrappers/src/fdw/auth0_fdw/auth0_client/row.rs
+++ b/wrappers/src/fdw/auth0_fdw/auth0_client/row.rs
@@ -39,7 +39,7 @@ impl ResultPayload {
     pub fn into_users(self) -> Vec<Auth0User> {
         self.users
     }
-    pub fn into_total(&self) -> Option<u64> {
+    pub fn get_total(&self) -> Option<u64> {
         self.total
     }
 }

--- a/wrappers/src/fdw/auth0_fdw/auth0_client/rows_iterator.rs
+++ b/wrappers/src/fdw/auth0_fdw/auth0_client/rows_iterator.rs
@@ -42,7 +42,10 @@ impl RowsIterator {
             .map(|u| u.into_row(&self.columns))
             .collect();
         self.page_offset = self.page_offset.map(|offset| offset + 1);
-        let page_offset = self.page_offset.unwrap_or(0);
+        let page_offset = match self.page_offset {
+            Some(offset) => offset,
+            None => return Err(Auth0ClientError::MissingPageOffset),
+        };
         self.have_more_rows = total > self.per_page * page_offset;
         Ok(self.get_next_row())
     }

--- a/wrappers/src/fdw/auth0_fdw/auth0_client/rows_iterator.rs
+++ b/wrappers/src/fdw/auth0_fdw/auth0_client/rows_iterator.rs
@@ -8,7 +8,7 @@ pub(crate) struct RowsIterator {
     columns: Vec<Column>,
     rows: VecDeque<Row>,
     have_more_rows: bool,
-    page_offset: Option<u64>,
+    page_offset: u64,
 }
 
 impl RowsIterator {
@@ -19,11 +19,11 @@ impl RowsIterator {
             per_page,
             rows: VecDeque::new(),
             have_more_rows: true,
-            page_offset: Some(0),
+            page_offset: 0,
         }
     }
 
-    fn get_page_offset(&self) -> Option<u64> {
+    fn get_page_offset(&self) -> u64 {
         self.page_offset
     }
 
@@ -42,7 +42,7 @@ impl RowsIterator {
             .map(|u| u.into_row(&self.columns))
             .collect();
         self.page_offset += 1;
-        self.have_more_rows = total > self.per_page * page_offset;
+        self.have_more_rows = total > self.per_page * self.page_offset;
         Ok(self.get_next_row())
     }
 

--- a/wrappers/src/fdw/auth0_fdw/auth0_client/rows_iterator.rs
+++ b/wrappers/src/fdw/auth0_fdw/auth0_client/rows_iterator.rs
@@ -19,7 +19,7 @@ impl RowsIterator {
             per_page,
             rows: VecDeque::new(),
             have_more_rows: true,
-            page_offset: None,
+            page_offset: Some(0),
         }
     }
 
@@ -35,7 +35,7 @@ impl RowsIterator {
         let result_payload = self
             .auth0_client
             .fetch_users(self.get_page_offset(), self.get_per_page())?;
-        let total = result_payload.into_total().unwrap_or(0);
+        let total = result_payload.get_total().unwrap_or(0);
         self.rows = result_payload
             .into_users()
             .into_iter()

--- a/wrappers/src/fdw/auth0_fdw/auth0_client/rows_iterator.rs
+++ b/wrappers/src/fdw/auth0_fdw/auth0_client/rows_iterator.rs
@@ -41,11 +41,7 @@ impl RowsIterator {
             .into_iter()
             .map(|u| u.into_row(&self.columns))
             .collect();
-        self.page_offset = self.page_offset.map(|offset| offset + 1);
-        let page_offset = match self.page_offset {
-            Some(offset) => offset,
-            None => return Err(Auth0ClientError::MissingPageOffset),
-        };
+        self.page_offset += 1;
         self.have_more_rows = total > self.per_page * page_offset;
         Ok(self.get_next_row())
     }

--- a/wrappers/src/fdw/auth0_fdw/auth0_fdw.rs
+++ b/wrappers/src/fdw/auth0_fdw/auth0_fdw.rs
@@ -122,7 +122,7 @@ impl ForeignDataWrapper<Auth0FdwError> for Auth0Fdw {
         _options: &HashMap<String, String>,
     ) -> Auth0FdwResult<()> {
         let auth0_client = Auth0Client::new(&self.url, &self.api_key)?;
-        self.rows_iterator = Some(RowsIterator::new(columns.to_vec(), 1000, auth0_client));
+        self.rows_iterator = Some(RowsIterator::new(columns.to_vec(), 50, auth0_client));
 
         Ok(())
     }


### PR DESCRIPTION
## What kind of change does this PR introduce?
FLUP to #183 where we aim to introduce pagination on the user object. Auth0 has `pagination` by supplying the following fields:

- `total` - this is the total number of entries
-  `per_page` - this is the number of entries per page
- `page` - this is the current page we're on

Here are the [docs](https://auth0.com/docs/manage-users/user-search/view-search-results-by-page#sample-request)

We default to having 50 entries per_page. It also seems like there's a 1000 entry limit which is unfortunate.

## What is the current behavior?
No proper pagination

