### PR TITLE
docs: reorganize fdw catalog nav

### DIFF
--- a/docs/catalog/wasm/index.md
+++ b/docs/catalog/wasm/index.md
@@ -13,7 +13,7 @@ Foreign data wrappers built with Wasm which can be used on Supabase platform.
 
 <div class="grid cards" markdown>
 
-- :simple-webassembly: &nbsp; **[Paddle](../paddle)**
+- :simple-webassembly: &nbsp; **[Paddle](../paddle.md)**
 
     ----
 
@@ -23,9 +23,9 @@ Foreign data wrappers built with Wasm which can be used on Supabase platform.
 
     :octicons-tag-24: [v0.1.0](https://github.com/supabase/wrappers/releases/tag/wasm_paddle_fdw_v0.1.0) &nbsp;
     :octicons-code-24: [source](https://github.com/supabase/wrappers/tree/wasm_paddle_fdw_v0.1.0/wasm-wrappers/fdw/paddle_fdw) &nbsp;
-    :material-file-document: [docs](../paddle)
+    :material-file-document: [docs](../paddle.md)
 
-- :simple-webassembly: &nbsp; **[Snowflake](../snowflake)**
+- :simple-webassembly: &nbsp; **[Snowflake](../snowflake.md)**
 
     ----
 
@@ -35,6 +35,6 @@ Foreign data wrappers built with Wasm which can be used on Supabase platform.
 
     :octicons-tag-24: [v0.1.0](https://github.com/supabase/wrappers/releases/tag/wasm_snowflake_fdw_v0.1.0) &nbsp;
     :octicons-code-24: [source](https://github.com/supabase/wrappers/tree/wasm_snowflake_fdw_v0.1.0/wasm-wrappers/fdw/snowflake_fdw) &nbsp;
-    :material-file-document: [docs](../snowflake)
+    :material-file-document: [docs](../snowflake.md)
 
 </div>

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -11,21 +11,23 @@ nav:
         - 'index.md'
     - Catalog: 
         - catalog/index.md
-        - Airtable: 'catalog/airtable.md'
-        - Auth0: 'catalog/auth0.md'
-        - AWS Cognito: 'catalog/cognito.md'
-        - BigQuery: 'catalog/bigquery.md'
-        - ClickHouse: 'catalog/clickhouse.md'
-        - Firebase: 'catalog/firebase.md'
-        - Logflare: 'catalog/logflare.md'
-        - Notion: 'catalog/notion.md'
-        - Paddle: 'catalog/paddle.md'
-        - Redis: 'catalog/redis.md'
-        - S3 (CSV, JSON, Parquet): 'catalog/s3.md'
-        - Snowflake: 'catalog/snowflake.md'
-        - Stripe: 'catalog/stripe.md'
-        - SQL Server: 'catalog/mssql.md'
-        - Wasm: 'catalog/wasm.md'
+        - Native:
+          - Airtable: 'catalog/airtable.md'
+          - Auth0: 'catalog/auth0.md'
+          - AWS Cognito: 'catalog/cognito.md'
+          - BigQuery: 'catalog/bigquery.md'
+          - ClickHouse: 'catalog/clickhouse.md'
+          - Firebase: 'catalog/firebase.md'
+          - Logflare: 'catalog/logflare.md'
+          - Notion: 'catalog/notion.md'
+          - Redis: 'catalog/redis.md'
+          - S3 (CSV, JSON, Parquet): 'catalog/s3.md'
+          - Stripe: 'catalog/stripe.md'
+          - SQL Server: 'catalog/mssql.md'
+        - Wasm:
+          - catalog/wasm/index.md
+          - Paddle: 'catalog/paddle.md'
+          - Snowflake: 'catalog/snowflake.md'
     - Guides:
         - Native vs Wasm Wrappers: 'guides/native-wasm.md'
         - Query Pushdown: 'guides/query-pushdown.md'


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to reorganize fdw catalog nav, split them into: native and wasm.

## What is the current behavior?

<img width="218" alt="image" src="https://github.com/user-attachments/assets/97e2b736-7ad3-4e37-8785-fd9e73218cb1">

## What is the new behavior?

<img width="194" alt="image" src="https://github.com/user-attachments/assets/dd6a282e-3e4b-4a09-b879-bd20cff8164c">

## Additional context

N/A
