### PR TITLE
fix: deparse LIKE operator in qual

### DIFF
--- a/supabase-wrappers/src/interface.rs
+++ b/supabase-wrappers/src/interface.rs
@@ -345,6 +345,8 @@ impl Qual {
                         }
                         _ => format!("{} {} {}", self.field, self.operator, cell),
                     },
+                    "~~" => format!("{} like {}", self.field, cell),
+                    "!~~" => format!("{} not like {}", self.field, cell),
                     _ => format!("{} {} {}", self.field, self.operator, cell),
                 },
                 Value::Array(_) => unreachable!(),

--- a/wrappers/src/fdw/mssql_fdw/tests.rs
+++ b/wrappers/src/fdw/mssql_fdw/tests.rs
@@ -133,6 +133,28 @@ mod tests {
 
             let results = c
                 .select(
+                    "SELECT name FROM mssql_users WHERE name like 'ba%' ORDER BY id",
+                    None,
+                    None,
+                )
+                .unwrap()
+                .filter_map(|r| r.get_by_name::<&str, _>("name").unwrap())
+                .collect::<Vec<_>>();
+            assert_eq!(results, vec!["bar", "baz"]);
+
+            let results = c
+                .select(
+                    "SELECT name FROM mssql_users WHERE name not like 'ba%'",
+                    None,
+                    None,
+                )
+                .unwrap()
+                .filter_map(|r| r.get_by_name::<&str, _>("name").unwrap())
+                .collect::<Vec<_>>();
+            assert_eq!(results, vec!["foo"]);
+
+            let results = c
+                .select(
                     "SELECT name FROM mssql_users_cust_sql ORDER BY id",
                     None,
                     None,


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to fix `LIKE` operator qual deparse, which will fix #278 .

## What is the current behavior?

Currently, the `LIKE` operator is translated to its original presentation `~~`, which caused error when deparsing qual.

## What is the new behavior?

Translate `LIKE` and `NOT LIKE` to sql `like` and `not like` correctly.

## Additional context

N/A
