### PR TITLE
feat(stripe): add `api_version` server option

### DIFF
--- a/docs/stripe.md
+++ b/docs/stripe.md
@@ -45,7 +45,8 @@ We need to provide Postgres with the credentials to connect to Stripe, and any a
       foreign data wrapper stripe_wrapper
       options (
         api_key_id '<key_ID>', -- The Key ID from above, required.
-        api_url 'https://api.stripe.com/v1/'  -- Stripe API base URL, optional. Default is 'https://api.stripe.com/v1/'
+        api_url 'https://api.stripe.com/v1/',  -- Stripe API base URL, optional. Default is 'https://api.stripe.com/v1/'
+        api_version '2024-06-20'  -- Stripe API version, optional. Default is your Stripe account’s default API version.
       );
     ```
 
@@ -56,7 +57,8 @@ We need to provide Postgres with the credentials to connect to Stripe, and any a
       foreign data wrapper stripe_wrapper
       options (
         api_key '<Stripe API Key>',  -- Stripe API key, required
-        api_url 'https://api.stripe.com/v1/'  -- Stripe API base URL, optional. Default is 'https://api.stripe.com/v1/'
+        api_url 'https://api.stripe.com/v1/',  -- Stripe API base URL, optional. Default is 'https://api.stripe.com/v1/'
+        api_version '2024-06-20'  -- Stripe API version, optional. Default is your Stripe account’s default API version.
       );
     ```
 

--- a/wrappers/src/fdw/stripe_fdw/README.md
+++ b/wrappers/src/fdw/stripe_fdw/README.md
@@ -10,6 +10,7 @@ This is a foreign data wrapper for [Stripe](https://stripe.com/) developed using
 
 | Version | Date       | Notes                                                |
 | ------- | ---------- | ---------------------------------------------------- |
+| 0.1.9   | 2024-07-01 | Added 'api_version' server option                    |
 | 0.1.7   | 2023-07-13 | Added fdw stats collection                           |
 | 0.1.6   | 2023-05-30 | Added Checkout Session object                        |
 | 0.1.5   | 2023-05-01 | Added 'prices' object and empty result improvement   |


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to add a new `api_version` foreign server option for Stripe FDW. Fix #291 .

## What is the current behavior?

The current Stripe API requests are always using latest Stripe API version, which can cause issues when requesting legacy Stripe API.

## What is the new behavior?

Add a new `api_version` foreign server option, so users can specify a specific Stripe API version number when creating a foreign server.

More details about Stripe API versioning: https://docs.stripe.com/api/versioning

## Additional context

N/A
