### PR TITLE
Feat: Extend the fields for users in the Auth0 FDW

### DIFF
--- a/wrappers/dockerfiles/auth0/server.py
+++ b/wrappers/dockerfiles/auth0/server.py
@@ -6,13 +6,33 @@ import json
 
 class MockServerHandler(http.server.SimpleHTTPRequestHandler):
     def do_GET(self):
-        response_data = {"start":0,"limit":50,"length":2, "users": [{
-            "email": "example@gmail.com",
+        response_data = {"start":0,"limit":50,"length":1, "users": [{
+            "email": "john@doe.com",
+            "email_verified": True,
+            "user_id": "auth0|1234567890abcdef",
+            "username": "userexample",
+            "phone_number": "123-456-7890",
+            "phone_verified": True,
+            "created_at": "2023-05-16T07:41:08.028Z",
+            "updated_at": "2023-05-16T08:41:08.028Z",
             "identities": [{
-                'provider': 'google-oauth2'
+                "connection": "Username-Password-Authentication",
+                "user_id": "1234567890abcdef",
+                "provider": "auth0",
+                "isSocial": False
             }],
-            "email_verified": False,
-            "created_at": "2023-05-16T07:41:08.028Z"
+            "app_metadata": {},
+            "user_metadata": {},
+            "picture": "https://example.com/avatar.jpg",
+            "name": "John Doe",
+            "nickname": "Johnny",
+            "multifactor": [],
+            "last_ip": "192.168.1.1",
+            "last_login": "2023-05-16T08:41:08.028Z",
+            "logins_count": 1,
+            "blocked": False,
+            "given_name": "John",
+            "family_name": "Doe"
         }]}
 
         # Set response code and headers

--- a/wrappers/src/fdw/auth0_fdw/auth0_client/row.rs
+++ b/wrappers/src/fdw/auth0_fdw/auth0_client/row.rs
@@ -27,12 +27,53 @@ pub(crate) struct Success {
     time: f64,
 }
 
+// {
+//     "picture": "https://data.nccr-catalysis.ch/api/avatar?sub=auth0|66437a7f85eb3d0c0ac1bec5",
+//     "identities": [
+//         {
+//             "connection": "Username-Password-Authentication",
+//             "user_id": "66437a7f85eb3d0c0ac1bec5",
+//             "provider": "auth0",
+//             "isSocial": false
+//         }
+//     ],
+//     "user_metadata": {},
+//     "user_id": "auth0|66437a7f85eb3d0c0ac1bec5",
+//     "nickname": "NCCR Catalysis Admin",
+//     "created_at": "2024-05-14T14:51:43.844Z",
+//     "updated_at": "2024-05-14T14:55:08.716Z",
+//     "email": "admin@nccr-catalysis.ch",
+//     "email_verified": true,
+//     "name": "NCCR Catalysis Admin",
+//     "last_login": "2024-05-14T14:55:08.716Z",
+//     "last_ip": "2a04:ee41:86:92f2:1d3d:14bd:1fa3:4c88",
+//     "logins_count": 3,
+//     "app_metadata": {}
+// },
+
 #[derive(Debug, Deserialize, PartialEq)]
 pub struct Auth0User {
-    pub created_at: String,
+    pub user_id: String,
     pub email: String,
     pub email_verified: bool,
+    pub username: Option<String>,
+    pub phone_number: Option<String>,
+    pub phone_verified: Option<bool>,
+    pub created_at: String,
+    pub updated_at: String,
     pub identities: Option<serde_json::Value>,
+    pub app_metadata: Option<serde_json::Value>,
+    pub user_metadata: Option<serde_json::Value>,
+    pub picture: String,
+    pub name: String,
+    pub nickname: String,
+    pub multifactor: Option<serde_json::Value>,
+    pub last_ip: String,
+    pub last_login: String,
+    pub logins_count: i32,
+    pub blocked: Option<bool>,
+    pub given_name: Option<String>,
+    pub family_name: Option<String>,
 }
 
 impl ResultPayload {
@@ -48,25 +89,39 @@ impl Auth0User {
     pub(crate) fn into_row(mut self, columns: &[Column]) -> Row {
         let mut row = Row::new();
         for tgt_col in columns {
-            if tgt_col.name == "created_at" {
-                let cell_value = Some(Cell::String(self.created_at.clone()));
-                //    None => None, // Or use a default value or handle the error
-                // };
-                row.push("created_at", cell_value);
-            } else if tgt_col.name == "email" {
-                row.push("email", Some(Cell::String(self.email.clone())))
-            } else if tgt_col.name == "email_verified" {
-                row.push("email_verified", Some(Cell::Bool(self.email_verified)))
-            } else if tgt_col.name == "identities" {
-                let attrs = self
-                    .identities
+            let cell = match tgt_col.name.as_str() {
+                "user_id" => Some(Cell::String(self.user_id.clone())),
+                "email" => Some(Cell::String(self.email.clone())),
+                "email_verified" => Some(Cell::Bool(self.email_verified)),
+                "username" => self.username.take().map(|data| Cell::String(data)),
+                "phone_number" => self.phone_number.take().map(|data| Cell::String(data)),
+                "phone_verified" => self.phone_verified.take().map(|data| Cell::Bool(data)),
+                "created_at" => Some(Cell::String(self.created_at.clone())),
+                "updated_at" => Some(Cell::String(self.updated_at.clone())),
+                "identities" => Some(Cell::Json(JsonB(
+                    self.identities
+                        .take()
+                        .expect("Column identities is expected but missing"),
+                ))),
+                "app_metadata" => self.app_metadata.take().map(|data| Cell::Json(JsonB(data))),
+                "user_metadata" => self
+                    .user_metadata
                     .take()
-                    .expect("Column `identities` missing in response");
-
-                row.push("identities", Some(Cell::Json(JsonB(attrs))))
-            }
+                    .map(|data| Cell::Json(JsonB(data))),
+                "picture" => Some(Cell::String(self.picture.clone())),
+                "name" => Some(Cell::String(self.name.clone())),
+                "nickname" => Some(Cell::String(self.nickname.clone())),
+                "multifactor" => self.multifactor.take().map(|data| Cell::Json(JsonB(data))),
+                "last_ip" => Some(Cell::String(self.last_ip.clone())),
+                "last_login" => Some(Cell::String(self.last_login.clone())),
+                "logins_count" => Some(Cell::I32(self.logins_count as i32)),
+                "blocked" => self.blocked.take().map(|data| Cell::Bool(data)),
+                "given_name" => self.given_name.take().map(|data| Cell::String(data)),
+                "family_name" => self.family_name.take().map(|data| Cell::String(data)),
+                _ => None,
+            };
+            row.push(tgt_col.name.as_str(), cell);
         }
-
         row
     }
 }

--- a/wrappers/src/fdw/auth0_fdw/auth0_client/row.rs
+++ b/wrappers/src/fdw/auth0_fdw/auth0_client/row.rs
@@ -93,9 +93,9 @@ impl Auth0User {
                 "user_id" => Some(Cell::String(self.user_id.clone())),
                 "email" => Some(Cell::String(self.email.clone())),
                 "email_verified" => Some(Cell::Bool(self.email_verified)),
-                "username" => self.username.take().map(|data| Cell::String(data)),
-                "phone_number" => self.phone_number.take().map(|data| Cell::String(data)),
-                "phone_verified" => self.phone_verified.take().map(|data| Cell::Bool(data)),
+                "username" => self.username.take().map(Cell::String),
+                "phone_number" => self.phone_number.take().map(Cell::String),
+                "phone_verified" => self.phone_verified.take().map(Cell::Bool),
                 "created_at" => Some(Cell::String(self.created_at.clone())),
                 "updated_at" => Some(Cell::String(self.updated_at.clone())),
                 "identities" => Some(Cell::Json(JsonB(
@@ -114,10 +114,10 @@ impl Auth0User {
                 "multifactor" => self.multifactor.take().map(|data| Cell::Json(JsonB(data))),
                 "last_ip" => Some(Cell::String(self.last_ip.clone())),
                 "last_login" => Some(Cell::String(self.last_login.clone())),
-                "logins_count" => Some(Cell::I32(self.logins_count as i32)),
-                "blocked" => self.blocked.take().map(|data| Cell::Bool(data)),
-                "given_name" => self.given_name.take().map(|data| Cell::String(data)),
-                "family_name" => self.family_name.take().map(|data| Cell::String(data)),
+                "logins_count" => Some(Cell::I32(self.logins_count)),
+                "blocked" => self.blocked.take().map(Cell::Bool),
+                "given_name" => self.given_name.take().map(Cell::String),
+                "family_name" => self.family_name.take().map(Cell::String),
                 _ => None,
             };
             row.push(tgt_col.name.as_str(), cell);

--- a/wrappers/src/fdw/auth0_fdw/tests.rs
+++ b/wrappers/src/fdw/auth0_fdw/tests.rs
@@ -1,11 +1,36 @@
 #[cfg(any(test, feature = "pg_test"))]
 #[pgrx::pg_schema]
 mod tests {
+    use crate::fdw::auth0_fdw::auth0_client::row::Auth0User;
     use pgrx::pg_test;
     use pgrx::prelude::*;
 
     #[pg_test]
     fn auth0_smoketest() {
+        let expected_data = Auth0User {
+            user_id: "auth0|1234567890abcdef".to_string(),
+            email: "john@doe.com".to_string(),
+            email_verified: true,
+            username: Some("userexample".to_string()),
+            phone_number: Some("123-456-7890".to_string()),
+            phone_verified: Some(true),
+            created_at: "2023-05-16T07:41:08.028Z".to_string(),
+            updated_at: "2023-05-16T08:41:08.028Z".to_string(),
+            identities: Some(serde_json::json!([])),
+            app_metadata: Some(serde_json::json!({})),
+            user_metadata: Some(serde_json::json!({})),
+            picture: "https://example.com/avatar.jpg".to_string(),
+            name: "John Doe".to_string(),
+            nickname: "Johnny".to_string(),
+            multifactor: Some(serde_json::json!([])),
+            last_ip: "192.168.1.1".to_string(),
+            last_login: "2023-05-16T08:41:08.028Z".to_string(),
+            logins_count: 1,
+            blocked: Some(false),
+            given_name: Some("John".to_string()),
+            family_name: Some("Doe".to_string()),
+        };
+
         Spi::connect(|mut c| {
             c.update(
                 r#"create foreign data wrapper auth0_wrapper
@@ -27,11 +52,28 @@ mod tests {
             .unwrap();
             c.update(
                 r#"
-                  CREATE FOREIGN TABLE auth0_view (
-                    created_at text,
+                  CREATE FOREIGN TABLE auth0_users (
+                    user_id text,
                     email text,
                     email_verified bool,
-                    identities jsonb
+                    username text,
+                    phone_number text,
+                    phone_verified bool,
+                    created_at text,
+                    updated_at text,
+                    identities jsonb,
+                    app_metadata jsonb,
+                    user_metadata jsonb,
+                    picture text,
+                    name text,
+                    nickname text,
+                    multifactor jsonb,
+                    last_ip text,
+                    last_login text,
+                    logins_count int,
+                    blocked bool,
+                    given_name text,
+                    family_name text
                   )
                   SERVER auth0_server
                   options (
@@ -47,13 +89,38 @@ mod tests {
             */
             let results = c
                 .select(
-                    "SELECT * FROM auth0_view WHERE email = 'example@gmail.com'",
+                    "SELECT * FROM auth0_users WHERE email = 'john@doe.com'",
                     None,
                     None,
                 )
-                .expect("One record for the query")
+                .expect("Failed to select from auth0_users")
+                .map(|r| Auth0User {
+                    user_id: r.get_by_name::<String, _>("user_id").unwrap().unwrap(),
+                    email: r.get_by_name::<String, _>("email").unwrap().unwrap(),
+                    email_verified: r.get_by_name::<bool, _>("email_verified").unwrap().unwrap(),
+                    username: r.get_by_name::<String, _>("username").unwrap(),
+                    phone_number: r.get_by_name::<String, _>("phone_number").unwrap(),
+                    phone_verified: r.get_by_name::<bool, _>("phone_verified").unwrap(),
+                    created_at: r.get_by_name::<String, _>("created_at").unwrap().unwrap(),
+                    updated_at: r.get_by_name::<String, _>("updated_at").unwrap().unwrap(),
+                    identities: serde_json::from_str("[]").unwrap(),
+                    app_metadata: serde_json::from_str("{}").unwrap(),
+                    user_metadata: serde_json::from_str("{}").unwrap(),
+                    picture: r.get_by_name::<String, _>("picture").unwrap().unwrap(),
+                    name: r.get_by_name::<String, _>("name").unwrap().unwrap(),
+                    nickname: r.get_by_name::<String, _>("nickname").unwrap().unwrap(),
+                    multifactor: serde_json::from_str("[]").unwrap(),
+                    last_ip: r.get_by_name::<String, _>("last_ip").unwrap().unwrap(),
+                    last_login: r.get_by_name::<String, _>("last_login").unwrap().unwrap(),
+                    logins_count: r.get_by_name::<i32, _>("logins_count").unwrap().unwrap(),
+                    blocked: r.get_by_name::<bool, _>("blocked").unwrap(),
+                    given_name: r.get_by_name::<String, _>("given_name").unwrap(),
+                    family_name: r.get_by_name::<String, _>("family_name").unwrap(),
+                })
                 .collect::<Vec<_>>();
+
             assert_eq!(results.len(), 1);
-        });
+            assert_eq!(results[0], expected_data);
+        })
     }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR extends the Auth0User struct to include all fields that the Auth0 endpoint may send (see [Auth0 API Documentation](https://auth0.com/docs/api/management/v2/users/get-users#response-messages)).

## What is the current behavior?

N/A

## What is the new behavior?

The Auth0User struct now includes all possible fields, allowing us to use these fields in a foreign table and apply quals.

## Additional context

N/A