### PR TITLE
ci: add `cargo fmt` and `cargo clippy` checks to CI

### DIFF
--- a/.github/workflows/test_supabase_wrappers.yml
+++ b/.github/workflows/test_supabase_wrappers.yml
@@ -18,6 +18,14 @@ jobs:
       with:
         toolchain: stable
 
+    - name: Format code
+      run: |
+        cd supabase-wrappers && cargo fmt --check
+
+    - name: Run clippy
+      run: |
+        cd supabase-wrappers && cargo clippy --all --tests --no-deps
+
     - run: |
         sudo apt remove -y postgres*
         sudo apt-get install -y wget gnupg

--- a/.github/workflows/test_supabase_wrappers.yml
+++ b/.github/workflows/test_supabase_wrappers.yml
@@ -18,14 +18,6 @@ jobs:
       with:
         toolchain: stable
 
-    - name: Format code
-      run: |
-        cd supabase-wrappers && cargo fmt --check
-
-    - name: Run clippy
-      run: |
-        cd supabase-wrappers && cargo clippy --all --tests --no-deps
-
     - run: |
         sudo apt remove -y postgres*
         sudo apt-get install -y wget gnupg
@@ -50,4 +42,13 @@ jobs:
 
     - run: cargo install cargo-pgrx --version 0.11.2
     - run: cargo pgrx init --pg15 /usr/lib/postgresql/15/bin/pg_config
+
+    - name: Format code
+      run: |
+        cd supabase-wrappers && cargo fmt --check
+
+    - name: Run clippy
+      run: |
+        cd supabase-wrappers && cargo clippy --all --tests --no-deps
+
     - run: cd supabase-wrappers && cargo test

--- a/.github/workflows/test_supabase_wrappers.yml
+++ b/.github/workflows/test_supabase_wrappers.yml
@@ -49,6 +49,6 @@ jobs:
 
     - name: Run clippy
       run: |
-        cd supabase-wrappers && cargo clippy --all --tests --no-deps
+        cd supabase-wrappers && RUSTFLAGS="-D warnings" cargo clippy --all --tests --no-deps
 
     - run: cd supabase-wrappers && cargo test

--- a/.github/workflows/test_wrappers.yml
+++ b/.github/workflows/test_wrappers.yml
@@ -24,11 +24,11 @@ jobs:
 
     - name: Format code
       run: |
-        cargo fmt --check
+        cd wrappers && cargo fmt --check
 
     - name: Run clippy
       run: |
-        cargo clippy --all --tests --no-deps --features all_fdws,helloworld_fdw
+        cd wrappers && cargo clippy --all --tests --no-deps --features all_fdws,helloworld_fdw
 
     - run: |
         sudo apt remove -y postgres*

--- a/.github/workflows/test_wrappers.yml
+++ b/.github/workflows/test_wrappers.yml
@@ -22,14 +22,6 @@ jobs:
       with:
         toolchain: stable
 
-    - name: Format code
-      run: |
-        cd wrappers && cargo fmt --check
-
-    - name: Run clippy
-      run: |
-        cd wrappers && cargo clippy --all --tests --no-deps --features all_fdws,helloworld_fdw
-
     - run: |
         sudo apt remove -y postgres*
         sudo apt-get install -y wget gnupg
@@ -54,4 +46,13 @@ jobs:
 
     - run: cargo install cargo-pgrx --version 0.11.2
     - run: cargo pgrx init --pg15 /usr/lib/postgresql/15/bin/pg_config
+
+    - name: Format code
+      run: |
+        cd wrappers && cargo fmt --check
+
+    - name: Run clippy
+      run: |
+        cd wrappers && cargo clippy --all --tests --no-deps --features all_fdws,helloworld_fdw
+
     - run: cd wrappers && cargo pgrx test --features all_fdws,pg15

--- a/.github/workflows/test_wrappers.yml
+++ b/.github/workflows/test_wrappers.yml
@@ -53,6 +53,6 @@ jobs:
 
     - name: Run clippy
       run: |
-        cd wrappers && cargo clippy --all --tests --no-deps --features all_fdws,helloworld_fdw
+        cd wrappers && RUSTFLAGS="-D warnings" cargo clippy --all --tests --no-deps --features all_fdws,helloworld_fdw
 
     - run: cd wrappers && cargo pgrx test --features all_fdws,pg15

--- a/.github/workflows/test_wrappers.yml
+++ b/.github/workflows/test_wrappers.yml
@@ -22,6 +22,14 @@ jobs:
       with:
         toolchain: stable
 
+    - name: Format code
+      run: |
+        cargo fmt --check
+
+    - name: Run clippy
+      run: |
+        cargo clippy --all --tests --no-deps --features all_fdws,helloworld_fdw
+
     - run: |
         sudo apt remove -y postgres*
         sudo apt-get install -y wget gnupg

--- a/supabase-wrappers/src/qual.rs
+++ b/supabase-wrappers/src/qual.rs
@@ -58,7 +58,7 @@ pub(crate) unsafe fn form_array_from_datum(
 pub(crate) unsafe fn get_operator(opno: pg_sys::Oid) -> pg_sys::Form_pg_operator {
     let htup = pg_sys::SearchSysCache1(
         pg_sys::SysCacheIdentifier_OPEROID.try_into().unwrap(),
-        opno.try_into().unwrap(),
+        opno.into(),
     );
     if htup.is_null() {
         pg_sys::ReleaseSysCache(htup);

--- a/wrappers/src/fdw/auth0_fdw/auth0_client/rows_iterator.rs
+++ b/wrappers/src/fdw/auth0_fdw/auth0_client/rows_iterator.rs
@@ -58,12 +58,10 @@ impl Iterator for RowsIterator {
     fn next(&mut self) -> Option<Self::Item> {
         if let Some(row) = self.get_next_row() {
             Some(Ok(row))
+        } else if self.have_more_rows {
+            self.fetch_rows_batch().transpose()
         } else {
-            if self.have_more_rows {
-                self.fetch_rows_batch().transpose()
-            } else {
-                None
-            }
+            None
         }
     }
 }

--- a/wrappers/src/fdw/clickhouse_fdw/mod.rs
+++ b/wrappers/src/fdw/clickhouse_fdw/mod.rs
@@ -2,6 +2,7 @@
 mod clickhouse_fdw;
 mod tests;
 
+use pgrx::datum::datetime_support::DateTimeConversionError;
 use pgrx::pg_sys::panic::ErrorReport;
 use pgrx::prelude::PgSqlErrorCode;
 use thiserror::Error;
@@ -18,6 +19,9 @@ enum ClickHouseFdwError {
 
     #[error("column data type '{0}' is not supported")]
     UnsupportedColumnType(String),
+
+    #[error("datetime conversion error: {0}")]
+    DatetimeConversionError(#[from] DateTimeConversionError),
 
     #[error("datetime parse error: {0}")]
     DatetimeParseError(#[from] chrono::format::ParseError),

--- a/wrappers/src/fdw/stripe_fdw/tests.rs
+++ b/wrappers/src/fdw/stripe_fdw/tests.rs
@@ -527,10 +527,7 @@ mod tests {
                         .zip(r.get_by_name::<&str, _>("type").unwrap())
                 })
                 .collect::<Vec<_>>();
-            assert_eq!(
-                results,
-                vec![(((((100, "usd"), 0), "available"), "charge"))]
-            );
+            assert_eq!(results, vec![((((100, "usd"), 0), "available"), "charge")]);
 
             let results = c
                 .select("SELECT * FROM stripe_charges", None, None)
@@ -542,7 +539,7 @@ mod tests {
                         .zip(r.get_by_name::<&str, _>("status").unwrap())
                 })
                 .collect::<Vec<_>>();
-            assert_eq!(results, vec![(((100, "usd"), "succeeded"))]);
+            assert_eq!(results, vec![((100, "usd"), "succeeded")]);
 
             let results = c
                 .select("SELECT * FROM stripe_customers", None, None)

--- a/wrappers/src/fdw/stripe_fdw/tests.rs
+++ b/wrappers/src/fdw/stripe_fdw/tests.rs
@@ -552,10 +552,7 @@ mod tests {
                 .collect::<Vec<_>>();
             assert_eq!(
                 results,
-                vec![(
-                    "cus_MJiBgSUgeWFN0z",
-                    Timestamp::from(287883090000000i64)
-                )]
+                vec![("cus_MJiBgSUgeWFN0z", Timestamp::from(287883090000000i64))]
             );
 
             let results = c

--- a/wrappers/src/fdw/stripe_fdw/tests.rs
+++ b/wrappers/src/fdw/stripe_fdw/tests.rs
@@ -554,7 +554,7 @@ mod tests {
                 results,
                 vec![(
                     "cus_MJiBgSUgeWFN0z",
-                    Timestamp::try_from(287883090000000i64).unwrap()
+                    Timestamp::from(287883090000000i64)
                 )]
             );
 
@@ -822,9 +822,9 @@ mod tests {
                 vec![(
                     (
                         ("cus_MJiBtCqOF1Bb3F", "usd"),
-                        Timestamp::try_from(287883090000000i64).unwrap()
+                        Timestamp::from(287883090000000i64)
                     ),
-                    Timestamp::try_from(287883090000000i64).unwrap()
+                    Timestamp::from(287883090000000i64)
                 )]
             );
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is mainly to add below 2 checking tasks to CI, these will enforce code formation and also make clippy happy.

- `cargo fmt`
- `cargo clippy`

Some code has been improved to make those 2 tasks working.

## What is the current behavior?

N/A

## What is the new behavior?

N/A

## Additional context

N/A
