### PR TITLE
chore: bump version to 0.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6043,7 +6043,7 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "supabase-wrappers"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "pgrx",
  "pgrx-tests",
@@ -7642,7 +7642,7 @@ dependencies = [
 
 [[package]]
 name = "wrappers"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "arrow-array",

--- a/supabase-wrappers/Cargo.toml
+++ b/supabase-wrappers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "supabase-wrappers"
-version = "0.1.18"
+version = "0.1.19"
 edition = "2021"
 authors = ["Supabase Inc. https://supabase.com/"]
 license = "Apache-2.0"

--- a/wrappers/Cargo.toml
+++ b/wrappers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wrappers"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to bump versions:

- supabase-wrappers -> v0.1.19
- wrappers -> v0.4.2

## What is the current behavior?

N/A

## What is the new behavior?

N/A

## Additional context

N/A
