### PR TITLE
fix: reset state when begin scan

### DIFF
--- a/.github/workflows/test_wrappers.yml
+++ b/.github/workflows/test_wrappers.yml
@@ -55,4 +55,4 @@ jobs:
       run: |
         cd wrappers && RUSTFLAGS="-D warnings" cargo clippy --all --tests --no-deps --features all_fdws,helloworld_fdw
 
-    - run: cd wrappers && cargo pgrx test --features all_fdws,pg15
+    - run: cd wrappers && cargo pgrx test --features "all_fdws pg15"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,6 +387,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-sdk-cognitoidentityprovider"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ab24eef715050f56365d129fcff98de9e2981066e221cec8fe7b6170b188fcc"
+dependencies = [
+ "aws-credential-types",
+ "aws-http",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "http",
+ "once_cell",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
 name = "aws-sdk-s3"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2069,7 +2092,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.5",
  "tokio",
  "tower-service",
  "tracing",
@@ -5035,6 +5058,7 @@ dependencies = [
  "arrow-array",
  "async-compression",
  "aws-config",
+ "aws-sdk-cognitoidentityprovider",
  "aws-sdk-s3",
  "aws-smithy-http",
  "aws-smithy-runtime-api",

--- a/wrappers/.ci/docker-compose.yaml
+++ b/wrappers/.ci/docker-compose.yaml
@@ -28,8 +28,6 @@ services:
   clickhouse:
     image: clickhouse/clickhouse-server
     container_name: clickhouse-wrapped
-    environment:
-      CLICKHOUSE_DB: supa
     ports:
       - "9000:9000" # native interface
       - "8123:8123" # http interface

--- a/wrappers/src/fdw/mssql_fdw/mssql_fdw.rs
+++ b/wrappers/src/fdw/mssql_fdw/mssql_fdw.rs
@@ -192,6 +192,8 @@ impl ForeignDataWrapper<MssqlFdwError> for MssqlFdw {
         self.table = require_option("table", options)?.to_string();
         self.tgt_cols = columns.to_vec();
 
+        self.iter_idx = 0;
+
         // create sql server client
         let tcp = self
             .rt

--- a/wrappers/src/fdw/redis_fdw/redis_fdw.rs
+++ b/wrappers/src/fdw/redis_fdw/redis_fdw.rs
@@ -74,6 +74,13 @@ impl RedisFdw {
     const FDW_NAME: &'static str = "RedisFdw";
     const BUF_SIZE: isize = 256;
 
+    fn reset(&mut self) {
+        self.iter_idx = 0;
+        self.scan_result.clear();
+        self.iter_idx_stream = "-".to_string();
+        self.scan_result_stream.clear();
+    }
+
     // fetch a target row for list and zset
     fn fetch_row_list(&mut self) -> RedisFdwResult<Option<Row>> {
         if let Some(ref mut conn) = &mut self.conn {
@@ -271,6 +278,8 @@ impl ForeignDataWrapper<RedisFdwError> for RedisFdw {
 
         let mut conn = self.client.get_connection()?;
 
+        self.reset();
+
         match src_type.as_str() {
             "list" | "zset" => {
                 check_target_columns(
@@ -366,10 +375,7 @@ impl ForeignDataWrapper<RedisFdwError> for RedisFdw {
     }
 
     fn re_scan(&mut self) -> RedisFdwResult<()> {
-        self.iter_idx = 0;
-        self.scan_result.clear();
-        self.iter_idx_stream = "-".to_string();
-        self.scan_result_stream.clear();
+        self.reset();
         Ok(())
     }
 

--- a/wrappers/src/fdw/stripe_fdw/stripe_fdw.rs
+++ b/wrappers/src/fdw/stripe_fdw/stripe_fdw.rs
@@ -660,6 +660,8 @@ impl ForeignDataWrapper<StripeFdwError> for StripeFdw {
     ) -> StripeFdwResult<()> {
         let obj = require_option("object", options)?;
 
+        self.iter_idx = 0;
+
         if let Some(client) = &self.client {
             let page_size = 100; // maximum page size limit for Stripe API
             let page_cnt = if let Some(limit) = limit {


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to add state reset code when begin a scan, this can partially fix #237.

## What is the current behavior?

The foreign table scan execution plan will be cached when foreign table query is defined in a function, this will result in `begin_scan()` being called without calling `new()` function, which is supposed to re-initialise the FDW instance.

## What is the new behavior?

Added some state reseting codes in `begin_scan()` for some FDWs, so that their inner state will be reset correctly.

## Additional context

This PR can partially fix #237, so the continuous  foreign table function call should be correct. But for permanent fix, we need to find out better way to manage and re-use `FdwState`.
