### PR TITLE
feat(wasm): add `fdw_package_checksum` server option

### DIFF
--- a/docs/paddle.md
+++ b/docs/paddle.md
@@ -26,9 +26,9 @@ The Paddle API uses JSON formatted data, please refer to [Paddle docs](https://d
 
 ## Available Versions
 
-| Version | Wasm Package URL |
-| --------| ---------------- |
-| 0.1.0   | https://github.com/supabase/wrappers/releases/download/wasm_paddle_fdw_v0.1.0/paddle_fdw.wasm |
+| Version | Wasm Package URL | Checksum |
+| --------| ---------------- | -------- |
+| 0.1.0   | `https://github.com/supabase/wrappers/releases/download/wasm_paddle_fdw_v0.1.0/paddle_fdw.wasm` | `7d0b902440ac2ef1af85d09807145247f14d1d8fd4d700227e5a4d84c8145409` |
 
 ## Preparation
 
@@ -73,6 +73,7 @@ We need to provide Postgres with the credentials to access Paddle, and any addit
         fdw_package_url 'https://github.com/supabase/wrappers/releases/download/wasm_paddle_fdw_v0.1.0/paddle_fdw.wasm',
         fdw_package_name 'supabase:paddle-fdw',
         fdw_package_version '0.1.0',
+        fdw_package_checksum '7d0b902440ac2ef1af85d09807145247f14d1d8fd4d700227e5a4d84c8145409',
         api_url 'https://sandbox-api.paddle.com', -- Use https://api.paddle.com for live account
         api_key_id '<key_ID>' -- The Key ID from above.
       );
@@ -87,6 +88,7 @@ We need to provide Postgres with the credentials to access Paddle, and any addit
         fdw_package_url 'https://github.com/supabase/wrappers/releases/download/wasm_paddle_fdw_v0.1.0/paddle_fdw.wasm',
         fdw_package_name 'supabase:paddle-fdw',
         fdw_package_version '0.1.0',
+        fdw_package_checksum '7d0b902440ac2ef1af85d09807145247f14d1d8fd4d700227e5a4d84c8145409',
         api_url 'https://sandbox-api.paddle.com', -- Use https://api.paddle.com for live account
         api_key 'bb4e69088ea07a98a90565ac610c63654423f8f1e2d48b39b5'
       );

--- a/docs/snowflake.md
+++ b/docs/snowflake.md
@@ -24,9 +24,9 @@ The Snowflake Wrapper is a WebAssembly(Wasm) foreign data wrapper which allows y
 
 ## Available Versions
 
-| Version | Wasm Package URL |
-| --------| ---------------- |
-| 0.1.0   | https://github.com/supabase/wrappers/releases/download/wasm_snowflake_fdw_v0.1.0/snowflake_fdw.wasm |
+| Version | Wasm Package URL | Checksum |
+| --------| ---------------- | -------- |
+| 0.1.0   | `https://github.com/supabase/wrappers/releases/download/wasm_snowflake_fdw_v0.1.0/snowflake_fdw.wasm` | `2fb46fd8afa63f3975dadf772338106b609b131861849356e0c09dde032d1af8` |
 
 ## Preparation
 
@@ -73,6 +73,7 @@ We need to provide Postgres with the credentials to connect to Snowflake, and an
         fdw_package_url 'https://github.com/supabase/wrappers/releases/download/wasm_snowflake_fdw_v0.1.0/snowflake_fdw.wasm',
         fdw_package_name 'supabase:snowflake-fdw',
         fdw_package_version '0.1.0',
+        fdw_package_checksum '2fb46fd8afa63f3975dadf772338106b609b131861849356e0c09dde032d1af8',
         account_identifier 'MYORGANIZATION-MYACCOUNT',
         user 'MYUSER',
         public_key_fingerprint 'SizgPofeFX0jwC8IhbOfGFyOggFgo8oTOS1uPLZhzUQ=',
@@ -89,6 +90,7 @@ We need to provide Postgres with the credentials to connect to Snowflake, and an
         fdw_package_url 'https://github.com/supabase/wrappers/releases/download/wasm_snowflake_fdw_v0.1.0/snowflake_fdw.wasm',
         fdw_package_name 'supabase:snowflake-fdw',
         fdw_package_version '0.1.0',
+        fdw_package_checksum '2fb46fd8afa63f3975dadf772338106b609b131861849356e0c09dde032d1af8',
         account_identifier 'MYORGANIZATION-MYACCOUNT',
         user 'MYUSER',
         public_key_fingerprint 'SizgPofeFX0jwC8IhbOfGFyOggFgo8oTOS1uPLZhzUQ=',

--- a/wrappers/src/fdw/wasm_fdw/README.md
+++ b/wrappers/src/fdw/wasm_fdw/README.md
@@ -6,6 +6,7 @@ This is Wasm foreign data wrapper host, please visit each Wasm foreign data wrap
 
 | Version | Date       | Notes                                                |
 | ------- | ---------- | ---------------------------------------------------- |
+| 0.1.2   | 2024-07-07 | Add fdw_package_checksum server option               |
 | 0.1.1   | 2024-07-05 | Fix missing wasm package cache dir issue             |
 | 0.1.0   | 2024-07-03 | Initial version                                      |
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to add `fdw_package_checksum` server option support. 

## What is the current behavior?

Currently the remote Wasm package is specified by package name, url and version. This package content isn't checked so it is vulnerable to the security issue mentioned in #301 .

## What is the new behavior?

Add `fdw_package_checksum` server option will make the Wasm package content been checked after download, thus can further protect it from the security issue mentioned above.

## Additional context

Note this `fdw_package_checksum` server option is only required for `http://` and `https://` package url, for local file and `warg` protocol the checksum isn't required.
