### PR TITLE
update cargo.lock

### DIFF
--- a/wrappers/Cargo.lock
+++ b/wrappers/Cargo.lock
@@ -1058,7 +1058,7 @@ checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
 [[package]]
 name = "clickhouse-rs"
 version = "1.0.0-alpha.1"
-source = "git+https://github.com/suharev7/clickhouse-rs?branch=async-await#ecf28f46774773f39c74ee5213ad1e3ea240739b"
+source = "git+https://github.com/suharev7/clickhouse-rs?rev=ecf28f4677#ecf28f46774773f39c74ee5213ad1e3ea240739b"
 dependencies = [
  "byteorder",
  "chrono",
@@ -1087,7 +1087,7 @@ dependencies = [
 [[package]]
 name = "clickhouse-rs-cityhash-sys"
 version = "0.1.2"
-source = "git+https://github.com/suharev7/clickhouse-rs?branch=async-await#ecf28f46774773f39c74ee5213ad1e3ea240739b"
+source = "git+https://github.com/suharev7/clickhouse-rs?rev=ecf28f4677#ecf28f46774773f39c74ee5213ad1e3ea240739b"
 dependencies = [
  "cc",
 ]


### PR DESCRIPTION
`Cargo.lock` file was not commited after recent changes in clickhouse dependency. This PR updates `Cargo.lock`.