### PR TITLE
fix: remove `unwrap()` from stats related functions

### DIFF
--- a/wrappers/src/stats.rs
+++ b/wrappers/src/stats.rs
@@ -36,8 +36,8 @@ fn get_stats_table() -> String {
         FDW_STATS_TABLE
     );
     Spi::get_one(&sql)
-        .unwrap()
-        .unwrap_or_else(|| panic!("cannot find fdw stats table '{}'", FDW_STATS_TABLE))
+        .expect("wrappers extension should be installed")
+        .expect("fdw stats table should be created")
 }
 
 fn is_txn_read_only() -> bool {
@@ -70,7 +70,7 @@ pub(crate) fn inc_stats(fdw_name: &str, metric: Metric, inc: i64) {
             (PgBuiltInOids::INT8OID.oid(), inc.into_datum()),
         ]),
     )
-    .unwrap();
+    .expect("should insert into fdw stats table");
 }
 
 // get metadata
@@ -84,7 +84,7 @@ pub(crate) fn get_metadata(fdw_name: &str) -> Option<JsonB> {
         &sql,
         vec![(PgBuiltInOids::TEXTOID.oid(), fdw_name.into_datum())],
     )
-    .unwrap()
+    .unwrap_or_default()
 }
 
 // set metadata
@@ -102,12 +102,11 @@ pub(crate) fn set_metadata(fdw_name: &str, metadata: Option<JsonB>) {
             updated_at = timezone('utc'::text, now())",
         get_stats_table()
     );
-    Spi::run_with_args(
+    let _ = Spi::run_with_args(
         &sql,
         Some(vec![
             (PgBuiltInOids::TEXTOID.oid(), fdw_name.into_datum()),
             (PgBuiltInOids::JSONBOID.oid(), metadata.into_datum()),
         ]),
-    )
-    .unwrap();
+    );
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to remove `unwrap()` call from stats related functions. This also caused failure when using API to access foreign tables in some cases.

## What is the current behavior?

Currently, it is hard to troubleshot when the panic is caused by `unwrap()` call.

## What is the new behavior?

Replace `unwrap()` with `expect()` or remove it if possible.

## Additional context

N/A
