### PR TITLE
chore: bump version to 0.4.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,6 +104,7 @@ jobs:
           cp ${extension_dir}/${{ matrix.extension_name }}--${deb_version}.sql ${extension_dir}/${{ matrix.extension_name }}--0.1.18--${deb_version}.sql
           cp ${extension_dir}/${{ matrix.extension_name }}--${deb_version}.sql ${extension_dir}/${{ matrix.extension_name }}--0.1.19--${deb_version}.sql
           cp ${extension_dir}/${{ matrix.extension_name }}--${deb_version}.sql ${extension_dir}/${{ matrix.extension_name }}--0.2.0--${deb_version}.sql
+          cp ${extension_dir}/${{ matrix.extension_name }}--${deb_version}.sql ${extension_dir}/${{ matrix.extension_name }}--0.3.1--${deb_version}.sql
 
           # Create installable package
           mkdir archive

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7615,7 +7615,7 @@ dependencies = [
 
 [[package]]
 name = "wrappers"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "arrow-array",

--- a/wrappers/Cargo.toml
+++ b/wrappers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wrappers"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to bump Wrappers version to `0.4.0`.

## What is the current behavior?

N/A

## What is the new behavior?

N/A

## Additional context

N/A
