### PR TITLE
ci: remove clickhouse init db

### DIFF
--- a/.github/workflows/test_wrappers.yml
+++ b/.github/workflows/test_wrappers.yml
@@ -55,4 +55,4 @@ jobs:
       run: |
         cd wrappers && RUSTFLAGS="-D warnings" cargo clippy --all --tests --no-deps --features all_fdws,helloworld_fdw
 
-    - run: cd wrappers && cargo pgrx test --features all_fdws,pg15
+    - run: cd wrappers && cargo pgrx test --features "all_fdws pg15"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,6 +387,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-sdk-cognitoidentityprovider"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ab24eef715050f56365d129fcff98de9e2981066e221cec8fe7b6170b188fcc"
+dependencies = [
+ "aws-credential-types",
+ "aws-http",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "http",
+ "once_cell",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
 name = "aws-sdk-s3"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2069,7 +2092,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.5",
  "tokio",
  "tower-service",
  "tracing",
@@ -5035,6 +5058,7 @@ dependencies = [
  "arrow-array",
  "async-compression",
  "aws-config",
+ "aws-sdk-cognitoidentityprovider",
  "aws-sdk-s3",
  "aws-smithy-http",
  "aws-smithy-runtime-api",

--- a/wrappers/.ci/docker-compose.yaml
+++ b/wrappers/.ci/docker-compose.yaml
@@ -28,8 +28,6 @@ services:
   clickhouse:
     image: clickhouse/clickhouse-server
     container_name: clickhouse-wrapped
-    environment:
-      CLICKHOUSE_DB: supa
     ports:
       - "9000:9000" # native interface
       - "8123:8123" # http interface

--- a/wrappers/src/fdw/clickhouse_fdw/tests.rs
+++ b/wrappers/src/fdw/clickhouse_fdw/tests.rs
@@ -17,9 +17,7 @@ mod tests {
                 .expect("handle");
 
             rt.block_on(async {
-                handle
-                    .execute("DROP TABLE IF EXISTS test_table")
-                    .await?;
+                handle.execute("DROP TABLE IF EXISTS test_table").await?;
                 handle
                     .execute("CREATE TABLE test_table (id INT, name TEXT) engine = Memory")
                     .await

--- a/wrappers/src/fdw/clickhouse_fdw/tests.rs
+++ b/wrappers/src/fdw/clickhouse_fdw/tests.rs
@@ -9,7 +9,7 @@ mod tests {
     #[pg_test]
     fn clickhouse_smoketest() {
         Spi::connect(|mut c| {
-            let clickhouse_pool = ch::Pool::new("tcp://default:@localhost:9000/supa");
+            let clickhouse_pool = ch::Pool::new("tcp://default:@localhost:9000/default");
 
             let rt = create_async_runtime().expect("failed to create runtime");
             let mut handle = rt
@@ -18,10 +18,10 @@ mod tests {
 
             rt.block_on(async {
                 handle
-                    .execute("DROP TABLE IF EXISTS supa.test_table")
+                    .execute("DROP TABLE IF EXISTS test_table")
                     .await?;
                 handle
-                    .execute("CREATE TABLE supa.test_table (id INT, name TEXT) engine = Memory")
+                    .execute("CREATE TABLE test_table (id INT, name TEXT) engine = Memory")
                     .await
             })
             .expect("test_table in ClickHouse");
@@ -37,7 +37,7 @@ mod tests {
                 r#"CREATE SERVER my_clickhouse_server
                          FOREIGN DATA WRAPPER clickhouse_wrapper
                          OPTIONS (
-                           conn_string 'tcp://default:@localhost:9000/supa'
+                           conn_string 'tcp://default:@localhost:9000/default'
                          )"#,
                 None,
                 None,
@@ -235,7 +235,7 @@ mod tests {
             let remote_value: String = rt
                 .block_on(async {
                     handle
-                        .query("SELECT name FROM supa.test_table ORDER BY name LIMIT 1")
+                        .query("SELECT name FROM test_table ORDER BY name LIMIT 1")
                         .fetch_all()
                         .await?
                         .rows()


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to remove db initialisation for ClickHouse FDW test, as it is not supported by the latest ClickHouse docker image and it is actually not needed to set up a new database.

## What is the current behavior?

The ClickHouse FDW test uses a database called `supa`.

## What is the new behavior?

It is no need to set up a new database for testing, just use the `default` db is enought.

## Additional context

This PR also updated the github action run command to remove warning `Ignoring feature 'clickhouse_fdw,pg15'`
