### PR TITLE
fix: allow dead code to make clippy happy

### DIFF
--- a/wrappers/src/fdw/cognito_fdw/cognito_client/row.rs
+++ b/wrappers/src/fdw/cognito_fdw/cognito_client/row.rs
@@ -28,6 +28,7 @@ pub struct CognitoUser {
 
 #[derive(Debug)]
 pub enum IntoRowError {
+    #[allow(dead_code)]
     UnsupportedColumnType(String),
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to add `#[allow(dead_code)]` to suppress clippy warning.

## What is the current behavior?

N/A

## What is the new behavior?

N/A

## Additional context

N/A
