### PR TITLE
Add support for IMPORT FOREIGN SCHEMA

### DIFF
--- a/supabase-wrappers/src/import_foreign_schema.rs
+++ b/supabase-wrappers/src/import_foreign_schema.rs
@@ -84,5 +84,5 @@ pub(super) extern "C" fn import_foreign_schema<E: Into<ErrorReport>, W: ForeignD
         ret.push(command.as_pg_cstr());
     }
 
-    return ret.into_pg();
+    ret.into_pg()
 }

--- a/supabase-wrappers/src/import_foreign_schema.rs
+++ b/supabase-wrappers/src/import_foreign_schema.rs
@@ -1,0 +1,88 @@
+use pg_sys::AsPgCStr;
+use pgrx::pg_sys::panic::ErrorReport;
+use pgrx::{debug2, prelude::*, PgList};
+
+use crate::options::options_to_hashmap;
+use crate::prelude::ForeignDataWrapper;
+
+#[repr(u32)]
+#[derive(Debug, Clone)]
+pub enum ListType {
+    FdwImportSchemaAll = pgrx::pg_sys::ImportForeignSchemaType_FDW_IMPORT_SCHEMA_ALL,
+    FdwImportSchemaLimitTo = pgrx::pg_sys::ImportForeignSchemaType_FDW_IMPORT_SCHEMA_LIMIT_TO,
+    FdwImportSchemaExcept = pgrx::pg_sys::ImportForeignSchemaType_FDW_IMPORT_SCHEMA_EXCEPT,
+}
+
+#[derive(Debug, Clone)]
+pub struct ImportForeignSchemaStmt {
+    pub server_name: String,
+    pub remote_schema: String,
+    pub local_schema: String,
+    pub list_type: ListType,
+    pub table_list: Vec<String>,
+    pub options: std::collections::HashMap<String, String>,
+}
+
+#[pg_guard]
+pub(super) extern "C" fn import_foreign_schema<E: Into<ErrorReport>, W: ForeignDataWrapper<E>>(
+    stmt: *mut pg_sys::ImportForeignSchemaStmt,
+    server_oid: pg_sys::Oid,
+) -> *mut pg_sys::List {
+    debug2!("---> import_foreign_schema");
+
+    let import_foreign_schema_stmt: ImportForeignSchemaStmt;
+
+    unsafe {
+        import_foreign_schema_stmt = ImportForeignSchemaStmt {
+            server_name: std::ffi::CStr::from_ptr((*stmt).server_name)
+                .to_str()
+                .unwrap()
+                .to_string(),
+            remote_schema: std::ffi::CStr::from_ptr((*stmt).remote_schema)
+                .to_str()
+                .unwrap()
+                .to_string(),
+            local_schema: std::ffi::CStr::from_ptr((*stmt).local_schema)
+                .to_str()
+                .unwrap()
+                .to_string(),
+
+            list_type: match (*stmt).list_type {
+                pgrx::pg_sys::ImportForeignSchemaType_FDW_IMPORT_SCHEMA_ALL => {
+                    ListType::FdwImportSchemaAll
+                }
+                pgrx::pg_sys::ImportForeignSchemaType_FDW_IMPORT_SCHEMA_LIMIT_TO => {
+                    ListType::FdwImportSchemaLimitTo
+                }
+                pgrx::pg_sys::ImportForeignSchemaType_FDW_IMPORT_SCHEMA_EXCEPT => {
+                    ListType::FdwImportSchemaExcept
+                }
+                // This should not happen, it's okay to default to FdwImportSchemaAll
+                // because PostgreSQL will filter the list anyway.
+                _ => ListType::FdwImportSchemaAll,
+            },
+
+            table_list: {
+                let tables: PgList<pg_sys::RangeVar> = PgList::from_pg((*stmt).table_list);
+                tables
+                    .iter_ptr()
+                    .map(|item| {
+                        std::ffi::CStr::from_ptr(item.as_mut().unwrap().relname)
+                            .to_str()
+                            .unwrap()
+                            .to_string()
+                    })
+                    .collect()
+            },
+
+            options: options_to_hashmap((*stmt).options).unwrap(),
+        }
+    }
+
+    let mut ret: PgList<i8> = PgList::new();
+    for command in W::import_foreign_schema(import_foreign_schema_stmt, server_oid) {
+        ret.push(command.as_pg_cstr());
+    }
+
+    return ret.into_pg();
+}

--- a/supabase-wrappers/src/interface.rs
+++ b/supabase-wrappers/src/interface.rs
@@ -631,7 +631,7 @@ pub trait ForeignDataWrapper<E: Into<ErrorReport>> {
         _stmt: crate::import_foreign_schema::ImportForeignSchemaStmt,
         _server_oid: pg_sys::Oid,
     ) -> Vec<String> {
-        return Vec::new();
+        Vec::new()
     }
 
     /// Returns a FdwRoutine for the FDW

--- a/supabase-wrappers/src/lib.rs
+++ b/supabase-wrappers/src/lib.rs
@@ -298,12 +298,12 @@ pub mod utils;
 
 /// The prelude includes all necessary imports to make Wrappers work
 pub mod prelude {
+    pub use crate::import_foreign_schema::*;
     pub use crate::interface::*;
     pub use crate::options::*;
     pub use crate::utils::*;
     pub use crate::wrappers_fdw;
     pub use tokio::runtime::Runtime;
-    pub use crate::import_foreign_schema::*;
 }
 
 use pgrx::prelude::*;

--- a/supabase-wrappers/src/lib.rs
+++ b/supabase-wrappers/src/lib.rs
@@ -308,6 +308,7 @@ pub mod prelude {
 use pgrx::prelude::*;
 use pgrx::AllocatedByPostgres;
 
+mod import_foreign_schema;
 mod instance;
 mod limit;
 mod memctx;

--- a/supabase-wrappers/src/lib.rs
+++ b/supabase-wrappers/src/lib.rs
@@ -303,6 +303,7 @@ pub mod prelude {
     pub use crate::utils::*;
     pub use crate::wrappers_fdw;
     pub use tokio::runtime::Runtime;
+    pub use crate::import_foreign_schema::*;
 }
 
 use pgrx::prelude::*;


### PR DESCRIPTION
## What kind of change does this PR introduce?

This patch add support for the `IMPORT FOREIGN SCHEMA` command.

## What is the current behavior?

Closes https://github.com/supabase/wrappers/issues/175

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

