### PR TITLE
fix(mssql): incorrect sql deparse for limit and offset clause

### DIFF
--- a/wrappers/src/fdw/mssql_fdw/mod.rs
+++ b/wrappers/src/fdw/mssql_fdw/mod.rs
@@ -10,6 +10,9 @@ use supabase_wrappers::prelude::{CreateRuntimeError, OptionsError};
 
 #[derive(Error, Debug)]
 enum MssqlFdwError {
+    #[error("syntax error: {0}")]
+    SyntaxError(String),
+
     #[error("column '{0}' data type is not supported")]
     UnsupportedColumnType(String),
 

--- a/wrappers/src/fdw/mssql_fdw/mssql_fdw.rs
+++ b/wrappers/src/fdw/mssql_fdw/mssql_fdw.rs
@@ -146,6 +146,12 @@ impl MssqlFdw {
         // from remote, so we calculate the real limit and only use it without
         // pushing down offset.
         if let Some(limit) = limit {
+            if sorts.is_empty() {
+                return Err(MssqlFdwError::SyntaxError(
+                    "'limit' must be with 'order by' clause".to_string(),
+                ));
+            }
+
             let real_limit = limit.offset + limit.count;
             sql.push_str(&format!(
                 " offset 0 rows fetch next {} rows only",

--- a/wrappers/src/fdw/mssql_fdw/tests.rs
+++ b/wrappers/src/fdw/mssql_fdw/tests.rs
@@ -144,7 +144,7 @@ mod tests {
         });
 
         let result = std::panic::catch_unwind(|| {
-            Spi::connect(|mut c| {
+            Spi::connect(|c| {
                 c.select("SELECT name FROM mssql_users LIMIT 2 OFFSET 1", None, None)
                     .is_err()
             })

--- a/wrappers/src/fdw/mssql_fdw/tests.rs
+++ b/wrappers/src/fdw/mssql_fdw/tests.rs
@@ -142,5 +142,13 @@ mod tests {
                 .collect::<Vec<_>>();
             assert_eq!(results, vec!["foo", "bar"]);
         });
+
+        let result = std::panic::catch_unwind(|| {
+            Spi::connect(|mut c| {
+                c.select("SELECT name FROM mssql_users LIMIT 2 OFFSET 1", None, None)
+                    .is_err()
+            })
+        });
+        assert!(result.is_err());
     }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to fix #262 , which is caused by incorrect translation from PG sql dialect to T-SQL syntax when using `LIMIT..OFFSET` clause.

## What is the current behavior?

The SQL with `LIMIT..OFFSET` clause will be deparsed to `offset 0 rows fetch next .. rows only`, but it needs `ORDER BY` clause to be presented in T-SQL while it is not necessary in Postgres.

## What is the new behavior?

An error will happen when `LIMIT..OFFSET` clause is not with an `ORDER BY` clause.

## Additional context

N/A
