### PR TITLE
feat(clickhouse): add Nullable data type support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -661,7 +661,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "tracing",
- "uuid 1.8.0",
+ "uuid",
 ]
 
 [[package]]
@@ -1364,7 +1364,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29c39203181991a7dd4343b8005bd804e7a9a37afb8ac070e43771e8c820bbde"
 dependencies = [
  "chrono",
- "chrono-tz-build",
+ "chrono-tz-build 0.0.3",
+ "phf",
+]
+
+[[package]]
+name = "chrono-tz"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d59ae0466b83e838b81a54256c39d5d7c20b9d7daa10510a242d9b75abd5936e"
+dependencies = [
+ "chrono",
+ "chrono-tz-build 0.2.1",
  "phf",
 ]
 
@@ -1373,6 +1384,17 @@ name = "chrono-tz-build"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f509c3a87b33437b05e2458750a0700e5bdd6956176773e6c7d6dd15a283a0c"
+dependencies = [
+ "parse-zoneinfo",
+ "phf",
+ "phf_codegen",
+]
+
+[[package]]
+name = "chrono-tz-build"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "433e39f13c9a060046954e0592a8d0a4bcb1040125cbf91cb8ee58964cfb350f"
 dependencies = [
  "parse-zoneinfo",
  "phf",
@@ -1451,12 +1473,13 @@ checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "clickhouse-rs"
-version = "1.0.0-alpha.1"
-source = "git+https://github.com/suharev7/clickhouse-rs?rev=ecf28f4677#ecf28f46774773f39c74ee5213ad1e3ea240739b"
+version = "1.1.0-alpha.1"
+source = "git+https://github.com/suharev7/clickhouse-rs?rev=abfe517101eefe36bfdb7da248690659aa284ad3#abfe517101eefe36bfdb7da248690659aa284ad3"
 dependencies = [
  "byteorder",
+ "cfg-if",
  "chrono",
- "chrono-tz",
+ "chrono-tz 0.8.6",
  "clickhouse-rs-cityhash-sys",
  "combine",
  "crossbeam",
@@ -1475,13 +1498,13 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "url",
- "uuid 0.8.2",
+ "uuid",
 ]
 
 [[package]]
 name = "clickhouse-rs-cityhash-sys"
 version = "0.1.2"
-source = "git+https://github.com/suharev7/clickhouse-rs?rev=ecf28f4677#ecf28f46774773f39c74ee5213ad1e3ea240739b"
+source = "git+https://github.com/suharev7/clickhouse-rs?rev=abfe517101eefe36bfdb7da248690659aa284ad3#abfe517101eefe36bfdb7da248690659aa284ad3"
 dependencies = [
  "cc",
 ]
@@ -4298,7 +4321,7 @@ dependencies = [
  "serde_cbor",
  "serde_json",
  "thiserror",
- "uuid 1.8.0",
+ "uuid",
 ]
 
 [[package]]
@@ -5288,7 +5311,7 @@ dependencies = [
  "rkyv_derive",
  "seahash",
  "tinyvec",
- "uuid 1.8.0",
+ "uuid",
 ]
 
 [[package]]
@@ -6050,7 +6073,7 @@ dependencies = [
  "supabase-wrappers-macros",
  "thiserror",
  "tokio",
- "uuid 1.8.0",
+ "uuid",
 ]
 
 [[package]]
@@ -6238,7 +6261,7 @@ dependencies = [
  "rust_decimal",
  "thiserror",
  "tracing",
- "uuid 1.8.0",
+ "uuid",
  "winauth",
 ]
 
@@ -6692,12 +6715,6 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
-
-[[package]]
-name = "uuid"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 
 [[package]]
 name = "uuid"
@@ -7651,7 +7668,7 @@ dependencies = [
  "aws-sdk-cognitoidentityprovider",
  "aws-sdk-s3",
  "chrono",
- "chrono-tz",
+ "chrono-tz 0.6.3",
  "clickhouse-rs",
  "csv",
  "dirs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7672,6 +7672,7 @@ dependencies = [
  "clickhouse-rs",
  "csv",
  "dirs",
+ "either",
  "futures",
  "gcp-bigquery-client",
  "hex",

--- a/docs/catalog/clickhouse.md
+++ b/docs/catalog/clickhouse.md
@@ -33,6 +33,7 @@ The ClickHouse Wrapper allows you to read and write data from ClickHouse within 
 | text             | String          |
 | date             | Date            |
 | timestamp        | DateTime        |
+| *                | Nullable<T>     |
 
 ## Preparation
 

--- a/wrappers/Cargo.toml
+++ b/wrappers/Cargo.toml
@@ -26,7 +26,7 @@ bigquery_fdw = [
     "yup-oauth2",
     "thiserror",
 ]
-clickhouse_fdw = ["clickhouse-rs", "chrono", "chrono-tz", "regex", "thiserror"]
+clickhouse_fdw = ["clickhouse-rs", "chrono", "chrono-tz", "regex", "thiserror", "either"]
 stripe_fdw = [
     "http",
     "reqwest",
@@ -175,6 +175,7 @@ clickhouse-rs = { git = "https://github.com/suharev7/clickhouse-rs", rev = "abfe
 ], optional = true }
 chrono = { version = "0.4", optional = true }
 chrono-tz = { version = "0.6", optional = true }
+either = { version = "1.12.0", optional = true }
 
 
 # for bigquery_fdw, firebase_fdw, airtable_fdw and etc.

--- a/wrappers/Cargo.toml
+++ b/wrappers/Cargo.toml
@@ -170,7 +170,7 @@ pgrx = { version = "=0.11.3" }
 supabase-wrappers = { path = "../supabase-wrappers", default-features = false }
 
 # for clickhouse_fdw
-clickhouse-rs = { git = "https://github.com/suharev7/clickhouse-rs", rev = "ecf28f4677", features = [
+clickhouse-rs = { git = "https://github.com/suharev7/clickhouse-rs", rev = "abfe517101eefe36bfdb7da248690659aa284ad3", features = [
     "tls",
 ], optional = true }
 chrono = { version = "0.4", optional = true }

--- a/wrappers/src/fdw/clickhouse_fdw/README.md
+++ b/wrappers/src/fdw/clickhouse_fdw/README.md
@@ -11,6 +11,7 @@ This is a foreign data wrapper for [ClickHouse](https://clickhouse.com/). It is 
 
 | Version | Date       | Notes                                                |
 | ------- | ---------- | ---------------------------------------------------- |
+| 0.1.4   | 2024-09-10 | Added Nullable type suppport                         |
 | 0.1.3   | 2023-07-17 | Added sort and limit pushdown suppport               |
 | 0.1.2   | 2023-07-13 | Added fdw stats collection                           |
 | 0.1.1   | 2023-05-19 | Added custom sql support                             |


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to add `Nullable<T>` data type support for Clickhouse FDW.

## What is the current behavior?

Currently `Nullable<T>` data type is not supported.

## What is the new behavior?

`Nullable<T>` data type is supported.

## Additional context

This PR also upgraded dependent Clickhouse client lib.
