### PR TITLE
use unicode emojis instead of GH markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,19 +4,17 @@
 
 `Wrappers` is also a collection of FDWs built by [Supabase](https://www.supabase.com). We currently support the following FDWs, with more under development:
 
-| FDW | Description | Read | Modify | 
-|----------------|---------------|---------------|----------------|
-| [HelloWorld](./wrappers/src/fdw/helloworld_fdw) | A demo FDW to show how to develop a basic FDW. | | | 
-| [BigQuery](./wrappers/src/fdw/bigquery_fdw) | A FDW for Google [BigQuery](https://cloud.google.com/bigquery) | :white_check_mark: | :white_check_mark: | 
-| [Clickhouse](./wrappers/src/fdw/clickhouse_fdw)  | A FDW for [ClickHouse](https://clickhouse.com/) | :white_check_mark: | :white_check_mark: | 
-| [Stripe](./wrappers/src/fdw/stripe_fdw) | A FDW for [Stripe](https://stripe.com/) API | :white_check_mark: | :white_check_mark: |
-| [Firebase](./wrappers/src/fdw/firebase_fdw) | A FDW for Google [Firebase](https://firebase.google.com/) | :white_check_mark: | :x: |
-| [Airtable](./wrappers/src/fdw/airtable_fdw) | A FDW for [Airtable](https://airtable.com/) API | :white_check_mark: | :x: |
-| [S3](./wrappers/src/fdw/s3_fdw) | A FDW for [AWS S3](https://aws.amazon.com/s3/) | :white_check_mark: | :x: |
-| [Logflare](./wrappers/src/fdw/logflare_fdw) | A FDW for [Logflare](https://logflare.app/) | :white_check_mark: | :x: |
-| [Auth0](./wrappers/src/fdw/auth0_fdw) | A FDW for [Auth0](https://auth0.com/) | :white_check_mark: | :x: |
-
-
+| FDW                                             | Description                                                    | Read | Modify |
+| ----------------------------------------------- | -------------------------------------------------------------- | ---- | ------ |
+| [HelloWorld](./wrappers/src/fdw/helloworld_fdw) | A demo FDW to show how to develop a basic FDW.                 |      |        |
+| [BigQuery](./wrappers/src/fdw/bigquery_fdw)     | A FDW for Google [BigQuery](https://cloud.google.com/bigquery) | ✅   | ✅     |
+| [Clickhouse](./wrappers/src/fdw/clickhouse_fdw) | A FDW for [ClickHouse](https://clickhouse.com/)                | ✅   | ✅     |
+| [Stripe](./wrappers/src/fdw/stripe_fdw)         | A FDW for [Stripe](https://stripe.com/) API                    | ✅   | ✅     |
+| [Firebase](./wrappers/src/fdw/firebase_fdw)     | A FDW for Google [Firebase](https://firebase.google.com/)      | ✅   | ❌     |
+| [Airtable](./wrappers/src/fdw/airtable_fdw)     | A FDW for [Airtable](https://airtable.com/) API                | ✅   | ❌     |
+| [S3](./wrappers/src/fdw/s3_fdw)                 | A FDW for [AWS S3](https://aws.amazon.com/s3/)                 | ✅   | ❌     |
+| [Logflare](./wrappers/src/fdw/logflare_fdw)     | A FDW for [Logflare](https://logflare.app/)                    | ✅   | ❌     |
+| [Auth0](./wrappers/src/fdw/auth0_fdw)           | A FDW for [Auth0](https://auth0.com/)                          | ✅   | ❌     |
 
 ## Features
 
@@ -150,11 +148,8 @@ All contributions, feature requests, bug report or ideas are welcomed.
 
 [Apache License Version 2.0](./LICENSE)
 
-
 [![crates.io badge](https://img.shields.io/crates/v/supabase-wrappers.svg)](https://crates.io/crates/supabase-wrappers)
 [![docs.rs badge](https://docs.rs/supabase-wrappers/badge.svg)](https://docs.rs/supabase-wrappers)
 [![Test Status](https://img.shields.io/github/actions/workflow/status/supabase/wrappers/test_wrappers.yml?branch=main&label=test)](https://github.com/supabase/wrappers/actions/workflows/test_wrappers.yml)
 [![MIT/Apache-2 licensed](https://img.shields.io/crates/l/supabase-wrappers.svg)](./LICENSE)
 [![Contributors](https://img.shields.io/github/contributors/supabase/wrappers)](https://github.com/supabase/wrappers/graphs/contributors)
-
-

--- a/docs/airtable.md
+++ b/docs/airtable.md
@@ -1,4 +1,4 @@
-[Airtable](https://www.airtable.com) is an easy-to-use online platform for creating and sharing relational databases. 
+[Airtable](https://www.airtable.com) is an easy-to-use online platform for creating and sharing relational databases.
 
 The Airtable Wrapper allows you to read data from your Airtable bases/tables within your Postgres database.
 
@@ -59,11 +59,11 @@ We need to provide Postgres with the credentials to connect to Airtable, and any
 
 ## Creating Foreign Tables
 
-The Airtable Wrapper supports data reads from Airtable's [Records](https://airtable.com/developers/web/api/list-records) endpoint (*read only*).
+The Airtable Wrapper supports data reads from Airtable's [Records](https://airtable.com/developers/web/api/list-records) endpoint (_read only_).
 
-| Airtable    | Select            | Insert            | Update            | Delete            | Truncate          |
-| ----------- | :----:            | :----:            | :----:            | :----:            | :----:            |
-| Records     | :white_check_mark:| :x:               | :x:               | :x:               | :x:               |
+| Airtable | Select | Insert | Update | Delete | Truncate |
+| -------- | :----: | :----: | :----: | :----: | :------: |
+| Records  |   ✅   |   ❌   |   ❌   |   ❌   |    ❌    |
 
 For example:
 
@@ -97,7 +97,7 @@ Some examples on how to use Airtable foreign tables.
 
 ### Basic example
 
-This will create a "foreign table" inside your Postgres database called `airtable_table`: 
+This will create a "foreign table" inside your Postgres database called `airtable_table`:
 
 ```sql
 create foreign table airtable_table (

--- a/docs/bigquery.md
+++ b/docs/bigquery.md
@@ -4,17 +4,17 @@ The BigQuery Wrapper allows you to read and write data from BigQuery within your
 
 ## Supported Data Types
 
-| Postgres Type      | BigQuery Type   |
-| ------------------ | --------------- |
-| boolean            | BOOL            |
-| bigint             | INT64           |
-| double precision   | FLOAT64         |
-| numeric            | NUMERIC         |
-| text               | STRING          |
-| varchar            | STRING          |
-| date               | DATE            |
-| timestamp          | DATETIME        |
-| timestamp          | TIMESTAMP       |
+| Postgres Type    | BigQuery Type |
+| ---------------- | ------------- |
+| boolean          | BOOL          |
+| bigint           | INT64         |
+| double precision | FLOAT64       |
+| numeric          | NUMERIC       |
+| text             | STRING        |
+| varchar          | STRING        |
+| date             | DATE          |
+| timestamp        | DATETIME      |
+| timestamp        | TIMESTAMP     |
 
 ## Preparation
 
@@ -92,9 +92,9 @@ We need to provide Postgres with the credentials to connect to BigQuery, and any
 
 The BigQuery Wrapper supports data reads and writes from BigQuery.
 
-| Integration | Select            | Insert            | Update            | Delete            | Truncate          |
-| ----------- | :----:            | :----:            | :----:            | :----:            | :----:            |
-| BigQuery    | :white_check_mark:| :white_check_mark:| :white_check_mark:| :white_check_mark:| :x:               |
+| Integration | Select | Insert | Update | Delete | Truncate |
+| ----------- | :----: | :----: | :----: | :----: | :------: |
+| BigQuery    |   ✅   |   ✅   |   ✅   |   ✅   |    ❌    |
 
 For example:
 
@@ -117,13 +117,13 @@ The full list of foreign table options are below:
 
 - `table` - Source table or view name in BigQuery, required.
 
-   This can also be a subquery enclosed in parentheses, for example,
+  This can also be a subquery enclosed in parentheses, for example,
 
-   ```sql
-   table '(select * except(props), to_json_string(props) as props from `my_project.my_dataset.my_table`)'
-   ```
+  ```sql
+  table '(select * except(props), to_json_string(props) as props from `my_project.my_dataset.my_table`)'
+  ```
 
-   **Note**: When using subquery in this option, full qualitified table name must be used.
+  **Note**: When using subquery in this option, full qualitified table name must be used.
 
 - `location` - Source table location, optional. Default is 'US'.
 - `timeout` - Query request timeout in milliseconds, optional. Default is '30000' (30 seconds).
@@ -155,8 +155,8 @@ create table your_project_id.your_dataset_id.people (
 
 -- Add some test data
 insert into your_project_id.your_dataset_id.people values
-  (1, 'Luke Skywalker', current_timestamp()), 
-  (2, 'Leia Organa', current_timestamp()), 
+  (1, 'Luke Skywalker', current_timestamp()),
+  (2, 'Leia Organa', current_timestamp()),
   (3, 'Han Solo', current_timestamp());
 ```
 

--- a/docs/clickhouse.md
+++ b/docs/clickhouse.md
@@ -4,20 +4,20 @@ The ClickHouse Wrapper allows you to read and write data from ClickHouse within 
 
 ## Supported Data Types
 
-| Postgres Type      | ClickHouse Type   |
-| ------------------ | ----------------- |
-| boolean            | UInt8             |
-| smallint           | Int16             |
-| integer            | UInt16            |
-| integer            | Int32             |
-| bigint             | UInt32            |
-| bigint             | Int64             |
-| bigint             | UInt64            |
-| real               | Float32           |
-| double precision   | Float64           |
-| text               | String            |
-| date               | Date              |
-| timestamp          | DateTime          |
+| Postgres Type    | ClickHouse Type |
+| ---------------- | --------------- |
+| boolean          | UInt8           |
+| smallint         | Int16           |
+| integer          | UInt16          |
+| integer          | Int32           |
+| bigint           | UInt32          |
+| bigint           | Int64           |
+| bigint           | UInt64          |
+| real             | Float32         |
+| double precision | Float64         |
+| text             | String          |
+| date             | Date            |
+| timestamp        | DateTime        |
 
 ## Preparation
 
@@ -84,9 +84,9 @@ Check [more connection string parameters](https://github.com/suharev7/clickhouse
 
 The ClickHouse Wrapper supports data reads and writes from ClickHouse.
 
-| Integration | Select            | Insert            | Update            | Delete            | Truncate          |
-| ----------- | :----:            | :----:            | :----:            | :----:            | :----:            |
-| ClickHouse  | :white_check_mark:| :white_check_mark:| :white_check_mark:| :white_check_mark:| :x:               |
+| Integration | Select | Insert | Update | Delete | Truncate |
+| ----------- | :----: | :----: | :----: | :----: | :------: |
+| ClickHouse  |   ✅   |   ✅   |   ✅   |   ✅   |    ❌    |
 
 For example:
 
@@ -107,29 +107,29 @@ The full list of foreign table options are below:
 
 - `table` - Source table name in ClickHouse, required.
 
-   This can also be a subquery enclosed in parentheses, for example,
+  This can also be a subquery enclosed in parentheses, for example,
 
-   ```sql
-   table '(select * from my_table)'
-   ```
+  ```sql
+  table '(select * from my_table)'
+  ```
 
-   [Parametrized view](https://clickhouse.com/docs/en/sql-reference/statements/create/view#parameterized-view) is also supported in the subquery. In this case, you need to define a column for each parameter and use `where` to pass values to them. For example,
+  [Parametrized view](https://clickhouse.com/docs/en/sql-reference/statements/create/view#parameterized-view) is also supported in the subquery. In this case, you need to define a column for each parameter and use `where` to pass values to them. For example,
 
-   ```sql
-    create foreign table test_vw (
-      id bigint,
-      col1 text,
-      col2 bigint,
-      _param1 text,
-      _param2 bigint
-    )
-      server clickhouse_server
-      options (
-        table '(select * from my_view(column1=${_param1}, column2=${_param2}))'
-      );
+  ```sql
+   create foreign table test_vw (
+     id bigint,
+     col1 text,
+     col2 bigint,
+     _param1 text,
+     _param2 bigint
+   )
+     server clickhouse_server
+     options (
+       table '(select * from my_view(column1=${_param1}, column2=${_param2}))'
+     );
 
-    select * from test_vw where _param1='aaa' and _param2=32;
-   ```
+   select * from test_vw where _param1='aaa' and _param2=32;
+  ```
 
 - `rowid_column` - Primary key column name, optional for data scan, required for data modify
 
@@ -143,13 +143,13 @@ Some examples on how to use ClickHouse foreign tables.
 
 ### Basic example
 
-This will create a "foreign table" inside your Postgres database called `people`: 
+This will create a "foreign table" inside your Postgres database called `people`:
 
 ```sql
 -- Run below SQLs on ClickHouse to create source table
 drop table if exists people;
 create table people (
-    id Int64, 
+    id Int64,
     name String
 )
 engine=MergeTree()

--- a/docs/firebase.md
+++ b/docs/firebase.md
@@ -1,7 +1,7 @@
 [Firebase](https://firebase.google.com/) is an app development platform built around non-relational technologies. The Firebase Wrapper supports connecting to below objects.
 
-1. [Authentication Users](https://firebase.google.com/docs/auth/users) (*read only*)
-2. [Firestore Database Documents](https://firebase.google.com/docs/firestore) (*read only*)
+1. [Authentication Users](https://firebase.google.com/docs/auth/users) (_read only_)
+2. [Firestore Database Documents](https://firebase.google.com/docs/firestore) (_read only_)
 
 ## Preparation
 
@@ -73,10 +73,10 @@ We need to provide Postgres with the credentials to connect to Firebase, and any
 
 The Firebase Wrapper supports reading data from below Firebase's objects:
 
-| Firebase                     | Select            | Insert     | Update     | Delete   | Truncate          |
-| -----------                  | :----:            | :----:     | :----:     | :----:   | :----:            |
-| Authentication Users         | :white_check_mark:| :x:        | :x:        | :x:      | :x:               |
-| Firestore Database Documents | :white_check_mark:| :x:        | :x:        | :x:      | :x:               |
+| Firebase                     | Select | Insert | Update | Delete | Truncate |
+| ---------------------------- | :----: | :----: | :----: | :----: | :------: |
+| Authentication Users         |   ✅   |   ❌   |   ❌   |   ❌   |    ❌    |
+| Firestore Database Documents |   ✅   |   ❌   |   ❌   |   ❌   |    ❌    |
 
 For example:
 
@@ -93,7 +93,7 @@ create foreign table firebase_users (
   );
 ```
 
-Note there is a meta column `attrs` in the foreign table, which contains all the returned data from Firebase as json format. 
+Note there is a meta column `attrs` in the foreign table, which contains all the returned data from Firebase as json format.
 
 ### Foreign table options
 
@@ -133,8 +133,7 @@ create foreign table firebase_docs (
 
 Note that `name`, `created_at`, and `updated_at`, are automatic metadata fields on all Firestore collections.
 
-
-### auth/users 
+### auth/users
 
 The `auth/users` collection is a special case with unique metadata. The following shows how to map Firebase users to PostgreSQL table.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,6 +20,7 @@
 `supabase/wrappers` is a PostgreSQL extension that provides integrations with external sources so you can interact with third-party data using SQL.
 
 For example, the Stripe wrapper allows you to query and join against your Stripe customer data straight from PostgreSQL:
+
 ```sql
 select
   customer_id
@@ -27,22 +28,24 @@ select
 from
    stripe.customers;
 ```
+
 returns
+
 ```
-    customer_id     | currency 
+    customer_id     | currency
 --------------------+-----------
- cus_MJiBtCqOF1Bb3F | usd      
+ cus_MJiBtCqOF1Bb3F | usd
 (1 row)
 ```
 
 Currently `supabase/wrappers` supports:
 
-| Integration | Select            | Insert            | Update            | Delete            | Truncate          |
-| ----------- | :----:            | :----:            | :----:            | :----:            | :----:            |
-| Airtable    | :white_check_mark:| :x:               | :x:               | :x:               | :x:               |
-| BigQuery    | :white_check_mark:| :white_check_mark:| :white_check_mark:| :white_check_mark:| :x:               |
-| ClickHouse  | :white_check_mark:| :white_check_mark:| :white_check_mark:| :white_check_mark:| :x:               |
-| Firebase    | :white_check_mark:| :x:               | :x:               | :x:               | :x:               |
-| Logflare    | :white_check_mark:| :x:               | :x:               | :x:               | :x:               |
-| S3          | :white_check_mark:| :x:               | :x:               | :x:               | :x:               |
-| Stripe      | :white_check_mark:| :white_check_mark:| :white_check_mark:| :white_check_mark:| :x:               |
+| Integration | Select | Insert | Update | Delete | Truncate |
+| ----------- | :----: | :----: | :----: | :----: | :------: |
+| Airtable    |   ✅   |   ❌   |   ❌   |   ❌   |    ❌    |
+| BigQuery    |   ✅   |   ✅   |   ✅   |   ✅   |    ❌    |
+| ClickHouse  |   ✅   |   ✅   |   ✅   |   ✅   |    ❌    |
+| Firebase    |   ✅   |   ❌   |   ❌   |   ❌   |    ❌    |
+| Logflare    |   ✅   |   ❌   |   ❌   |   ❌   |    ❌    |
+| S3          |   ✅   |   ❌   |   ❌   |   ❌   |    ❌    |
+| Stripe      |   ✅   |   ✅   |   ✅   |   ✅   |    ❌    |

--- a/docs/logflare.md
+++ b/docs/logflare.md
@@ -60,9 +60,9 @@ We need to provide Postgres with the credentials to connect to Logflare, and any
 
 The Logflare Wrapper supports data reads from Logflare's endpoints.
 
-| Integration | Select            | Insert            | Update            | Delete            | Truncate          |
-| ----------- | :----:            | :----:            | :----:            | :----:            | :----:            |
-| Logflare    | :white_check_mark:| :x:               | :x:               | :x:               | :x:               |
+| Integration | Select | Insert | Update | Delete | Truncate |
+| ----------- | :----: | :----: | :----: | :----: | :------: |
+| Logflare    |   ✅   |   ❌   |   ❌   |   ❌   |    ❌    |
 
 For example:
 
@@ -183,4 +183,3 @@ where _param_org_id = 123
   and _param_iso_timestamp_start = '2023-07-01 02:03:04'
   and _param_iso_timestamp_end = '2023-07-02';
 ```
-

--- a/docs/s3.md
+++ b/docs/s3.md
@@ -21,19 +21,19 @@ The S3 Wrapper also supports below compression algorithms:
 
 The S3 Wrapper uses Parquet file data types from [arrow_array::types](https://docs.rs/arrow-array/41.0.0/arrow_array/types/index.html), below are their mappings to Postgres data types.
 
-| Postgres Type      | Parquet Type             |
-| ------------------ | ------------------------ |
-| boolean            | BooleanType              |
-| char               | Int8Type                 |
-| smallint           | Int16Type                |
-| real               | Float32Type              |
-| integer            | Int32Type                |
-| double precision   | Float64Type              |
-| bigint             | Int64Type                |
-| numeric            | Float64Type              |
-| text               | ByteArrayType            |
-| date               | Date64Type               |
-| timestamp          | TimestampNanosecondType  |
+| Postgres Type    | Parquet Type            |
+| ---------------- | ----------------------- |
+| boolean          | BooleanType             |
+| char             | Int8Type                |
+| smallint         | Int16Type               |
+| real             | Float32Type             |
+| integer          | Int32Type               |
+| double precision | Float64Type             |
+| bigint           | Int64Type               |
+| numeric          | Float64Type             |
+| text             | ByteArrayType           |
+| date             | Date64Type              |
+| timestamp        | TimestampNanosecondType |
 
 ## Preparation
 
@@ -104,9 +104,9 @@ We need to provide Postgres with the credentials to connect to S3, and any addit
 
 The S3 Wrapper supports data reads from S3.
 
-| Integration | Select            | Insert            | Update            | Delete            | Truncate          |
-| ----------- | :----:            | :----:            | :----:            | :----:            | :----:            |
-| S3          | :white_check_mark:| :x:               | :x:               | :x:               | :x:               |
+| Integration | Select | Insert | Update | Delete | Truncate |
+| ----------- | :----: | :----: | :----: | :----: | :------: |
+| S3          |   ✅   |   ❌   |   ❌   |   ❌   |    ❌    |
 
 For example:
 
@@ -129,7 +129,6 @@ create foreign table s3_table_csv (
 One file in S3 corresponds a foreign table in Postgres. For CSV and JSONL file, all columns must be present in the foreign table and type must be `text`. You can do custom transformations, like type conversion, by creating a view on top of the foreign table or using a subquery.
 
 For Parquet file, no need to define all columns in the foreign table but column names must match between Parquet file and its foreign table.
-
 
 ### Foreign table options
 
@@ -229,4 +228,3 @@ create foreign table s3_table_parquet_gz (
     compress 'gzip'
   );
 ```
-

--- a/docs/stripe.md
+++ b/docs/stripe.md
@@ -58,31 +58,31 @@ We need to provide Postgres with the credentials to connect to Stripe, and any a
 
 The Stripe Wrapper supports data read and modify from Stripe API.
 
-| Object      | Select            | Insert            | Update            | Delete            | Truncate          |
-| ----------- | :----:            | :----:            | :----:            | :----:            | :----:            |
-| [Accounts](https://stripe.com/docs/api/accounts/list)     | :white_check_mark:| :x:               | :x:               | :x:               | :x:               |
-| [Balance](https://stripe.com/docs/api/balance)     | :white_check_mark:| :x:               | :x:               | :x:               | :x:               |
-| [Balance Transactions](https://stripe.com/docs/api/balance_transactions/list)     | :white_check_mark:| :x:               | :x:               | :x:               | :x:               |
-| [Charges](https://stripe.com/docs/api/charges/list)     | :white_check_mark:| :x:               | :x:               | :x:               | :x:               |
-| [Checkout Sessions](https://stripe.com/docs/api/checkout/sessions/list)     | :white_check_mark:| :x:               | :x:               | :x:               | :x:               |
-| [Customers](https://stripe.com/docs/api/customers/list)     | :white_check_mark:| :white_check_mark:| :white_check_mark:| :white_check_mark:| :x:               |
-| [Disputes](https://stripe.com/docs/api/disputes/list)     | :white_check_mark:| :x:               | :x:               | :x:               | :x:               |
-| [Events](https://stripe.com/docs/api/events/list)     | :white_check_mark:| :x:               | :x:               | :x:               | :x:               |
-| [Files](https://stripe.com/docs/api/files/list)     | :white_check_mark:| :x:               | :x:               | :x:               | :x:               |
-| [File Links](https://stripe.com/docs/api/file_links/list)     | :white_check_mark:| :x:               | :x:               | :x:               | :x:               |
-| [Invoices](https://stripe.com/docs/api/invoices/list)     | :white_check_mark:| :x:               | :x:               | :x:               | :x:               |
-| [Mandates](https://stripe.com/docs/api/mandates)     | :white_check_mark:| :x:               | :x:               | :x:               | :x:               |
-| [PaymentIntents](https://stripe.com/docs/api/payment_intents/list)     | :white_check_mark:| :x:               | :x:               | :x:               | :x:               |
-| [Payouts](https://stripe.com/docs/api/payouts/list)     | :white_check_mark:| :x:               | :x:               | :x:               | :x:               |
-| [Prices](https://stripe.com/docs/api/prices/list)     | :white_check_mark:| :x:               | :x:               | :x:               | :x:               |
-| [Products](https://stripe.com/docs/api/products/list)     | :white_check_mark:| :white_check_mark:| :white_check_mark:| :white_check_mark:| :x:               |
-| [Refunds](https://stripe.com/docs/api/refunds/list)     | :white_check_mark:| :x:               | :x:               | :x:               | :x:               |
-| [SetupAttempts](https://stripe.com/docs/api/setup_attempts/list)     | :white_check_mark:| :x:               | :x:               | :x:               | :x:               |
-| [SetupIntents](https://stripe.com/docs/api/setup_intents/list)     | :white_check_mark:| :x:               | :x:               | :x:               | :x:               |
-| [Subscriptions](https://stripe.com/docs/api/subscriptions/list)     | :white_check_mark:| :white_check_mark:| :white_check_mark:| :white_check_mark:| :x:               |
-| [Tokens](https://stripe.com/docs/api/tokens)     | :white_check_mark:| :x:               | :x:               | :x:               | :x:               |
-| [Topups](https://stripe.com/docs/api/topups/list)     | :white_check_mark:| :x:               | :x:               | :x:               | :x:               |
-| [Transfers](https://stripe.com/docs/api/transfers/list)     | :white_check_mark:| :x:               | :x:               | :x:               | :x:               |
+| Object                                                                        | Select | Insert | Update | Delete | Truncate |
+| ----------------------------------------------------------------------------- | :----: | :----: | :----: | :----: | :------: |
+| [Accounts](https://stripe.com/docs/api/accounts/list)                         |   ✅   |   ❌   |   ❌   |   ❌   |    ❌    |
+| [Balance](https://stripe.com/docs/api/balance)                                |   ✅   |   ❌   |   ❌   |   ❌   |    ❌    |
+| [Balance Transactions](https://stripe.com/docs/api/balance_transactions/list) |   ✅   |   ❌   |   ❌   |   ❌   |    ❌    |
+| [Charges](https://stripe.com/docs/api/charges/list)                           |   ✅   |   ❌   |   ❌   |   ❌   |    ❌    |
+| [Checkout Sessions](https://stripe.com/docs/api/checkout/sessions/list)       |   ✅   |   ❌   |   ❌   |   ❌   |    ❌    |
+| [Customers](https://stripe.com/docs/api/customers/list)                       |   ✅   |   ✅   |   ✅   |   ✅   |    ❌    |
+| [Disputes](https://stripe.com/docs/api/disputes/list)                         |   ✅   |   ❌   |   ❌   |   ❌   |    ❌    |
+| [Events](https://stripe.com/docs/api/events/list)                             |   ✅   |   ❌   |   ❌   |   ❌   |    ❌    |
+| [Files](https://stripe.com/docs/api/files/list)                               |   ✅   |   ❌   |   ❌   |   ❌   |    ❌    |
+| [File Links](https://stripe.com/docs/api/file_links/list)                     |   ✅   |   ❌   |   ❌   |   ❌   |    ❌    |
+| [Invoices](https://stripe.com/docs/api/invoices/list)                         |   ✅   |   ❌   |   ❌   |   ❌   |    ❌    |
+| [Mandates](https://stripe.com/docs/api/mandates)                              |   ✅   |   ❌   |   ❌   |   ❌   |    ❌    |
+| [PaymentIntents](https://stripe.com/docs/api/payment_intents/list)            |   ✅   |   ❌   |   ❌   |   ❌   |    ❌    |
+| [Payouts](https://stripe.com/docs/api/payouts/list)                           |   ✅   |   ❌   |   ❌   |   ❌   |    ❌    |
+| [Prices](https://stripe.com/docs/api/prices/list)                             |   ✅   |   ❌   |   ❌   |   ❌   |    ❌    |
+| [Products](https://stripe.com/docs/api/products/list)                         |   ✅   |   ✅   |   ✅   |   ✅   |    ❌    |
+| [Refunds](https://stripe.com/docs/api/refunds/list)                           |   ✅   |   ❌   |   ❌   |   ❌   |    ❌    |
+| [SetupAttempts](https://stripe.com/docs/api/setup_attempts/list)              |   ✅   |   ❌   |   ❌   |   ❌   |    ❌    |
+| [SetupIntents](https://stripe.com/docs/api/setup_intents/list)                |   ✅   |   ❌   |   ❌   |   ❌   |    ❌    |
+| [Subscriptions](https://stripe.com/docs/api/subscriptions/list)               |   ✅   |   ✅   |   ✅   |   ✅   |    ❌    |
+| [Tokens](https://stripe.com/docs/api/tokens)                                  |   ✅   |   ❌   |   ❌   |   ❌   |    ❌    |
+| [Topups](https://stripe.com/docs/api/topups/list)                             |   ✅   |   ❌   |   ❌   |   ❌   |    ❌    |
+| [Transfers](https://stripe.com/docs/api/transfers/list)                       |   ✅   |   ❌   |   ❌   |   ❌   |    ❌    |
 
 The Stripe foreign tables mirror Stripe's API. We can create a schema to hold all the Stripe tables.
 
@@ -111,7 +111,8 @@ create foreign table stripe.accounts (
 `attrs` is a special column which stores all the object attributes in JSON format, you can extract any attributes needed or its associated sub objects from it. See more examples below.
 
 ### Accounts
-*read only*
+
+_read only_
 
 This is an object representing a Stripe account.
 
@@ -138,7 +139,8 @@ While any column is allowed in a where clause, it is most efficient to filter by
 - id
 
 ### Balance
-*read only*
+
+_read only_
 
 Shows the balance currently on your Stripe account.
 
@@ -158,7 +160,8 @@ create foreign table stripe.balance (
 ```
 
 ### Balance Transactions
-*read only*
+
+_read only_
 
 Balance transactions represent funds moving through your Stripe account. They're created for every type of transaction that comes into or flows out of your Stripe account balance.
 
@@ -189,7 +192,8 @@ While any column is allowed in a where clause, it is most efficient to filter by
 - type
 
 ### Charges
-*read only*
+
+_read only_
 
 To charge a credit or a debit card, you create a Charge object. You can retrieve and refund individual charges as well as list all charges. Charges are identified by a unique, random ID.
 
@@ -221,7 +225,7 @@ While any column is allowed in a where clause, it is most efficient to filter by
 
 ### Checkout Sessions
 
-*read only*
+_read only_
 
 A Checkout Session represents your customer's session as they pay for one-time purchases or subscriptions through Checkout or Payment Links. We recommend creating a new Session each time your customer attempts to pay.
 
@@ -250,7 +254,8 @@ While any column is allowed in a where clause, it is most efficient to filter by
 - subscription
 
 ### Customers
-*read and modify*
+
+_read and modify_
 
 Contains customers known to Stripe.
 
@@ -278,7 +283,8 @@ While any column is allowed in a where clause, it is most efficient to filter by
 - email
 
 ### Disputes
-*read only*
+
+_read only_
 
 A dispute occurs when a customer questions your charge with their card issuer.
 
@@ -309,7 +315,8 @@ While any column is allowed in a where clause, it is most efficient to filter by
 - payment_intent
 
 ### Events
-*read only*
+
+_read only_
 
 Events are our way of letting you know when something interesting happens in your account.
 
@@ -335,7 +342,8 @@ While any column is allowed in a where clause, it is most efficient to filter by
 - type
 
 ### Files
-*read only*
+
+_read only_
 
 This is an object representing a file hosted on Stripe's servers.
 
@@ -366,7 +374,8 @@ While any column is allowed in a where clause, it is most efficient to filter by
 - purpose
 
 ### File Links
-*read only*
+
+_read only_
 
 To share the contents of a `File` object with non-Stripe users, you can create a `FileLink`.
 
@@ -389,7 +398,8 @@ create foreign table stripe.file_links (
 ```
 
 ### Invoices
-*read only*
+
+_read only_
 
 Invoices are statements of amounts owed by a customer, and are either generated one-off, or generated periodically from a subscription.
 
@@ -422,7 +432,8 @@ While any column is allowed in a where clause, it is most efficient to filter by
 - subscription
 
 ### Mandates
-*read only*
+
+_read only_
 
 A Mandate is a record of the permission a customer has given you to debit their payment method.
 
@@ -446,9 +457,9 @@ While any column is allowed in a where clause, it is most efficient to filter by
 
 - id
 
-
 ### Payment Intents
-*read only*
+
+_read only_
 
 A payment intent guides you through the process of collecting a payment from your customer.
 
@@ -476,7 +487,8 @@ While any column is allowed in a where clause, it is most efficient to filter by
 - customer
 
 ### Payouts
-*read only*
+
+_read only_
 
 A `Payout` object is created when you receive funds from Stripe, or when you initiate a payout to either a bank account or debit card of a connected Stripe account.
 
@@ -506,7 +518,8 @@ While any column is allowed in a where clause, it is most efficient to filter by
 - status
 
 ### Prices
-*read only*
+
+_read only_
 
 A `Price` object is needed for all of your products to facilitate multiple currencies and pricing options.
 
@@ -535,7 +548,8 @@ While any column is allowed in a where clause, it is most efficient to filter by
 - active
 
 ### Products
-*read and modify*
+
+_read and modify_
 
 All products available in Stripe.
 
@@ -565,7 +579,8 @@ While any column is allowed in a where clause, it is most efficient to filter by
 - active
 
 ### Refunds
-*read only*
+
+_read only_
 
 `Refund` objects allow you to refund a charge that has previously been created but not yet refunded.
 
@@ -596,7 +611,8 @@ While any column is allowed in a where clause, it is most efficient to filter by
 - payment_intent
 
 ### SetupAttempts
-*read only*
+
+_read only_
 
 A `SetupAttempt` describes one attempted confirmation of a SetupIntent, whether that confirmation was successful or unsuccessful.
 
@@ -627,7 +643,8 @@ While any column is allowed in a where clause, it is most efficient to filter by
 - setup_intent
 
 ### SetupIntents
-*read only*
+
+_read only_
 
 A `SetupIntent` guides you through the process of setting up and saving a customer's payment credentials for future payments.
 
@@ -658,12 +675,12 @@ While any column is allowed in a where clause, it is most efficient to filter by
 - payment_method
 
 ### Subscriptions
-*read and modify*
+
+_read and modify_
 
 Customer recurring payment schedules.
 
 Ref: [Stripe docs](https://stripe.com/docs/api/subscriptions/list)
-
 
 ```sql
 create foreign table stripe.subscriptions (
@@ -689,7 +706,8 @@ While any column is allowed in a where clause, it is most efficient to filter by
 - status
 
 ### Tokens
-*read only*
+
+_read only_
 
 Tokenization is the process Stripe uses to collect sensitive card or bank account details, or personally identifiable information (PII), directly from your customers in a secure manner.
 
@@ -711,7 +729,8 @@ create foreign table stripe.tokens (
 ```
 
 ### Top-ups
-*read only*
+
+_read only_
 
 To top up your Stripe balance, you create a top-up object.
 
@@ -739,7 +758,8 @@ While any column is allowed in a where clause, it is most efficient to filter by
 - status
 
 ### Transfers
-*read only*
+
+_read only_
 
 A Transfer object is created when you move funds between Stripe accounts as part of Connect.
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

Docs used GH specific markdown syntax to show emojis which did not render correctly on some sites like trunk. See this e.g.: https://pgt.dev/extensions/wrappers

## What is the new behavior?

We use unicode emojis which should be supported by more platforms because it is just unicode.

## Additional context

Fixes #211. The whitespace and other formatting changes are done automatically by vscode when saving a file.