### PR TITLE
docs: Update the nullable to use escaped angle brackets

### DIFF
--- a/docs/catalog/clickhouse.md
+++ b/docs/catalog/clickhouse.md
@@ -33,7 +33,7 @@ The ClickHouse Wrapper allows you to read and write data from ClickHouse within 
 | text             | String          |
 | date             | Date            |
 | timestamp        | DateTime        |
-| *                | Nullable<T>     |
+| *                | Nullable&lt;T&gt; |
 
 ## Preparation
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR fixes the angle brackets in the docs for Clickhouse.

## What is the current behavior?

The docs use `Nullable<T>` but markdown table handle angle brackets badly.

## What is the new behavior?

This PR changes the docs to use `&lt;` and `&gt;` instead.

## Additional context

Breaks all deployments of the `docs` app because the Clickhouse docs are fetched during each build.