### PR TITLE
Fix type of return value for import_foreign_schema()

### DIFF
--- a/supabase-wrappers/src/import_foreign_schema.rs
+++ b/supabase-wrappers/src/import_foreign_schema.rs
@@ -102,7 +102,7 @@ pub(super) extern "C" fn import_foreign_schema<E: Into<ErrorReport>, W: ForeignD
             .import_foreign_schema(import_foreign_schema_stmt);
     }
 
-    let mut ret: PgList<i8> = PgList::new();
+    let mut ret: PgList<std::ffi::c_char> = PgList::new();
     for command in create_stmts {
         ret.push(command.as_pg_cstr());
     }


### PR DESCRIPTION
I checked that this fixes the issue on ARM Linux by using a Docker container on a M2 Mac.

Closes https://github.com/supabase/wrappers/issues/318.