### PR TITLE
feat: add `get_vault_secret_by_name()` function

### DIFF
--- a/docs/catalog/stripe.md
+++ b/docs/catalog/stripe.md
@@ -41,18 +41,6 @@ create foreign data wrapper stripe_wrapper
 
 We need to provide Postgres with the credentials to connect to Stripe, and any additional options. We can do this using the `create server` command:
 
-=== "Without Vault"
-
-    ```sql
-    create server stripe_server
-      foreign data wrapper stripe_wrapper
-      options (
-        api_key '<Stripe API Key>',  -- Stripe API key, required
-        api_url 'https://api.stripe.com/v1/',  -- Stripe API base URL, optional. Default is 'https://api.stripe.com/v1/'
-        api_version '2024-06-20'  -- Stripe API version, optional. Default is your Stripe account’s default API version.
-      );
-    ```
-
 === "With Vault"
 
     By default, Postgres stores FDW credentials inside `pg_catalog.pg_foreign_server` in plain text. Anyone with access to this table will be able to view these credentials.
@@ -68,13 +56,26 @@ We need to provide Postgres with the credentials to connect to Stripe, and any a
     )
     returning key_id;
     ```
-    Reference the credentials using the Key ID:
+    Reference the credentials using the Key ID or Key Name:
 
     ```sql
     create server stripe_server
       foreign data wrapper stripe_wrapper
       options (
-        api_key_id '<key_ID>', -- The Key ID from above, required.
+        api_key_id '<key_ID>', -- The Key ID from above, required if api_key_name is not specified.
+        api_key_name '<key_Name>', -- The Key Name from above, required if api_key_id is not specified.
+        api_url 'https://api.stripe.com/v1/',  -- Stripe API base URL, optional. Default is 'https://api.stripe.com/v1/'
+        api_version '2024-06-20'  -- Stripe API version, optional. Default is your Stripe account’s default API version.
+      );
+    ```
+
+=== "Without Vault"
+
+    ```sql
+    create server stripe_server
+      foreign data wrapper stripe_wrapper
+      options (
+        api_key '<Stripe API Key>',  -- Stripe API key, required
         api_url 'https://api.stripe.com/v1/',  -- Stripe API base URL, optional. Default is 'https://api.stripe.com/v1/'
         api_version '2024-06-20'  -- Stripe API version, optional. Default is your Stripe account’s default API version.
       );

--- a/wrappers/src/fdw/stripe_fdw/README.md
+++ b/wrappers/src/fdw/stripe_fdw/README.md
@@ -10,6 +10,7 @@ This is a foreign data wrapper for [Stripe](https://stripe.com/) developed using
 
 | Version | Date       | Notes                                                |
 | ------- | ---------- | ---------------------------------------------------- |
+| 0.1.10  | 2024-08-26 | Added 'api_key_name' server option                   |
 | 0.1.9   | 2024-07-01 | Added 'api_version' server option                    |
 | 0.1.7   | 2023-07-13 | Added fdw stats collection                           |
 | 0.1.6   | 2023-05-30 | Added Checkout Session object                        |

--- a/wrappers/src/fdw/stripe_fdw/stripe_fdw.rs
+++ b/wrappers/src/fdw/stripe_fdw/stripe_fdw.rs
@@ -255,7 +255,7 @@ fn inc_stats_request_cnt(stats_metadata: &mut JsonB) -> StripeFdwResult<()> {
 }
 
 #[wrappers_fdw(
-    version = "0.1.9",
+    version = "0.1.10",
     author = "Supabase",
     website = "https://github.com/supabase/wrappers/tree/main/wrappers/src/fdw/stripe_fdw",
     error_type = "StripeFdwError"

--- a/wrappers/src/fdw/stripe_fdw/stripe_fdw.rs
+++ b/wrappers/src/fdw/stripe_fdw/stripe_fdw.rs
@@ -648,7 +648,14 @@ impl ForeignDataWrapper<StripeFdwError> for StripeFdw {
                         .get("api_key_name")
                         .and_then(|key_name| get_vault_secret_by_name(key_name))
                 })
-                .map(|api_key| create_client(&api_key, api_version)),
+                .map(|api_key| create_client(&api_key, api_version))
+                .or_else(|| {
+                    report_error(
+                        pgrx::PgSqlErrorCode::ERRCODE_FDW_ERROR,
+                        "either api_key_id or api_key_name option is required",
+                    );
+                    None
+                }),
         }
         .transpose()?;
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to add `get_vault_secret_by_name()` function in the framework, so fdws can use it to retrieve a secret from Vault by name. This PR will fix #284 .

## What is the current behavior?

Currently the Vault secret can only be retrieved by id, which is inconvenient using with db migrations.

## What is the new behavior?

Added a new `get_vault_secret_by_name()` function in the framework, so downstream fdws can use it to retrieve a secret from Vault by name.

## Additional context

Stripe FDW has been updated in this PR to add a new server option `api_key_name`, which used the new `get_vault_secret_by_name()` function.
