### PR TITLE
fix: replace deprecated `chrono::NaiveDateTime::timestamp` method

### DIFF
--- a/wrappers/src/fdw/mssql_fdw/mssql_fdw.rs
+++ b/wrappers/src/fdw/mssql_fdw/mssql_fdw.rs
@@ -68,7 +68,7 @@ fn field_to_cell(src_row: &tiberius::Row, tgt_col: &Column) -> MssqlFdwResult<Op
         }
         PgOid::BuiltIn(PgBuiltInOids::TIMESTAMPTZOID) => {
             src_row.try_get::<NaiveDateTime, &str>(col_name)?.map(|v| {
-                let ts = to_timestamp(v.timestamp() as f64);
+                let ts = to_timestamp(v.and_utc().timestamp() as f64);
                 Cell::Timestamptz(ts)
             })
         }

--- a/wrappers/src/fdw/s3_fdw/parquet.rs
+++ b/wrappers/src/fdw/s3_fdw/parquet.rs
@@ -348,7 +348,7 @@ impl S3Parquet {
                             None
                         } else {
                             arr.value_as_datetime(self.batch_idx).map(|ts| {
-                                let ts = to_timestamp(ts.timestamp() as f64);
+                                let ts = to_timestamp(ts.and_utc().timestamp() as f64);
                                 Cell::Timestamptz(ts)
                             })
                         }


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to replace deprecated method `chrono::NaiveDateTime::timestamp` with `.and_utc().timestamp()`, which is suggested by clippy.

## What is the current behavior?

N/A

## What is the new behavior?

N/A

## Additional context

N/A
