### PR TITLE
feat: add timestamp with time zone cell type support

### DIFF
--- a/docs/bigquery.md
+++ b/docs/bigquery.md
@@ -15,6 +15,7 @@ The BigQuery Wrapper allows you to read and write data from BigQuery within your
 | date             | DATE          |
 | timestamp        | DATETIME      |
 | timestamp        | TIMESTAMP     |
+| timestamptz      | TIMESTAMP     |
 
 ## Preparation
 

--- a/docs/mssql.md
+++ b/docs/mssql.md
@@ -17,6 +17,7 @@ The SQL Server Wrapper allows you to read data from Microsoft SQL Server within 
 | text               | varchar/char/text                |
 | date               | date                             |
 | timestamp          | datetime/datetime2/smalldatetime |
+| timestamptz        | datetime/datetime2/smalldatetime |
 
 ## Preparation
 

--- a/docs/s3.md
+++ b/docs/s3.md
@@ -34,6 +34,7 @@ The S3 Wrapper uses Parquet file data types from [arrow_array::types](https://do
 | text             | ByteArrayType           |
 | date             | Date64Type              |
 | timestamp        | TimestampNanosecondType |
+| timestamptz      | TimestampNanosecondType |
 
 ## Preparation
 

--- a/wrappers/src/fdw/airtable_fdw/result.rs
+++ b/wrappers/src/fdw/airtable_fdw/result.rs
@@ -213,6 +213,19 @@ impl AirtableRecord {
                         }
                     },
                 ),
+                pg_sys::TIMESTAMPTZOID => self.fields.0.get(&col.name).map_or_else(
+                    || Ok(None),
+                    |val| {
+                        if let Value::String(v) = val {
+                            let n = pgrx::TimestampWithTimeZone::from_str(v.as_str())
+                                .ok()
+                                .map(Cell::Timestamptz);
+                            Ok(n)
+                        } else {
+                            Err(())
+                        }
+                    },
+                ),
                 // TODO: Think about adding support for BOOLARRAYOID, NUMERICARRAYOID, TEXTARRAYOID and rest of array types.
                 pg_sys::JSONBOID => self.fields.0.get(&col.name).map_or_else(
                     || Ok(None),

--- a/wrappers/src/fdw/bigquery_fdw/bigquery_fdw.rs
+++ b/wrappers/src/fdw/bigquery_fdw/bigquery_fdw.rs
@@ -393,6 +393,7 @@ impl ForeignDataWrapper<BigQueryFdwError> for BigQueryFdw {
                         Cell::String(v) => row_json[col_name] = json!(v),
                         Cell::Date(v) => row_json[col_name] = json!(v),
                         Cell::Timestamp(v) => row_json[col_name] = json!(v),
+                        Cell::Timestamptz(v) => row_json[col_name] = json!(v),
                         Cell::Json(v) => row_json[col_name] = json!(v),
                     }
                 }

--- a/wrappers/src/fdw/mssql_fdw/mssql_fdw.rs
+++ b/wrappers/src/fdw/mssql_fdw/mssql_fdw.rs
@@ -66,6 +66,12 @@ fn field_to_cell(src_row: &tiberius::Row, tgt_col: &Column) -> MssqlFdwResult<Op
                 Cell::Timestamp(ts.to_utc())
             })
         }
+        PgOid::BuiltIn(PgBuiltInOids::TIMESTAMPTZOID) => {
+            src_row.try_get::<NaiveDateTime, &str>(col_name)?.map(|v| {
+                let ts = to_timestamp(v.timestamp() as f64);
+                Cell::Timestamptz(ts)
+            })
+        }
         _ => {
             return Err(MssqlFdwError::UnsupportedColumnType(tgt_col.name.clone()));
         }


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to add a new column type `timestamp with time zone` support. With this new column type, below FDWs can support the new data type.

- Airtable
- BigQuery
- MS SQL Server
- S3 parquet
- Logflare

## What is the current behavior?

Currently only `timestamp without time zone` is supported.

## What is the new behavior?

Support `timestamp with time zone` in the framework.

## Additional context

N/A
