### PR TITLE
fix(wasm): missing wasm package cache dir creation

### DIFF
--- a/wrappers/src/fdw/wasm_fdw/README.md
+++ b/wrappers/src/fdw/wasm_fdw/README.md
@@ -1,0 +1,11 @@
+# Wasm Foreign Data Wrapper
+
+This is Wasm foreign data wrapper host, please visit each Wasm foreign data wrapper documentation.
+
+## Changelog
+
+| Version | Date       | Notes                                                |
+| ------- | ---------- | ---------------------------------------------------- |
+| 0.1.1   | 2024-07-05 | Fix missing wasm package cache dir issue             |
+| 0.1.0   | 2024-07-03 | Initial version                                      |
+

--- a/wrappers/src/fdw/wasm_fdw/wasm_fdw.rs
+++ b/wrappers/src/fdw/wasm_fdw/wasm_fdw.rs
@@ -86,7 +86,11 @@ fn download_component(
         // download component wasm from remote and save it to local cache
         let resp = rt.block_on(reqwest::get(url))?;
         let bytes = rt.block_on(resp.bytes())?;
-        fs::write(&path, bytes)?;
+        if let Some(parent) = path.parent() {
+            // create all parent directories if they do not exist
+            fs::create_dir_all(parent).expect("should create cache folder");
+        }
+        fs::write(&path, bytes).expect("should save fdw package");
     }
 
     Ok(Component::from_file(engine, &path).map_err(|err| {
@@ -97,7 +101,7 @@ fn download_component(
 }
 
 #[wrappers_fdw(
-    version = "0.1.0",
+    version = "0.1.1",
     author = "Supabase",
     website = "https://github.com/supabase/wrappers/tree/main/wrappers/src/fdw/wasm_fdw",
     error_type = "WasmFdwError"

--- a/wrappers/src/fdw/wasm_fdw/wasm_fdw.rs
+++ b/wrappers/src/fdw/wasm_fdw/wasm_fdw.rs
@@ -88,9 +88,9 @@ fn download_component(
         let bytes = rt.block_on(resp.bytes())?;
         if let Some(parent) = path.parent() {
             // create all parent directories if they do not exist
-            fs::create_dir_all(parent).expect("should create cache folder");
+            fs::create_dir_all(parent)?;
         }
-        fs::write(&path, bytes).expect("should save fdw package");
+        fs::write(&path, bytes)?;
     }
 
     Ok(Component::from_file(engine, &path).map_err(|err| {


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to fix an issue with wasm package cache dir creation.

## What is the current behavior?

The wasm foreign data wrapper (.wasm file) will be downloaded and saved to local cache folder when foreign table is queried. If the local cache doesn't exist yet, this operation will fail.

## What is the new behavior?

Create the local cache folder if it doesn't exist before save the wasm file.

## Additional context

This PR also added README and change logs for wasm foreign data wrapper.
