### PR TITLE
feat: pin clickhouse.rs to fixed commit 

### DIFF
--- a/wrappers/Cargo.toml
+++ b/wrappers/Cargo.toml
@@ -123,7 +123,7 @@ pgrx = { version = "=0.11.2" }
 supabase-wrappers = { path = "../supabase-wrappers", default-features = false }
 
 # for clickhouse_fdw
-clickhouse-rs = { git = "https://github.com/suharev7/clickhouse-rs", branch = "async-await", rev = "afd8ce5", features = [
+clickhouse-rs = { git = "https://github.com/suharev7/clickhouse-rs", rev = "afd8ce5", features = [
     "tls",
 ], optional = true }
 chrono = { version = "0.4", optional = true }

--- a/wrappers/Cargo.toml
+++ b/wrappers/Cargo.toml
@@ -123,7 +123,7 @@ pgrx = { version = "=0.11.2" }
 supabase-wrappers = { path = "../supabase-wrappers", default-features = false }
 
 # for clickhouse_fdw
-clickhouse-rs = { git = "https://github.com/suharev7/clickhouse-rs", rev = "afd8ce5", features = [
+clickhouse-rs = { git = "https://github.com/suharev7/clickhouse-rs", rev = "ecf28f4677", features = [
     "tls",
 ], optional = true }
 chrono = { version = "0.4", optional = true }

--- a/wrappers/Cargo.toml
+++ b/wrappers/Cargo.toml
@@ -123,7 +123,7 @@ pgrx = { version = "=0.11.2" }
 supabase-wrappers = { path = "../supabase-wrappers", default-features = false }
 
 # for clickhouse_fdw
-clickhouse-rs = { git = "https://github.com/suharev7/clickhouse-rs", branch = "async-await", features = [
+clickhouse-rs = { git = "https://github.com/suharev7/clickhouse-rs", branch = "async-await", rev = "afd8ce5", features = [
     "tls",
 ], optional = true }
 chrono = { version = "0.4", optional = true }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Pin clickhouse.rs to a fixed commit so that type or function signature changes in the library do not affect wrappers.

As only one of `branch` and `rev` can be used we drop the `branch` specifier.
