### PR TITLE
chore(s3): add not use existing create_async_runtime() comment

### DIFF
--- a/wrappers/src/fdw/s3_fdw/s3_fdw.rs
+++ b/wrappers/src/fdw/s3_fdw/s3_fdw.rs
@@ -113,7 +113,10 @@ impl S3Fdw {
 
 impl ForeignDataWrapper<S3FdwError> for S3Fdw {
     fn new(options: &HashMap<String, String>) -> S3FdwResult<Self> {
-        let rt = create_async_runtime()?;
+        // cannot use create_async_runtime() as the runtime needs to be created
+        // for multiple threads
+        let rt = tokio::runtime::Runtime::new()
+            .map_err(CreateRuntimeError::FailedToCreateAsyncRuntime)?;
         let mut ret = S3Fdw {
             rt,
             client: None,

--- a/wrappers/src/fdw/s3_fdw/s3_fdw.rs
+++ b/wrappers/src/fdw/s3_fdw/s3_fdw.rs
@@ -113,8 +113,7 @@ impl S3Fdw {
 
 impl ForeignDataWrapper<S3FdwError> for S3Fdw {
     fn new(options: &HashMap<String, String>) -> S3FdwResult<Self> {
-        let rt = tokio::runtime::Runtime::new()
-            .map_err(CreateRuntimeError::FailedToCreateAsyncRuntime)?;
+        let rt = create_async_runtime()?;
         let mut ret = S3Fdw {
             rt,
             client: None,


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PS is to add comment to state the reason why not use `create_async_runtime()` function.

## What is the current behavior?

N/A

## What is the new behavior?

N/A

## Additional context

N/A
