### PR TITLE
feat: add array cell type support

### DIFF
--- a/supabase-wrappers/src/interface.rs
+++ b/supabase-wrappers/src/interface.rs
@@ -209,12 +209,12 @@ impl IntoDatum for Cell {
             || other == pg_sys::TIMESTAMPTZOID
             || other == pg_sys::JSONBOID
             || other == pg_sys::BOOLARRAYOID
-            || other == pg_sys::TEXTARRAYOID
             || other == pg_sys::INT2ARRAYOID
             || other == pg_sys::INT4ARRAYOID
             || other == pg_sys::INT8ARRAYOID
             || other == pg_sys::FLOAT4ARRAYOID
             || other == pg_sys::FLOAT8ARRAYOID
+            || other == pg_sys::TEXTARRAYOID
     }
 }
 

--- a/wrappers/src/fdw/bigquery_fdw/bigquery_fdw.rs
+++ b/wrappers/src/fdw/bigquery_fdw/bigquery_fdw.rs
@@ -42,7 +42,9 @@ fn field_to_cell(rs: &ResultSet, field: &TableFieldSchema) -> BigQueryFdwResult<
             Cell::Timestamp(ts.to_utc())
         }),
         _ => {
-            return Err(BigQueryFdwError::UnsupportedFieldType(field.r#type.clone()));
+            return Err(BigQueryFdwError::UnsupportedFieldType(
+                field.name.to_owned(),
+            ));
         }
     })
 }
@@ -397,6 +399,11 @@ impl ForeignDataWrapper<BigQueryFdwError> for BigQueryFdw {
                         Cell::Timestamp(v) => row_json[col_name] = json!(v),
                         Cell::Timestamptz(v) => row_json[col_name] = json!(v),
                         Cell::Json(v) => row_json[col_name] = json!(v),
+                        _ => {
+                            return Err(BigQueryFdwError::UnsupportedFieldType(
+                                col_name.to_owned(),
+                            ));
+                        }
                     }
                 }
             }

--- a/wrappers/src/fdw/bigquery_fdw/mod.rs
+++ b/wrappers/src/fdw/bigquery_fdw/mod.rs
@@ -1,7 +1,6 @@
 #![allow(clippy::module_inception)]
 
 use gcp_bigquery_client::error::BQError;
-use gcp_bigquery_client::model::field_type::FieldType;
 use pgrx::pg_sys::panic::ErrorReport;
 use pgrx::{DateTimeConversionError, PgSqlErrorCode};
 use supabase_wrappers::prelude::{CreateRuntimeError, OptionsError};
@@ -21,8 +20,8 @@ enum BigQueryFdwError {
     #[error("big query error: {0}")]
     BigQueryError(#[from] BQError),
 
-    #[error("field type {0:?} not supported")]
-    UnsupportedFieldType(FieldType),
+    #[error("field {0} type not supported")]
+    UnsupportedFieldType(String),
 
     #[error("{0}")]
     NumericConversionError(#[from] pgrx::numeric::Error),

--- a/wrappers/src/fdw/wasm_fdw/bindings.rs
+++ b/wrappers/src/fdw/wasm_fdw/bindings.rs
@@ -79,6 +79,7 @@ impl From<&HostCell> for GuestCell {
                 Self::Timestamptz(v.into_inner() + 946_684_800_000_000)
             }
             HostCell::Json(v) => Self::Json(v.0.to_string()),
+            _ => todo!(),
         }
     }
 }

--- a/wrappers/src/fdw/wasm_fdw/bindings.rs
+++ b/wrappers/src/fdw/wasm_fdw/bindings.rs
@@ -79,7 +79,7 @@ impl From<&HostCell> for GuestCell {
                 Self::Timestamptz(v.into_inner() + 946_684_800_000_000)
             }
             HostCell::Json(v) => Self::Json(v.0.to_string()),
-            _ => todo!(),
+            _ => todo!("Add array type support for Wasm FDW"),
         }
     }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to add `Array` cell type support.

## What is the current behavior?

Currently array cell type isn't supported.

## What is the new behavior?

Add below array cell types support to framework.

- BoolArray
- I16Array
- I32Array
- I64Array
- F32Array
- F64Array
- StringArray

## Additional context

N/A