### PR TITLE
fix: update with pgrx upstream and remove compilation warning

### DIFF
--- a/supabase-wrappers/src/interface.rs
+++ b/supabase-wrappers/src/interface.rs
@@ -6,7 +6,7 @@ use pgrx::pg_sys::panic::ErrorReport;
 use pgrx::prelude::{Date, Timestamp};
 use pgrx::{
     fcinfo,
-    pg_sys::{self, Datum, Oid},
+    pg_sys::{self, BuiltinOid, Datum, Oid},
     AllocatedByRust, AnyNumeric, FromDatum, IntoDatum, JsonB, PgBuiltInOids, PgOid,
 };
 use std::collections::HashMap;
@@ -22,13 +22,16 @@ use std::slice::Iter;
 // https://doxygen.postgresql.org/pg__foreign__table_8h.html
 
 /// Constant can be used in [validator](ForeignDataWrapper::validator)
+// Note: temporarily disable warning here, can be removed after this upstream PR
+// is merged. https://github.com/pgcentralfoundation/pgrx/pull/1432.
+#[allow(deprecated)]
 pub const FOREIGN_DATA_WRAPPER_RELATION_ID: Oid = unsafe { Oid::from_u32_unchecked(2328) };
 
 /// Constant can be used in [validator](ForeignDataWrapper::validator)
-pub const FOREIGN_SERVER_RELATION_ID: Oid = unsafe { Oid::from_u32_unchecked(1417) };
+pub const FOREIGN_SERVER_RELATION_ID: Oid = BuiltinOid::ForeignServerRelationId.value();
 
 /// Constant can be used in [validator](ForeignDataWrapper::validator)
-pub const FOREIGN_TABLE_RELATION_ID: Oid = unsafe { Oid::from_u32_unchecked(3118) };
+pub const FOREIGN_TABLE_RELATION_ID: Oid = BuiltinOid::ForeignTableRelationId.value();
 
 /// A data cell in a data row
 #[derive(Debug)]

--- a/supabase-wrappers/src/limit.rs
+++ b/supabase-wrappers/src/limit.rs
@@ -34,7 +34,8 @@ pub(crate) unsafe fn extract_limit(
 
     // only consider OFFSETS that are non-NULL constants
     let limit_offset = (*parse).limitOffset as *mut pg_sys::Const;
-    if !limit_offset.is_null() && is_a(limit_offset as *mut pg_sys::Node, pg_sys::NodeTag::T_Const) {
+    if !limit_offset.is_null() && is_a(limit_offset as *mut pg_sys::Node, pg_sys::NodeTag::T_Const)
+    {
         if let Some(offset) = i64::from_polymorphic_datum(
             (*limit_offset).constvalue,
             (*limit_offset).constisnull,


### PR DESCRIPTION
## What kind of change does this PR introduce?

After merged PR #205, there are some compilation warnings in `supabase-wrappers`, we need to deal with them.

## What is the current behavior?

N/A

## What is the new behavior?

N/A

## Additional context

When upstream pgrx merged [this PR](https://github.com/pgcentralfoundation/pgrx/pull/1432), we need to remove the temporary warning stopper.
