### PR TITLE
feat: Add user-defined cell fmt interface

### DIFF
--- a/supabase-wrappers/src/interface.rs
+++ b/supabase-wrappers/src/interface.rs
@@ -216,6 +216,23 @@ impl FromDatum for Cell {
     }
 }
 
+pub trait CellFormatter {
+    fn fmt_cell(&mut self, cell: &Cell) -> String;
+}
+
+struct DefaultFormatter {}
+
+impl DefaultFormatter {
+    fn new() -> Self {
+        Self {}
+    }
+}
+
+impl CellFormatter for DefaultFormatter {
+    fn fmt_cell(&mut self, cell: &Cell) -> String {
+        format!("{}", cell)
+    }
+}
 /// A data row in a table
 ///
 /// The row contains a column name list and cell list with same number of
@@ -352,13 +369,20 @@ pub struct Qual {
 
 impl Qual {
     pub fn deparse(&self) -> String {
+        let mut formatter = DefaultFormatter::new();
+        self.deparse_with_fmt(&mut formatter)
+    }
+
+    pub fn deparse_with_fmt<T: CellFormatter>(&self, t: &mut T) -> String {
         if self.use_or {
             match &self.value {
                 Value::Cell(_) => unreachable!(),
                 Value::Array(cells) => {
                     let conds: Vec<String> = cells
                         .iter()
-                        .map(|cell| format!("{} {} {}", self.field, self.operator, cell))
+                        .map(|cell| {
+                            format!("{} {} {}", self.field, self.operator, t.fmt_cell(cell))
+                        })
                         .collect();
                     conds.join(" or ")
                 }
@@ -370,11 +394,11 @@ impl Qual {
                         Cell::String(cell) if cell == "null" => {
                             format!("{} {} null", self.field, self.operator)
                         }
-                        _ => format!("{} {} {}", self.field, self.operator, cell),
+                        _ => format!("{} {} {}", self.field, self.operator, t.fmt_cell(cell)),
                     },
-                    "~~" => format!("{} like {}", self.field, cell),
-                    "!~~" => format!("{} not like {}", self.field, cell),
-                    _ => format!("{} {} {}", self.field, self.operator, cell),
+                    "~~" => format!("{} like {}", self.field, t.fmt_cell(cell)),
+                    "!~~" => format!("{} not like {}", self.field, t.fmt_cell(cell)),
+                    _ => format!("{} {} {}", self.field, self.operator, t.fmt_cell(cell)),
                 },
                 Value::Array(_) => unreachable!(),
             }


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the current behavior?
The Cell type format is fixed. While developing a PR for paradeb, I discovered that types like Bytea or Timestamp might be represented differently in various databases. The fmt function of Cell currently supports only the PostgreSQL style. It would be beneficial for users to define their own formatting function while retaining the qual deparse function.

Bytea in postgres is '\x68656C6C6F' and '\x68\x65\x6C\x6C\x6F' in duckdb. It's not Compatible. etc. 

## What is the new behavior?

Users of the crate could implement their own custom formatting for the Cell type

## Additional context

paradedb pr: https://github.com/paradedb/paradedb/pull/1404

[postgres bytea hex fomat](https://www.postgresql.org/docs/current/datatype-binary.html#DATATYPE-BINARY-BYTEA-HEX-FORMAT)
[duckdb bytea hex format](https://duckdb.org/docs/sql/data_types/blob)
