### PR TITLE
docs: fix docs website link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Restoring a logical backup of a database with a materialized view using a foreig
 
 ## Documentation
 
-- [Usage Docs](https://supabase.github.io/wrappers/)
+- [Usage Docs](https://fdw.dev/)
 - [Developer Docs (docs.rs)](https://docs.rs/supabase-wrappers/latest/supabase_wrappers/)
 
 ## Installation
@@ -51,7 +51,7 @@ cargo pgrx install --pg-config [path_to_pg_config] --features stripe_fdw
 
 ## Developing a FDW
 
-Visit [Wrappers Docs](https://supabase.github.io/wrappers/) for more details.
+Visit [Wrappers Docs](https://fdw.dev/) for more details.
 
 ## License
 

--- a/wrappers/src/fdw/airtable_fdw/README.md
+++ b/wrappers/src/fdw/airtable_fdw/README.md
@@ -4,7 +4,7 @@ This is a foreign data wrapper for [Airtable](https://www.airtable.com). It is d
 
 ## Documentation
 
-[https://supabase.github.io/wrappers/airtable/](https://supabase.github.io/wrappers/airtable/)
+[https://fdw.dev/catalog/airtable/](https://fdw.dev/catalog/airtable/)
 
 
 ## Changelog

--- a/wrappers/src/fdw/bigquery_fdw/README.md
+++ b/wrappers/src/fdw/bigquery_fdw/README.md
@@ -4,7 +4,7 @@ This is a foreign data wrapper for [BigQuery](https://cloud.google.com/bigquery)
 
 ## Documentation
 
-[https://supabase.github.io/wrappers/bigquery/](https://supabase.github.io/wrappers/bigquery/)
+[https://fdw.dev/catalog/bigquery/](https://fdw.dev/catalog/bigquery/)
 
 
 ## Changelog

--- a/wrappers/src/fdw/clickhouse_fdw/README.md
+++ b/wrappers/src/fdw/clickhouse_fdw/README.md
@@ -4,7 +4,7 @@ This is a foreign data wrapper for [ClickHouse](https://clickhouse.com/). It is 
 
 ## Documentation
 
-[https://supabase.github.io/wrappers/clickhouse/](https://supabase.github.io/wrappers/clickhouse/)
+[https://fdw.dev/catalog/clickhouse/](https://fdw.dev/catalog/clickhouse/)
 
 
 ## Changelog

--- a/wrappers/src/fdw/cognito_fdw/README.md
+++ b/wrappers/src/fdw/cognito_fdw/README.md
@@ -4,7 +4,7 @@ This is a demo foreign data wrapper which is developed using [Wrappers](https://
 
 ## Documentation
 
-[https://supabase.github.io/wrappers/cognito/](https://supabase.github.io/wrappers/cognito/)
+[https://fdw.dev/catalog/cognito/](https://fdw.dev/catalog/cognito/)
 
 ## Changelog
 

--- a/wrappers/src/fdw/logflare_fdw/README.md
+++ b/wrappers/src/fdw/logflare_fdw/README.md
@@ -4,7 +4,7 @@ This is a foreign data wrapper for [Logflare](https://logflare.app/). It is deve
 
 ## Documentation
 
-[https://supabase.github.io/wrappers/logflare/](https://supabase.github.io/wrappers/logflare/)
+[https://fdw.dev/catalog/logflare/](https://fdw.dev/catalog/logflare/)
 
 ## Changelog
 

--- a/wrappers/src/fdw/mssql_fdw/README.md
+++ b/wrappers/src/fdw/mssql_fdw/README.md
@@ -4,7 +4,7 @@ This is a foreign data wrapper for [Microsoft SQL Server](https://www.microsoft.
 
 ## Documentation
 
-[https://supabase.github.io/wrappers/mssql/](https://supabase.github.io/wrappers/mssql/)
+[https://fdw.dev/catalog/mssql/](https://fdw.dev/catalog/mssql/)
 
 ## Changelog
 

--- a/wrappers/src/fdw/notion_fdw/README.md
+++ b/wrappers/src/fdw/notion_fdw/README.md
@@ -4,7 +4,7 @@ This is a foreign data wrapper for [Notion](https://notion.so/) developed using 
 
 ## Documentation
 
-[https://supabase.github.io/wrappers/notion](https://supabase.github.io/wrappers/notion/)
+[https://fdw.dev/catalog/notion](https://fdw.dev/catalog/notion/)
 
 ## Basic usage
 

--- a/wrappers/src/fdw/redis_fdw/README.md
+++ b/wrappers/src/fdw/redis_fdw/README.md
@@ -4,7 +4,7 @@ This is a foreign data wrapper for [Redis](https://redis.io/). It is developed u
 
 ## Documentation
 
-[https://supabase.github.io/wrappers/redis/](https://supabase.github.io/wrappers/redis/)
+[https://fdw.dev/catalog/redis/](https://fdw.dev/catalog/redis/)
 
 ## Changelog
 

--- a/wrappers/src/fdw/s3_fdw/README.md
+++ b/wrappers/src/fdw/s3_fdw/README.md
@@ -4,7 +4,7 @@ This is a foreign data wrapper for [AWS S3](https://aws.amazon.com/s3/). It is d
 
 ## Documentation
 
-[https://supabase.github.io/wrappers/s3/](https://supabase.github.io/wrappers/s3/)
+[https://fdw.dev/catalog/s3/](https://fdw.dev/catalog/s3/)
 
 ## Changelog
 

--- a/wrappers/src/fdw/stripe_fdw/README.md
+++ b/wrappers/src/fdw/stripe_fdw/README.md
@@ -4,7 +4,7 @@ This is a foreign data wrapper for [Stripe](https://stripe.com/) developed using
 
 ## Documentation
 
-[https://supabase.github.io/wrappers/stripe/](https://supabase.github.io/wrappers/stripe/)
+[https://fdw.dev/catalog/stripe/](https://fdw.dev/catalog/stripe/)
 
 ## Changelog
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to fix all docs website link in README files as we've moved to the new docs website: https://fdw.dev/.

## What is the current behavior?

N/A

## What is the new behavior?

N/A

## Additional context

N/A
