### PR TITLE
fix: add attributes support for cognito wrapper

### DIFF
--- a/wrappers/src/fdw/auth0_fdw/auth0_client/row.rs
+++ b/wrappers/src/fdw/auth0_fdw/auth0_client/row.rs
@@ -1,8 +1,6 @@
 use pgrx::JsonB;
 use serde::Deserialize;
 use serde::Serialize;
-use serde_json::Value;
-use std::collections::HashMap;
 use supabase_wrappers::prelude::Cell;
 use supabase_wrappers::prelude::Column;
 use supabase_wrappers::prelude::Row;

--- a/wrappers/src/fdw/auth0_fdw/auth0_client/row.rs
+++ b/wrappers/src/fdw/auth0_fdw/auth0_client/row.rs
@@ -26,9 +26,6 @@ pub(crate) struct Success {
     time: f64,
 }
 
-#[derive(Debug)]
-pub struct Auth0Fields(HashMap<String, Value>);
-
 #[derive(Debug, Deserialize, PartialEq)]
 pub struct Auth0User {
     pub created_at: String,

--- a/wrappers/src/fdw/cognito_fdw/cognito_client/row.rs
+++ b/wrappers/src/fdw/cognito_fdw/cognito_client/row.rs
@@ -6,13 +6,11 @@ use std::collections::HashMap;
 use supabase_wrappers::prelude::Cell;
 use supabase_wrappers::prelude::Column;
 use supabase_wrappers::prelude::Row;
-use pgrx::notice;
 
 use pgrx::JsonB;
 
-use serde_json::json;
 use aws_sdk_cognitoidentityprovider::types::AttributeType;
-
+use serde_json::json;
 
 #[derive(Debug, Deserialize, PartialEq)]
 pub struct ResultPayload {
@@ -55,7 +53,6 @@ fn serialize_attributes(attributes: &Vec<AttributeType>) -> Value {
     json!(attrs)
 }
 
-
 impl IntoRow for UserType {
     fn into_row(self, columns: &[Column]) -> Result<Row, IntoRowError> {
         let mut row = Row::new();
@@ -69,14 +66,11 @@ impl IntoRow for UserType {
                 }
                 "attributes" => {
                     if let Some(ref attributes) = self.attributes {
-    // Now `attributes` is a reference to `Vec<AttributeType>`
-    let serialized_attributes = serialize_attributes(attributes); // Pass reference directly
+                        let serialized_attributes = serialize_attributes(attributes);
 
-    // Assuming `pgrx::JsonB` expects a value that implements `Serialize`
-    // and `JsonB::from` is the correct way to convert `pgrx::JsonB` to your desired `JsonB` type
-    let attributes_json_b = JsonB::from(pgrx::JsonB(serialized_attributes));
-    row.push("attributes", Some(Cell::Json(attributes_json_b)));
-                        }
+                        let attributes_json_b = JsonB::from(pgrx::JsonB(serialized_attributes));
+                        row.push("attributes", Some(Cell::Json(attributes_json_b)));
+                    }
                 }
                 "created_at" => {
                     if let Some(created_at) = self.extract_attribute_value("created_at") {

--- a/wrappers/src/fdw/cognito_fdw/cognito_client/row.rs
+++ b/wrappers/src/fdw/cognito_fdw/cognito_client/row.rs
@@ -7,8 +7,6 @@ use supabase_wrappers::prelude::Cell;
 use supabase_wrappers::prelude::Column;
 use supabase_wrappers::prelude::Row;
 
-use pgrx::JsonB;
-
 use aws_sdk_cognitoidentityprovider::types::AttributeType;
 use serde_json::json;
 
@@ -68,7 +66,7 @@ impl IntoRow for UserType {
                     if let Some(ref attributes) = self.attributes {
                         let serialized_attributes = serialize_attributes(attributes);
 
-                        let attributes_json_b = JsonB::from(pgrx::JsonB(serialized_attributes));
+                        let attributes_json_b = pgrx::JsonB(serialized_attributes);
                         row.push("attributes", Some(Cell::Json(attributes_json_b)));
                     }
                 }

--- a/wrappers/src/fdw/cognito_fdw/cognito_client/row.rs
+++ b/wrappers/src/fdw/cognito_fdw/cognito_client/row.rs
@@ -2,7 +2,6 @@ use aws_sdk_cognitoidentityprovider::types::UserType;
 use chrono::DateTime;
 use serde::Deserialize;
 use serde_json::Value;
-use std::collections::HashMap;
 use supabase_wrappers::prelude::Cell;
 use supabase_wrappers::prelude::Column;
 use supabase_wrappers::prelude::Row;
@@ -15,9 +14,6 @@ pub struct ResultPayload {
     pub(crate) users: Vec<CognitoUser>,
     pub(crate) next_page_offset: Option<u64>,
 }
-
-#[derive(Debug)]
-pub struct CognitoFields(HashMap<String, Value>);
 
 #[derive(Debug, Deserialize, PartialEq)]
 pub struct CognitoUser {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds support for the "attributes" field so we can fetch [all attributes from the user pool](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-settings-attributes.html)