### PR TITLE
chore: release supabase-wrappers v0.1.16 on crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4034,7 +4034,7 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "supabase-wrappers"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "pgrx",
  "pgrx-tests",

--- a/supabase-wrappers/Cargo.toml
+++ b/supabase-wrappers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "supabase-wrappers"
-version = "0.1.15"
+version = "0.1.16"
 edition = "2021"
 authors = ["Supabase Inc. https://supabase.com/"]
 license = "Apache-2.0"


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to increase version number of supabase-wrappers to v0.1.16, so it can be released on crates.io.

## What is the current behavior?

N/A

## What is the new behavior?

N/A

## Additional context

N/A
