### PR TITLE
feat: add boolean test qual support

### DIFF
--- a/supabase-wrappers/src/interface.rs
+++ b/supabase-wrappers/src/interface.rs
@@ -234,6 +234,7 @@ impl CellFormatter for DefaultFormatter {
         format!("{}", cell)
     }
 }
+
 /// A data row in a table
 ///
 /// The row contains a column name list and cell list with same number of
@@ -350,6 +351,11 @@ pub struct Param {
 /// ```sql
 /// where bool_col
 /// -- [Qual { field: "bool_col", operator: "=", value: Cell(Bool(true)), use_or: false }]
+/// ```
+///
+/// ```sql
+/// where bool_col is true
+/// -- [Qual { field: "bool_col", operator: "is", value: Cell(Bool(true)), use_or: false }]
 /// ```
 ///
 /// ```sql

--- a/wrappers/src/fdw/mssql_fdw/README.md
+++ b/wrappers/src/fdw/mssql_fdw/README.md
@@ -10,5 +10,6 @@ This is a foreign data wrapper for [Microsoft SQL Server](https://www.microsoft.
 
 | Version | Date       | Notes                                                |
 | ------- | ---------- | ---------------------------------------------------- |
+| 0.1.1   | 2024-09-09 | Add boolean test qual support                        |
 | 0.1.0   | 2023-12-27 | Initial version                                      |
 

--- a/wrappers/src/fdw/mssql_fdw/tests.rs
+++ b/wrappers/src/fdw/mssql_fdw/tests.rs
@@ -34,6 +34,7 @@ mod tests {
                     r#"CREATE TABLE users (
                         id bigint,
                         name varchar(30),
+                        is_admin bit,
                         dt datetime2
                     )"#,
                     &[],
@@ -46,9 +47,9 @@ mod tests {
             client
                 .execute(
                     r#"
-                    INSERT INTO users(id, name, dt) VALUES (42, 'foo', '2023-12-28');
-                    INSERT INTO users(id, name, dt) VALUES (43, 'bar', '2023-12-27');
-                    INSERT INTO users(id, name, dt) VALUES (44, 'baz', '2023-12-26');
+                    INSERT INTO users(id, name, is_admin, dt) VALUES (42, 'foo', 0, '2023-12-28');
+                    INSERT INTO users(id, name, is_admin, dt) VALUES (43, 'bar', 1, '2023-12-27');
+                    INSERT INTO users(id, name, is_admin, dt) VALUES (44, 'baz', 0, '2023-12-26');
                     "#,
                     &[],
                 )
@@ -79,6 +80,7 @@ mod tests {
                   CREATE FOREIGN TABLE mssql_users (
                     id bigint,
                     name text,
+                    is_admin boolean,
                     dt timestamp
                   )
                   SERVER mssql_server
@@ -163,6 +165,17 @@ mod tests {
                 .filter_map(|r| r.get_by_name::<&str, _>("name").unwrap())
                 .collect::<Vec<_>>();
             assert_eq!(results, vec!["foo", "bar"]);
+
+            let results = c
+                .select(
+                    "SELECT name FROM mssql_users WHERE is_admin is true",
+                    None,
+                    None,
+                )
+                .unwrap()
+                .filter_map(|r| r.get_by_name::<&str, _>("name").unwrap())
+                .collect::<Vec<_>>();
+            assert_eq!(results, vec!["bar"]);
         });
 
         let result = std::panic::catch_unwind(|| {


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to add boolean test qual support to Wrappers. Fix #340 .

## What is the current behavior?

Currently, the boolean test quals, like `bool_col is true` or `bool_col is not false`, are not supported by Wrappers.

## What is the new behavior?

Added support for boolean test quals. The qual `is_admin is active` is parsed like `Qual { field: "is_admin", operator: "is", value: Cell(Bool(true)), use_or: false, param: None }`.

## Additional context

Mssql FDW is changed to adopt this new feature.
