### PR TITLE
ci: add Wasm FDW release workflow

### DIFF
--- a/.github/workflows/release_wasm_fdw.yml
+++ b/.github/workflows/release_wasm_fdw.yml
@@ -1,0 +1,80 @@
+name: Wasm FDW Release
+
+on:
+  push:
+    tags:
+      - 'wasm_*_fdw_v[0-9]+.[0-9]+.[0-9]+' # Push events to matching wasm fdw tag, i.e. wasm_snowflake_fdw_v1.0.2
+  workflow_dispatch:
+    inputs:
+      project:
+        description: 'Wasm FDW Project to release'
+        required: true
+      version:
+        description: 'Version number'
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Create Wasm FDW Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Extract project and version from tag
+        id: extract_info
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          PROJECT=`echo "${TAG}" | sed -E 's/wasm_(.*_fdw)_v.*/\1/'`
+          VERSION=`echo "${TAG}" | sed -E 's/wasm_.*_fdw_(v.*)/\1/'`
+          echo "PROJECT=$PROJECT" >> "$GITHUB_OUTPUT"
+          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Rust
+        run: |
+          # install Rust
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --profile minimal --default-toolchain stable && \
+            rustup --version && \
+            rustc --version && \
+            cargo --version
+
+          # add wasm32-unknown-unknown target
+          rustup target add wasm32-unknown-unknown
+
+          # install Wasm component
+          cargo install cargo-component --locked
+
+      - name: Build Wasm FDW
+        run: |
+          cd wasm-wrappers/fdw/${{ steps.extract_info.outputs.PROJECT }}
+          cargo component build --release --target wasm32-unknown-unknown
+
+      - name: Create release
+        id: create_release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          gh release create "$TAG" \
+              --repo="$GITHUB_REPOSITORY" \
+              --title=${{ steps.extract_info.outputs.PROJECT }}_${{ steps.extract_info.outputs.VERSION }} \
+              --generate-notes
+
+      - name: Get upload url
+        run: echo UPLOAD_URL=$(curl --silent https://api.github.com/repos/${{ github.repository }}/releases/latest | jq .upload_url --raw-output) >> $GITHUB_ENV
+
+      - name: Upload release asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PROJECT: ${{ steps.extract_info.outputs.PROJECT }}
+        with:
+          upload_url: ${{ env.UPLOAD_URL }}
+          asset_path: ./wasm-wrappers/fdw/${{ env.PROJECT }}/target/wasm32-unknown-unknown/release/${{ env.PROJECT }}.wasm
+          asset_name: ${{ env.PROJECT }}.wasm
+          asset_content_type: application/wasm
+

--- a/.github/workflows/release_wasm_fdw.yml
+++ b/.github/workflows/release_wasm_fdw.yml
@@ -4,14 +4,6 @@ on:
   push:
     tags:
       - 'wasm_*_fdw_v[0-9]+.[0-9]+.[0-9]+' # Push events to matching wasm fdw tag, i.e. wasm_snowflake_fdw_v1.0.2
-  workflow_dispatch:
-    inputs:
-      project:
-        description: 'Wasm FDW Project to release'
-        required: true
-      version:
-        description: 'Version number'
-        required: true
 
 permissions:
   contents: write


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to add Wasm FDW release CI workflow. This workflow will be triggered by pushing tag like `wasm_[project name]_[version]`, for example `wasm_snowflake_fdw_v1.0.2`.

## What is the current behavior?

Currently there is no CI for Wasm FDW release.

## What is the new behavior?

When pushing tag like `wasm_snowflake_fdw_v1.0.2`, the action will build the project Wasm file and create a release for it. This release will be used for Wasm FDW distribution, that is, we can use it in foreign server option like below:

```sql
create server snowflake_server
  foreign data wrapper wasm_wrapper
  options (
    fdw_package_url 'https://github.com/supabase/wrappers/releases/download/wasm_snowflake_fdw_v0.1.0/snowflake_fdw.wasm',
    fdw_package_name 'supabase:snowflake-fdw',
    fdw_package_version '0.1.0',
    ...
);
```

## Additional context

N/A
