### PR TITLE
Give the full server struct to the FDW when instanciating it

### DIFF
--- a/supabase-wrappers/src/instance.rs
+++ b/supabase-wrappers/src/instance.rs
@@ -1,6 +1,16 @@
+use std::collections::HashMap;
+use std::ffi::CStr;
+
 use crate::prelude::*;
 use pgrx::pg_sys::panic::ErrorReport;
 use pgrx::prelude::*;
+
+pub struct ForeignServer {
+    pub server_name: String,
+    pub server_type: String,
+    pub server_version: String,
+    pub options: HashMap<String, String>
+}
 
 // create a fdw instance from its id
 pub(super) unsafe fn create_fdw_instance_from_server_id<
@@ -9,9 +19,22 @@ pub(super) unsafe fn create_fdw_instance_from_server_id<
 >(
     fserver_id: pg_sys::Oid,
 ) -> W {
+    let to_string = |raw: *mut std::ffi::c_char| -> String {
+        let c_str = CStr::from_ptr(raw);
+        c_str.to_str().map_err(|_| {
+            OptionsError::OptionValueIsInvalidUtf8(
+                String::from_utf8_lossy(c_str.to_bytes()).to_string(),
+            )
+        }).report_unwrap().to_string()
+    };
     let fserver = pg_sys::GetForeignServer(fserver_id);
-    let fserver_opts = options_to_hashmap((*fserver).options).report_unwrap();
-    let wrapper = W::new(&fserver_opts);
+    let server = ForeignServer {
+        server_name: to_string((*fserver).servername),
+        server_type: to_string((*fserver).servertype),
+        server_version: to_string((*fserver).serverversion),
+        options: options_to_hashmap((*fserver).options).report_unwrap(),
+    };
+    let wrapper = W::new(server);
     wrapper.report_unwrap()
 }
 

--- a/supabase-wrappers/src/instance.rs
+++ b/supabase-wrappers/src/instance.rs
@@ -9,7 +9,7 @@ pub struct ForeignServer {
     pub server_name: String,
     pub server_type: String,
     pub server_version: String,
-    pub options: HashMap<String, String>
+    pub options: HashMap<String, String>,
 }
 
 // create a fdw instance from its id
@@ -21,11 +21,15 @@ pub(super) unsafe fn create_fdw_instance_from_server_id<
 ) -> W {
     let to_string = |raw: *mut std::ffi::c_char| -> String {
         let c_str = CStr::from_ptr(raw);
-        c_str.to_str().map_err(|_| {
-            OptionsError::OptionValueIsInvalidUtf8(
-                String::from_utf8_lossy(c_str.to_bytes()).to_string(),
-            )
-        }).report_unwrap().to_string()
+        c_str
+            .to_str()
+            .map_err(|_| {
+                OptionsError::OptionValueIsInvalidUtf8(
+                    String::from_utf8_lossy(c_str.to_bytes()).to_string(),
+                )
+            })
+            .report_unwrap()
+            .to_string()
     };
     let fserver = pg_sys::GetForeignServer(fserver_id);
     let server = ForeignServer {

--- a/supabase-wrappers/src/instance.rs
+++ b/supabase-wrappers/src/instance.rs
@@ -7,8 +7,8 @@ use pgrx::prelude::*;
 
 pub struct ForeignServer {
     pub server_name: String,
-    pub server_type: String,
-    pub server_version: String,
+    pub server_type: Option<String>,
+    pub server_version: Option<String>,
     pub options: HashMap<String, String>,
 }
 
@@ -19,9 +19,12 @@ pub(super) unsafe fn create_fdw_instance_from_server_id<
 >(
     fserver_id: pg_sys::Oid,
 ) -> W {
-    let to_string = |raw: *mut std::ffi::c_char| -> String {
+    let to_string = |raw: *mut std::ffi::c_char| -> Option<String> {
+        if raw.is_null() {
+            return None;
+        }
         let c_str = CStr::from_ptr(raw);
-        c_str
+        let value = c_str
             .to_str()
             .map_err(|_| {
                 OptionsError::OptionValueIsInvalidUtf8(
@@ -29,11 +32,12 @@ pub(super) unsafe fn create_fdw_instance_from_server_id<
                 )
             })
             .report_unwrap()
-            .to_string()
+            .to_string();
+        Some(value)
     };
     let fserver = pg_sys::GetForeignServer(fserver_id);
     let server = ForeignServer {
-        server_name: to_string((*fserver).servername),
+        server_name: to_string((*fserver).servername).unwrap(),
         server_type: to_string((*fserver).servertype),
         server_version: to_string((*fserver).serverversion),
         options: options_to_hashmap((*fserver).options).report_unwrap(),

--- a/supabase-wrappers/src/interface.rs
+++ b/supabase-wrappers/src/interface.rs
@@ -1,6 +1,7 @@
 //! Provides interface types and trait to develop Postgres foreign data wrapper
 //!
 
+use crate::instance::ForeignServer;
 use crate::FdwRoutine;
 use pgrx::pg_sys::panic::ErrorReport;
 use pgrx::prelude::{Date, Timestamp, TimestampWithTimeZone};
@@ -502,7 +503,7 @@ pub trait ForeignDataWrapper<E: Into<ErrorReport>> {
     /// You can do any initalization in this function, like saving connection
     /// info or API url in an variable, but don't do heavy works like database
     /// connection or API call.
-    fn new(options: &HashMap<String, String>) -> Result<Self, E>
+    fn new(server: ForeignServer) -> Result<Self, E>
     where
         Self: Sized;
 

--- a/supabase-wrappers/src/lib.rs
+++ b/supabase-wrappers/src/lib.rs
@@ -299,6 +299,7 @@ pub mod utils;
 /// The prelude includes all necessary imports to make Wrappers work
 pub mod prelude {
     pub use crate::import_foreign_schema::*;
+    pub use crate::instance::ForeignServer;
     pub use crate::interface::*;
     pub use crate::options::*;
     pub use crate::utils::*;

--- a/supabase-wrappers/src/lib.rs
+++ b/supabase-wrappers/src/lib.rs
@@ -90,8 +90,8 @@
 //! type HelloWorldFdwResult<T> = Result<T, HelloWorldFdwError>;
 //!
 //! impl ForeignDataWrapper<HelloWorldFdwError> for HelloWorldFdw {
-//!     fn new(options: &HashMap<String, String>) -> HelloWorldFdwResult<Self> {
-//!         // 'options' is the key-value pairs defined in `CREATE SERVER` SQL, for example,
+//!     fn new(server: ForeignServer) -> HelloWorldFdwResult<Self> {
+//!         // 'server.options' is the key-value pairs defined in `CREATE SERVER` SQL, for example,
 //!         //
 //!         // create server my_helloworld_server
 //!         //   foreign data wrapper wrappers_helloworld
@@ -172,7 +172,7 @@
 //! }
 //!
 //! impl ForeignDataWrapper<HelloWorldFdwError> for HelloWorldFdw {
-//!     fn new(options: &HashMap<String, String>) -> Result<Self, HelloWorldFdwError> {
+//!     fn new(server: ForeignServer) -> Result<Self, HelloWorldFdwError> {
 //!         Ok(Self {
 //!             row_cnt: 0,
 //!             tgt_cols: Vec::new(),

--- a/wrappers/src/fdw/airtable_fdw/airtable_fdw.rs
+++ b/wrappers/src/fdw/airtable_fdw/airtable_fdw.rs
@@ -90,16 +90,16 @@ impl AirtableFdw {
 
 // TODO Add support for INSERT, UPDATE, DELETE
 impl ForeignDataWrapper<AirtableFdwError> for AirtableFdw {
-    fn new(options: &HashMap<String, String>) -> AirtableFdwResult<Self> {
-        let base_url = options
+    fn new(server: ForeignServer) -> AirtableFdwResult<Self> {
+        let base_url = server.options
             .get("api_url")
             .map(|t| t.to_owned())
             .unwrap_or_else(|| "https://api.airtable.com/v0".to_string());
 
-        let client = match options.get("api_key") {
+        let client = match server.options.get("api_key") {
             Some(api_key) => Some(create_client(api_key)?),
             None => {
-                let key_id = require_option("api_key_id", options)?;
+                let key_id = require_option("api_key_id", &server.options)?;
                 if let Some(api_key) = get_vault_secret(key_id) {
                     Some(create_client(&api_key)?)
                 } else {

--- a/wrappers/src/fdw/airtable_fdw/airtable_fdw.rs
+++ b/wrappers/src/fdw/airtable_fdw/airtable_fdw.rs
@@ -91,7 +91,8 @@ impl AirtableFdw {
 // TODO Add support for INSERT, UPDATE, DELETE
 impl ForeignDataWrapper<AirtableFdwError> for AirtableFdw {
     fn new(server: ForeignServer) -> AirtableFdwResult<Self> {
-        let base_url = server.options
+        let base_url = server
+            .options
             .get("api_url")
             .map(|t| t.to_owned())
             .unwrap_or_else(|| "https://api.airtable.com/v0".to_string());

--- a/wrappers/src/fdw/auth0_fdw/auth0_fdw.rs
+++ b/wrappers/src/fdw/auth0_fdw/auth0_fdw.rs
@@ -94,12 +94,12 @@ impl ForeignDataWrapper<Auth0FdwError> for Auth0Fdw {
     // info or API url in an variable, but don't do any heavy works like making a
     // database connection or API call.
 
-    fn new(options: &HashMap<String, String>) -> Result<Self, Auth0FdwError> {
-        let url = require_option("url", options)?.to_string();
-        let api_key = if let Some(api_key) = options.get("api_key") {
+    fn new(server: ForeignServer) -> Result<Self, Auth0FdwError> {
+        let url = require_option("url", &server.options)?.to_string();
+        let api_key = if let Some(api_key) = server.options.get("api_key") {
             api_key.clone()
         } else {
-            let api_key_id = options
+            let api_key_id = server.options
                 .get("api_key_id")
                 .expect("`api_key_id` must be set if `api_key` is not");
             get_vault_secret(api_key_id).ok_or(Auth0FdwError::SecretNotFound(api_key_id.clone()))?

--- a/wrappers/src/fdw/auth0_fdw/auth0_fdw.rs
+++ b/wrappers/src/fdw/auth0_fdw/auth0_fdw.rs
@@ -99,7 +99,8 @@ impl ForeignDataWrapper<Auth0FdwError> for Auth0Fdw {
         let api_key = if let Some(api_key) = server.options.get("api_key") {
             api_key.clone()
         } else {
-            let api_key_id = server.options
+            let api_key_id = server
+                .options
                 .get("api_key_id")
                 .expect("`api_key_id` must be set if `api_key` is not");
             get_vault_secret(api_key_id).ok_or(Auth0FdwError::SecretNotFound(api_key_id.clone()))?

--- a/wrappers/src/fdw/bigquery_fdw/bigquery_fdw.rs
+++ b/wrappers/src/fdw/bigquery_fdw/bigquery_fdw.rs
@@ -160,13 +160,15 @@ impl ForeignDataWrapper<BigQueryFdwError> for BigQueryFdw {
         };
 
         // Is authentication mocked
-        let mock_auth: bool = server.options
+        let mock_auth: bool = server
+            .options
             .get("mock_auth")
             .map(|t| t.to_owned())
             .unwrap_or_else(|| "false".to_string())
             == *"true";
 
-        let api_endpoint = server.options
+        let api_endpoint = server
+            .options
             .get("api_endpoint")
             .map(|t| t.to_owned())
             .unwrap_or_else(|| "https://bigquery.googleapis.com/bigquery/v2".to_string());

--- a/wrappers/src/fdw/bigquery_fdw/bigquery_fdw.rs
+++ b/wrappers/src/fdw/bigquery_fdw/bigquery_fdw.rs
@@ -146,12 +146,12 @@ impl BigQueryFdw {
 }
 
 impl ForeignDataWrapper<BigQueryFdwError> for BigQueryFdw {
-    fn new(options: &HashMap<String, String>) -> Result<Self, BigQueryFdwError> {
+    fn new(server: ForeignServer) -> Result<Self, BigQueryFdwError> {
         let mut ret = BigQueryFdw {
             rt: create_async_runtime()?,
             client: None,
-            project_id: require_option("project_id", options)?.to_string(),
-            dataset_id: require_option("dataset_id", options)?.to_string(),
+            project_id: require_option("project_id", &server.options)?.to_string(),
+            dataset_id: require_option("dataset_id", &server.options)?.to_string(),
             table: "".to_string(),
             rowid_col: "".to_string(),
             tgt_cols: Vec::new(),
@@ -160,13 +160,13 @@ impl ForeignDataWrapper<BigQueryFdwError> for BigQueryFdw {
         };
 
         // Is authentication mocked
-        let mock_auth: bool = options
+        let mock_auth: bool = server.options
             .get("mock_auth")
             .map(|t| t.to_owned())
             .unwrap_or_else(|| "false".to_string())
             == *"true";
 
-        let api_endpoint = options
+        let api_endpoint = server.options
             .get("api_endpoint")
             .map(|t| t.to_owned())
             .unwrap_or_else(|| "https://bigquery.googleapis.com/bigquery/v2".to_string());
@@ -182,10 +182,10 @@ impl ForeignDataWrapper<BigQueryFdwError> for BigQueryFdw {
                 serde_json::to_string_pretty(&dummy_auth_config)
                     .expect("dummy auth config should not fail to serialize")
             }
-            false => match options.get("sa_key") {
+            false => match server.options.get("sa_key") {
                 Some(sa_key) => sa_key.to_owned(),
                 None => {
-                    let sa_key_id = require_option("sa_key_id", options)?;
+                    let sa_key_id = require_option("sa_key_id", &server.options)?;
                     match get_vault_secret(sa_key_id) {
                         Some(sa_key) => sa_key,
                         None => return Ok(ret),

--- a/wrappers/src/fdw/clickhouse_fdw/clickhouse_fdw.rs
+++ b/wrappers/src/fdw/clickhouse_fdw/clickhouse_fdw.rs
@@ -201,12 +201,12 @@ impl ClickHouseFdw {
 }
 
 impl ForeignDataWrapper<ClickHouseFdwError> for ClickHouseFdw {
-    fn new(options: &HashMap<String, String>) -> ClickHouseFdwResult<Self> {
+    fn new(server: ForeignServer) -> ClickHouseFdwResult<Self> {
         let rt = create_async_runtime()?;
-        let conn_str = match options.get("conn_string") {
+        let conn_str = match server.options.get("conn_string") {
             Some(conn_str) => conn_str.to_owned(),
             None => {
-                let conn_str_id = require_option("conn_string_id", options)?;
+                let conn_str_id = require_option("conn_string_id", &server.options)?;
                 get_vault_secret(conn_str_id).unwrap_or_default()
             }
         };

--- a/wrappers/src/fdw/cognito_fdw/cognito_fdw.rs
+++ b/wrappers/src/fdw/cognito_fdw/cognito_fdw.rs
@@ -106,7 +106,8 @@ impl ForeignDataWrapper<CognitoFdwError> for CognitoFdw {
             if let Some(aws_secret_access_key) = server.options.get("aws_secret_access_key") {
                 aws_secret_access_key.clone()
             } else {
-                let aws_secret_access_key = server.options
+                let aws_secret_access_key = server
+                    .options
                     .get("api_key_id")
                     .expect("`api_key_id` must be set if `aws_secret_access_key` is not");
                 get_vault_secret(aws_secret_access_key).ok_or(CognitoFdwError::SecretNotFound(

--- a/wrappers/src/fdw/cognito_fdw/cognito_fdw.rs
+++ b/wrappers/src/fdw/cognito_fdw/cognito_fdw.rs
@@ -97,16 +97,16 @@ impl ForeignDataWrapper<CognitoFdwError> for CognitoFdw {
     // info or API url in an variable, but don't do any heavy works like making a
     // database connection or API call.
 
-    fn new(options: &HashMap<String, String>) -> Result<Self, CognitoFdwError> {
-        let user_pool_id = require_option("user_pool_id", options)?.to_string();
-        let aws_region = require_option("region", options)?.to_string();
+    fn new(server: ForeignServer) -> Result<Self, CognitoFdwError> {
+        let user_pool_id = require_option("user_pool_id", &server.options)?.to_string();
+        let aws_region = require_option("region", &server.options)?.to_string();
 
-        let aws_access_key_id = require_option("aws_access_key_id", options)?.to_string();
+        let aws_access_key_id = require_option("aws_access_key_id", &server.options)?.to_string();
         let aws_secret_access_key =
-            if let Some(aws_secret_access_key) = options.get("aws_secret_access_key") {
+            if let Some(aws_secret_access_key) = server.options.get("aws_secret_access_key") {
                 aws_secret_access_key.clone()
             } else {
-                let aws_secret_access_key = options
+                let aws_secret_access_key = server.options
                     .get("api_key_id")
                     .expect("`api_key_id` must be set if `aws_secret_access_key` is not");
                 get_vault_secret(aws_secret_access_key).ok_or(CognitoFdwError::SecretNotFound(
@@ -122,7 +122,7 @@ impl ForeignDataWrapper<CognitoFdwError> for CognitoFdw {
             let config = aws_config::load_defaults(BehaviorVersion::latest()).await;
 
             let mut builder = config.to_builder();
-            if let Some(endpoint_url) = options.get("endpoint_url") {
+            if let Some(endpoint_url) = server.options.get("endpoint_url") {
                 if !endpoint_url.is_empty() {
                     builder.set_endpoint_url(Some(endpoint_url.clone()));
                 }

--- a/wrappers/src/fdw/helloworld_fdw/helloworld_fdw.rs
+++ b/wrappers/src/fdw/helloworld_fdw/helloworld_fdw.rs
@@ -42,7 +42,7 @@ impl ForeignDataWrapper<HelloWorldFdwError> for HelloWorldFdw {
     // You can do any initalization in this new() function, like saving connection
     // info or API url in an variable, but don't do any heavy works like making a
     // database connection or API call.
-    fn new(_options: &HashMap<String, String>) -> HelloWorldFdwResult<Self> {
+    fn new(_server: ForeignServer) -> HelloWorldFdwResult<Self> {
         Ok(Self {
             row_cnt: 0,
             tgt_cols: Vec::new(),

--- a/wrappers/src/fdw/logflare_fdw/logflare_fdw.rs
+++ b/wrappers/src/fdw/logflare_fdw/logflare_fdw.rs
@@ -194,7 +194,8 @@ impl LogflareFdw {
 
 impl ForeignDataWrapper<LogflareFdwError> for LogflareFdw {
     fn new(server: ForeignServer) -> LogflareFdwResult<Self> {
-        let base_url = server.options
+        let base_url = server
+            .options
             .get("api_url")
             .map(|t| t.to_owned())
             .map(|s| {

--- a/wrappers/src/fdw/logflare_fdw/logflare_fdw.rs
+++ b/wrappers/src/fdw/logflare_fdw/logflare_fdw.rs
@@ -193,8 +193,8 @@ impl LogflareFdw {
 }
 
 impl ForeignDataWrapper<LogflareFdwError> for LogflareFdw {
-    fn new(options: &HashMap<String, String>) -> LogflareFdwResult<Self> {
-        let base_url = options
+    fn new(server: ForeignServer) -> LogflareFdwResult<Self> {
+        let base_url = server.options
             .get("api_url")
             .map(|t| t.to_owned())
             .map(|s| {
@@ -205,10 +205,10 @@ impl ForeignDataWrapper<LogflareFdwError> for LogflareFdw {
                 }
             })
             .unwrap_or_else(|| LogflareFdw::BASE_URL.to_string());
-        let client = match options.get("api_key") {
+        let client = match server.options.get("api_key") {
             Some(api_key) => Some(create_client(api_key)),
             None => {
-                let key_id = require_option("api_key_id", options)?;
+                let key_id = require_option("api_key_id", &server.options)?;
                 get_vault_secret(key_id).map(|api_key| create_client(&api_key))
             }
         }

--- a/wrappers/src/fdw/mssql_fdw/mssql_fdw.rs
+++ b/wrappers/src/fdw/mssql_fdw/mssql_fdw.rs
@@ -170,12 +170,12 @@ impl MssqlFdw {
 }
 
 impl ForeignDataWrapper<MssqlFdwError> for MssqlFdw {
-    fn new(options: &HashMap<String, String>) -> MssqlFdwResult<Self> {
+    fn new(server: ForeignServer) -> MssqlFdwResult<Self> {
         let rt = create_async_runtime()?;
-        let conn_str = match options.get("conn_string") {
+        let conn_str = match server.options.get("conn_string") {
             Some(conn_str) => conn_str.to_owned(),
             None => {
-                let conn_str_id = require_option("conn_string_id", options)?;
+                let conn_str_id = require_option("conn_string_id", &server.options)?;
                 get_vault_secret(conn_str_id).unwrap_or_default()
             }
         };

--- a/wrappers/src/fdw/redis_fdw/redis_fdw.rs
+++ b/wrappers/src/fdw/redis_fdw/redis_fdw.rs
@@ -240,11 +240,11 @@ impl RedisFdw {
 }
 
 impl ForeignDataWrapper<RedisFdwError> for RedisFdw {
-    fn new(options: &HashMap<String, String>) -> RedisFdwResult<Self> {
-        let conn_url = match options.get("conn_url") {
+    fn new(server: ForeignServer) -> RedisFdwResult<Self> {
+        let conn_url = match server.options.get("conn_url") {
             Some(url) => url.to_owned(),
             None => {
-                let conn_url_id = require_option("conn_url_id", options)?;
+                let conn_url_id = require_option("conn_url_id", &server.options)?;
                 get_vault_secret(conn_url_id).unwrap_or_default()
             }
         };

--- a/wrappers/src/fdw/s3_fdw/s3_fdw.rs
+++ b/wrappers/src/fdw/s3_fdw/s3_fdw.rs
@@ -163,7 +163,8 @@ impl ForeignDataWrapper<S3FdwError> for S3Fdw {
         let region = if is_mock {
             default_region
         } else {
-            server.options
+            server
+                .options
                 .get("aws_region")
                 .map(|t| t.to_owned())
                 .unwrap_or(default_region)

--- a/wrappers/src/fdw/stripe_fdw/stripe_fdw.rs
+++ b/wrappers/src/fdw/stripe_fdw/stripe_fdw.rs
@@ -621,7 +621,8 @@ impl StripeFdw {
 
 impl ForeignDataWrapper<StripeFdwError> for StripeFdw {
     fn new(server: ForeignServer) -> StripeFdwResult<Self> {
-        let base_url = server.options
+        let base_url = server
+            .options
             .get("api_url")
             .map(|t| t.to_owned())
             // Ensure trailing slash is always present, otherwise /v1 will get obliterated when

--- a/wrappers/src/fdw/stripe_fdw/stripe_fdw.rs
+++ b/wrappers/src/fdw/stripe_fdw/stripe_fdw.rs
@@ -620,8 +620,8 @@ impl StripeFdw {
 }
 
 impl ForeignDataWrapper<StripeFdwError> for StripeFdw {
-    fn new(options: &HashMap<String, String>) -> StripeFdwResult<Self> {
-        let base_url = options
+    fn new(server: ForeignServer) -> StripeFdwResult<Self> {
+        let base_url = server.options
             .get("api_url")
             .map(|t| t.to_owned())
             // Ensure trailing slash is always present, otherwise /v1 will get obliterated when
@@ -634,11 +634,11 @@ impl ForeignDataWrapper<StripeFdwError> for StripeFdw {
                 }
             })
             .unwrap_or_else(|| "https://api.stripe.com/v1/".to_string());
-        let api_version = options.get("api_version").map(|t| t.as_str());
-        let client = match options.get("api_key") {
+        let api_version = server.options.get("api_version").map(|t| t.as_str());
+        let client = match server.options.get("api_key") {
             Some(api_key) => Some(create_client(api_key, api_version)),
             None => {
-                let key_id = require_option("api_key_id", options)?;
+                let key_id = require_option("api_key_id", &server.options)?;
                 get_vault_secret(key_id).map(|api_key| create_client(&api_key, api_version))
             }
         }

--- a/wrappers/src/fdw/wasm_fdw/wasm_fdw.rs
+++ b/wrappers/src/fdw/wasm_fdw/wasm_fdw.rs
@@ -132,11 +132,11 @@ impl WasmFdw {
 }
 
 impl ForeignDataWrapper<WasmFdwError> for WasmFdw {
-    fn new(options: &HashMap<String, String>) -> WasmFdwResult<Self> {
-        let pkg_url = require_option("fdw_package_url", options)?;
-        let pkg_name = require_option("fdw_package_name", options)?;
-        let pkg_version = require_option("fdw_package_version", options)?;
-        let pkg_checksum = options.get("fdw_package_checksum").map(|t| t.as_str());
+    fn new(server: ForeignServer) -> WasmFdwResult<Self> {
+        let pkg_url = require_option("fdw_package_url", &server.options)?;
+        let pkg_name = require_option("fdw_package_name", &server.options)?;
+        let pkg_version = require_option("fdw_package_version", &server.options)?;
+        let pkg_checksum = server.options.get("fdw_package_checksum").map(|t| t.as_str());
 
         let rt = create_async_runtime()?;
 
@@ -151,7 +151,7 @@ impl ForeignDataWrapper<WasmFdwError> for WasmFdw {
         Wrappers::add_to_linker(&mut linker, |host: &mut FdwHost| host)?;
 
         let mut fdw_host = FdwHost::new(rt);
-        fdw_host.svr_opts.clone_from(options);
+        fdw_host.svr_opts.clone_from(&server.options);
 
         let mut store = Store::new(&engine, fdw_host);
         let (bindings, _) = Wrappers::instantiate(&mut store, &component, &linker)?;

--- a/wrappers/src/fdw/wasm_fdw/wasm_fdw.rs
+++ b/wrappers/src/fdw/wasm_fdw/wasm_fdw.rs
@@ -136,7 +136,10 @@ impl ForeignDataWrapper<WasmFdwError> for WasmFdw {
         let pkg_url = require_option("fdw_package_url", &server.options)?;
         let pkg_name = require_option("fdw_package_name", &server.options)?;
         let pkg_version = require_option("fdw_package_version", &server.options)?;
-        let pkg_checksum = server.options.get("fdw_package_checksum").map(|t| t.as_str());
+        let pkg_checksum = server
+            .options
+            .get("fdw_package_checksum")
+            .map(|t| t.as_str());
 
         let rt = create_async_runtime()?;
 


### PR DESCRIPTION
The complete SQL command to create a foreign data wrapper is 

```
CREATE SERVER [ IF NOT EXISTS ] server_name [ TYPE 'server_type' ] [ VERSION 'server_version' ]
    FOREIGN DATA WRAPPER fdw_name
    [ OPTIONS ( option 'value' [, ... ] ) ]
```

At this time only the options are given to the Foreign Data Wrapper implementation. This patch changes the signature of `ForeignDataWrapper::new()` to give it the full structure that matches PostgreSQL ForeignServer to expose the server_name, server_type and server_version attributes.