### PR TITLE
fix(wasm): add user id to wasm cache file hash

### DIFF
--- a/wrappers/src/fdw/wasm_fdw/wasm_fdw.rs
+++ b/wrappers/src/fdw/wasm_fdw/wasm_fdw.rs
@@ -75,8 +75,9 @@ fn download_component(
 
     // calculate file name hash and make up cache path
     let hash = Sha256::digest(format!(
-        "{}:{}@{}",
+        "{}:{}:{}@{}",
         unsafe { pg_sys::GetUserId().as_u32() },
+        url,
         name,
         version
     ));

--- a/wrappers/src/fdw/wasm_fdw/wasm_fdw.rs
+++ b/wrappers/src/fdw/wasm_fdw/wasm_fdw.rs
@@ -74,9 +74,12 @@ fn download_component(
     // otherwise, download from custom url if it is not in local cache
 
     // calculate file name hash and make up cache path
-    let mut hasher = Sha256::new();
-    hasher.update(format!("{}@{}", name, version));
-    let hash = hasher.finalize();
+    let hash = Sha256::digest(format!(
+        "{}:{}@{}",
+        unsafe { pg_sys::GetUserId().as_u32() },
+        name,
+        version
+    ));
     let file_name = hex::encode(hash);
     let mut path = dirs::cache_dir().expect("no cache dir found");
     path.push(file_name);


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to add current user id and package url to wasm fdw local cache file name hash, which is to mitigate a security issue described below.

## What is the current behavior?

The current wasm fdw local cache file name hash is calculated as `sha256('<pacakge_name>@<version>')`, this will cause a potential security risk. Suppose both user A and B can create foreign table on same database, and then below steps can cause data leaking:

1. user A create a normal foreign table using `package_name=foo, version=1.2.3`, but doesn't query it so the wasm fdw file hasn't been downloaded yet
2. user B made a malicious wasm fdw with the same package name `foo` and version `1.2.3`, this wasm fdw used the same code as user A used, but added an secret code which can post every response to user B controlled data collection site
3. user B published this malicious wasm fdw to a public website
4. user B created another normal foreign table using `package_name=foo, version=1.2.3`, and package url pointing to his wasm fdw
5. user B query his foreign table so the malicious wasm file is downloaded to local cache
6. when user A queries his foreign table, because the cache file name hash is same as user B's wasm fdw, the local malicious wasm file will be loaded and used, thus user A's data is leaked to user B.

## What is the new behavior?

The wasm fdw local cache file name hash will be changed to `sha256('<user_oid>:<package_ur>:<pacakge_name>@<version>')`, so each user will use their own local cache file and will not shared with other users. This will mitigate the vulnerability described above.

## Additional context

After database backup/restore, the user oid may change so the local cache file name hash will be changed, this will trigger another download. That's expected behaviour so we don't need to worry about it.
