### PR TITLE
ci: automate extension upgrade scripts creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,10 @@ jobs:
     runs-on: ${{ matrix.box.runner }}
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v3
+      - name: checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: build release artifacts
         run: |
@@ -90,21 +93,10 @@ jobs:
           deb_version=${extension_version:1}
 
           # copy schema file to version update sql files
-          # Note: some version numbers may be skipped
-          cp ${extension_dir}/${{ matrix.extension_name }}--${deb_version}.sql ${extension_dir}/${{ matrix.extension_name }}--0.1.6--${deb_version}.sql
-          cp ${extension_dir}/${{ matrix.extension_name }}--${deb_version}.sql ${extension_dir}/${{ matrix.extension_name }}--0.1.7--${deb_version}.sql
-          cp ${extension_dir}/${{ matrix.extension_name }}--${deb_version}.sql ${extension_dir}/${{ matrix.extension_name }}--0.1.8--${deb_version}.sql
-          cp ${extension_dir}/${{ matrix.extension_name }}--${deb_version}.sql ${extension_dir}/${{ matrix.extension_name }}--0.1.9--${deb_version}.sql
-          cp ${extension_dir}/${{ matrix.extension_name }}--${deb_version}.sql ${extension_dir}/${{ matrix.extension_name }}--0.1.10--${deb_version}.sql
-          cp ${extension_dir}/${{ matrix.extension_name }}--${deb_version}.sql ${extension_dir}/${{ matrix.extension_name }}--0.1.11--${deb_version}.sql
-          cp ${extension_dir}/${{ matrix.extension_name }}--${deb_version}.sql ${extension_dir}/${{ matrix.extension_name }}--0.1.14--${deb_version}.sql
-          cp ${extension_dir}/${{ matrix.extension_name }}--${deb_version}.sql ${extension_dir}/${{ matrix.extension_name }}--0.1.15--${deb_version}.sql
-          cp ${extension_dir}/${{ matrix.extension_name }}--${deb_version}.sql ${extension_dir}/${{ matrix.extension_name }}--0.1.16--${deb_version}.sql
-          cp ${extension_dir}/${{ matrix.extension_name }}--${deb_version}.sql ${extension_dir}/${{ matrix.extension_name }}--0.1.17--${deb_version}.sql
-          cp ${extension_dir}/${{ matrix.extension_name }}--${deb_version}.sql ${extension_dir}/${{ matrix.extension_name }}--0.1.18--${deb_version}.sql
-          cp ${extension_dir}/${{ matrix.extension_name }}--${deb_version}.sql ${extension_dir}/${{ matrix.extension_name }}--0.1.19--${deb_version}.sql
-          cp ${extension_dir}/${{ matrix.extension_name }}--${deb_version}.sql ${extension_dir}/${{ matrix.extension_name }}--0.2.0--${deb_version}.sql
-          cp ${extension_dir}/${{ matrix.extension_name }}--${deb_version}.sql ${extension_dir}/${{ matrix.extension_name }}--0.3.1--${deb_version}.sql
+          for tag in $(git tag -l "v*"); do
+            prev_version=`echo ${tag} | sed -E "s/v(.*)/\1/"`
+            cp ${extension_dir}/${{ matrix.extension_name }}--${deb_version}.sql ${extension_dir}/${{ matrix.extension_name }}--${prev_version}--${deb_version}.sql
+          done
 
           # Create installable package
           mkdir archive

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,8 +94,10 @@ jobs:
 
           # copy schema file to version update sql files
           for tag in $(git tag -l "v*"); do
-            prev_version=`echo ${tag} | sed -E "s/v(.*)/\1/"`
-            cp ${extension_dir}/${{ matrix.extension_name }}--${deb_version}.sql ${extension_dir}/${{ matrix.extension_name }}--${prev_version}--${deb_version}.sql
+            if [[ $tag != $extension_version ]]; then
+              prev_version=${tag:1}
+              cp ${extension_dir}/${{ matrix.extension_name }}--${deb_version}.sql ${extension_dir}/${{ matrix.extension_name }}--${prev_version}--${deb_version}.sql
+            fi
           done
 
           # Create installable package


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to automate the extension upgrade scripts creation.

## What is the current behavior?

When a new version is released, we need to manually change the `release.yml` workflow to add a command for previous version upgrade script. Although this manual process is written in playbook, it is tedious and sometimes missed during release. If a certain version upgrade script is missing, it will cause upgrade issue for database with that legacy version of wrappers.

## What is the new behavior?

Add a shell script to automate the upgrade script creation process, so it won't missing any previous version upgrade script.

## Additional context

N/A
