### PR TITLE
Add s3 endpoint support

### DIFF
--- a/docs/s3.md
+++ b/docs/s3.md
@@ -100,6 +100,25 @@ We need to provide Postgres with the credentials to connect to S3, and any addit
       );
     ```
 
+The full list of options are below:
+- `aws_access_key_id` (required) - Your access key
+- `aws_secret_access_key` (required) - Your secret key
+- `aws_region` (required) - The region of your bucket (if providing an endpoint URL with a region in it, make sure that they are the same)
+- `endpoint_url` (optional) - An optional URL to allow connection to S3-compliant providers (i.e. Wasabi, Cloudflare R2, Backblaze B2, DigitalOcean Spaces)
+
+### Connecting to S3-compliant Providers - Wasabi
+
+```sql
+create server s3_server
+      foreign data wrapper s3_wrapper
+      options (
+        aws_access_key_id 'you_wasabi_access_key',
+        aws_secret_access_key 'your_wasabi_secret_access_key',
+        aws_region 'eu-central-1',
+        endpoint_url 'https://s3.eu-central-1.wasabisys.com'
+      );
+```
+
 ## Creating Foreign Tables
 
 The S3 Wrapper supports data reads from S3.


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds the option to provide `endpoint_url` when configuring an s3 server

## What is the current behavior?

Current behaviour does not allow this option and limits s3 functionality to AWS

## What is the new behavior?

Allows any s3 compatible providers to be used with the wrapper

## Additional context

Env var could not be used as it is [not supported in the SDK](https://github.com/awslabs/aws-sdk-rust/issues/932)
