### PR TITLE
Change import_foreign_schema() signature.

### DIFF
--- a/supabase-wrappers/src/instance.rs
+++ b/supabase-wrappers/src/instance.rs
@@ -2,17 +2,6 @@ use crate::prelude::*;
 use pgrx::pg_sys::panic::ErrorReport;
 use pgrx::prelude::*;
 
-// create a fdw instance from a foreign table id
-pub(super) unsafe fn create_fdw_instance_from_table_id<
-    E: Into<ErrorReport>,
-    W: ForeignDataWrapper<E>,
->(
-    ftable_id: pg_sys::Oid,
-) -> W {
-    let ftable = pg_sys::GetForeignTable(ftable_id);
-    create_fdw_instance_from_server_id((*ftable).serverid)
-}
-
 // create a fdw instance from its id
 pub(super) unsafe fn create_fdw_instance_from_server_id<
     E: Into<ErrorReport>,
@@ -24,4 +13,15 @@ pub(super) unsafe fn create_fdw_instance_from_server_id<
     let fserver_opts = options_to_hashmap((*fserver).options).report_unwrap();
     let wrapper = W::new(&fserver_opts);
     wrapper.report_unwrap()
+}
+
+// create a fdw instance from a foreign table id
+pub(super) unsafe fn create_fdw_instance_from_table_id<
+    E: Into<ErrorReport>,
+    W: ForeignDataWrapper<E>,
+>(
+    ftable_id: pg_sys::Oid,
+) -> W {
+    let ftable = pg_sys::GetForeignTable(ftable_id);
+    create_fdw_instance_from_server_id((*ftable).serverid)
 }

--- a/supabase-wrappers/src/instance.rs
+++ b/supabase-wrappers/src/instance.rs
@@ -2,12 +2,25 @@ use crate::prelude::*;
 use pgrx::pg_sys::panic::ErrorReport;
 use pgrx::prelude::*;
 
-// create a fdw instance
-pub(super) unsafe fn create_fdw_instance<E: Into<ErrorReport>, W: ForeignDataWrapper<E>>(
+// create a fdw instance from a foreign table id
+pub(super) unsafe fn create_fdw_instance_from_table_id<
+    E: Into<ErrorReport>,
+    W: ForeignDataWrapper<E>,
+>(
     ftable_id: pg_sys::Oid,
 ) -> W {
     let ftable = pg_sys::GetForeignTable(ftable_id);
-    let fserver = pg_sys::GetForeignServer((*ftable).serverid);
+    create_fdw_instance_from_server_id((*ftable).serverid)
+}
+
+// create a fdw instance from its id
+pub(super) unsafe fn create_fdw_instance_from_server_id<
+    E: Into<ErrorReport>,
+    W: ForeignDataWrapper<E>,
+>(
+    fserver_id: pg_sys::Oid,
+) -> W {
+    let fserver = pg_sys::GetForeignServer(fserver_id);
     let fserver_opts = options_to_hashmap((*fserver).options).report_unwrap();
     let wrapper = W::new(&fserver_opts);
     wrapper.report_unwrap()

--- a/supabase-wrappers/src/interface.rs
+++ b/supabase-wrappers/src/interface.rs
@@ -628,8 +628,8 @@ pub trait ForeignDataWrapper<E: Into<ErrorReport>> {
     ///
     /// [See more details](https://www.postgresql.org/docs/current/fdw-callbacks.html#FDW-CALLBACKS-IMPORT).
     fn import_foreign_schema(
+        &mut self,
         _stmt: crate::import_foreign_schema::ImportForeignSchemaStmt,
-        _server_oid: pg_sys::Oid,
     ) -> Vec<String> {
         Vec::new()
     }

--- a/supabase-wrappers/src/modify.rs
+++ b/supabase-wrappers/src/modify.rs
@@ -40,7 +40,7 @@ struct FdwModifyState<E: Into<ErrorReport>, W: ForeignDataWrapper<E>> {
 impl<E: Into<ErrorReport>, W: ForeignDataWrapper<E>> FdwModifyState<E, W> {
     unsafe fn new(foreigntableid: Oid, tmp_ctx: PgMemoryContexts) -> Self {
         Self {
-            instance: instance::create_fdw_instance(foreigntableid),
+            instance: instance::create_fdw_instance_from_table_id(foreigntableid),
             rowid_name: String::default(),
             rowid_attno: 0,
             rowid_typid: Oid::INVALID,

--- a/supabase-wrappers/src/scan.rs
+++ b/supabase-wrappers/src/scan.rs
@@ -55,7 +55,7 @@ struct FdwState<E: Into<ErrorReport>, W: ForeignDataWrapper<E>> {
 impl<E: Into<ErrorReport>, W: ForeignDataWrapper<E>> FdwState<E, W> {
     unsafe fn new(foreigntableid: Oid, tmp_ctx: PgMemoryContexts) -> Self {
         Self {
-            instance: instance::create_fdw_instance(foreigntableid),
+            instance: instance::create_fdw_instance_from_table_id(foreigntableid),
             quals: Vec::new(),
             tgts: Vec::new(),
             sorts: Vec::new(),


### PR DESCRIPTION
`import_foreign_schema()` is now a method instead of static method that receives the server id.
