### PR TITLE
chore: upgrade wasm fdws to v0.1.1

### DIFF
--- a/wasm-wrappers/fdw/helloworld_fdw/Cargo.toml
+++ b/wasm-wrappers/fdw/helloworld_fdw/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "helloworld_fdw"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [lib]

--- a/wasm-wrappers/fdw/paddle_fdw/Cargo.toml
+++ b/wasm-wrappers/fdw/paddle_fdw/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "paddle_fdw"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [lib]

--- a/wasm-wrappers/fdw/snowflake_fdw/Cargo.toml
+++ b/wasm-wrappers/fdw/snowflake_fdw/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snowflake_fdw"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [lib]


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to upgrade 3 wasm fdws to v0.1.1, as their host requirement has been changed in #303 . No business logic change in this upgrade. This upgrade will also use the latest wasm fdw release workflow, so `README.txt` and `checksum.txt` file will be part of this new release.

## What is the current behavior?

N/A

## What is the new behavior?

N/A

## Additional context

After this PR is merged, need to run below commands to do release:

```bash
git tag wasm_paddle_fdw_v0.1.1
git push origin wasm_paddle_fdw_v0.1.1

git tag wasm_snowflake_fdw_v0.1.1
git push origin wasm_snowflake_fdw_v0.1.1
```
