### PR TITLE
docs: fix docs edit link

### DIFF
--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -4,6 +4,7 @@ site_description: A PostgreSQL extension for connecting to external data sources
 copyright: Copyright &copy; Supabase
 repo_name: supabase/wrappers
 repo_url: https://github.com/supabase/wrappers
+edit_uri: blob/main/docs/
 
 nav:
     - Home:  

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -4,7 +4,7 @@ site_description: A PostgreSQL extension for connecting to external data sources
 copyright: Copyright &copy; Supabase
 repo_name: supabase/wrappers
 repo_url: https://github.com/supabase/wrappers
-edit_uri: blob/main/docs/
+edit_uri: edit/main/docs/
 
 nav:
     - Home:  


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to fix broken docs edit link.

## What is the current behavior?

It points to `master` branch by default.

## What is the new behavior?

It points to `main` branch.

## Additional context

N/A
