### PR TITLE
chore: add support for pgrx v0.12.6 and pg17

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,8 +37,8 @@ jobs:
         extension_name:
           - wrappers
         pgrx_version:
-          - 0.11.3
-        postgres: [14, 15, 16]
+          - 0.12.6
+        postgres: [14, 15, 16, 17]
         features:
           - "all_fdws"
         box:

--- a/.github/workflows/test_supabase_wrappers.yml
+++ b/.github/workflows/test_supabase_wrappers.yml
@@ -40,7 +40,7 @@ jobs:
           postgresql-server-dev-15
         sudo chmod a+rwx `/usr/lib/postgresql/15/bin/pg_config --pkglibdir` `/usr/lib/postgresql/15/bin/pg_config --sharedir`/extension /var/run/postgresql/
 
-    - run: cargo install cargo-pgrx --version 0.11.3
+    - run: cargo install cargo-pgrx --version 0.12.6
     - run: cargo pgrx init --pg15 /usr/lib/postgresql/15/bin/pg_config
 
     - name: Format code

--- a/.github/workflows/test_wrappers.yml
+++ b/.github/workflows/test_wrappers.yml
@@ -47,7 +47,7 @@ jobs:
           postgresql-server-dev-15
         sudo chmod a+rwx `/usr/lib/postgresql/15/bin/pg_config --pkglibdir` `/usr/lib/postgresql/15/bin/pg_config --sharedir`/extension /var/run/postgresql/
 
-    - run: cargo install cargo-pgrx --version 0.11.3
+    - run: cargo install cargo-pgrx --version 0.12.6
     - run: cargo pgrx init --pg15 /usr/lib/postgresql/15/bin/pg_config
 
     - name: Format code
@@ -102,7 +102,7 @@ jobs:
           postgresql-server-dev-15
         sudo chmod a+rwx `/usr/lib/postgresql/15/bin/pg_config --pkglibdir` `/usr/lib/postgresql/15/bin/pg_config --sharedir`/extension /var/run/postgresql/
 
-    - run: cargo install cargo-pgrx --version 0.11.3
+    - run: cargo install cargo-pgrx --version 0.12.6
     - run: cargo pgrx init --pg15 /usr/lib/postgresql/15/bin/pg_config
     - run: cargo install cargo-component --version 0.13.2
     - run: rustup target add wasm32-unknown-unknown

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4359,9 +4359,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx"
-version = "0.12.5"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39464992d5b3cdda6b390efe51c27e849d2e93c1811e7610cf88f82d5b6a1a23"
+checksum = "29fd8bef6f9f963a224b6d92033aa75581ecf01c8a815eb6dea0ad7260ac4541"
 dependencies = [
  "atomic-traits",
  "bitflags 2.5.0",
@@ -4383,9 +4383,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-bindgen"
-version = "0.12.5"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b03b74332a89c852486c0a53c33e049fb56d7911e251ddd05b7820b2963592"
+checksum = "bb9cd617058bad2d78e31c55b58d2b003dcf039cba125b8e018c0f72562fb951"
 dependencies = [
  "bindgen",
  "cc",
@@ -4401,9 +4401,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-macros"
-version = "0.12.5"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "822e16af0dfc820dbd407b19538fde0def27c7d1913dea47a42c040c8bcf8b56"
+checksum = "cbf074a98b59d1811b29c97e58d7ec5cab00445c7a5d7ed4153d746eb8572d55"
 dependencies = [
  "pgrx-sql-entity-graph",
  "proc-macro2",
@@ -4413,9 +4413,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-config"
-version = "0.12.5"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31061cc1a9f860d1302ba952ccf3b3d0eec59be94f0a32bcc8ba858fdd44a824"
+checksum = "a82140784390a8f7f8a4f36acc6c04d177f59666012fa419eb03ab90201945ef"
 dependencies = [
  "cargo_toml",
  "eyre",
@@ -4431,9 +4431,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-sys"
-version = "0.12.5"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0225f2eeacf00702a705cbeb50252f4279169cd08501f73889b479d23a4250e1"
+checksum = "6a0b49de7e28fdf7eb9ace7b736c2527330441efd35e55768fa26c637366d1c3"
 dependencies = [
  "cee-scape",
  "libc",
@@ -4446,9 +4446,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-sql-entity-graph"
-version = "0.12.5"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9c9dfdc4b31b381405b9735b7d674680b42584ea2ef89f3668a21be57a39310"
+checksum = "dbf0cb2b4c8204678cf3dfc71bd0febe11dd4a6636b1971c3ee595d58d2db5f6"
 dependencies = [
  "convert_case",
  "eyre",
@@ -4462,9 +4462,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-tests"
-version = "0.12.5"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "992bb74e9cd178a55eab23f7a4b890a5427a411bbaf9588c86d435a3664eb4d2"
+checksum = "207fa953e4634371ff00e20584e80b1faf0c381fb7bec14648ce9076494582de"
 dependencies = [
  "clap-cargo",
  "eyre",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,6 +100,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "annotate-snippets"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccaf7e9dfbb6ab22c82e473cd1a8a7bd313c19a5b7e40970f3d89ef5a5c9e81e"
+dependencies = [
+ "unicode-width",
+ "yansi-term",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -552,15 +562,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
 dependencies = [
  "num-traits 0.2.19",
-]
-
-[[package]]
-name = "atomic-polyfill"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
-dependencies = [
- "critical-section",
 ]
 
 [[package]]
@@ -1062,16 +1063,15 @@ checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 
 [[package]]
 name = "bindgen"
-version = "0.69.4"
+version = "0.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
+checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
 dependencies = [
+ "annotate-snippets",
  "bitflags 2.5.0",
  "cexpr",
  "clang-sys",
  "itertools 0.12.1",
- "lazy_static 1.4.0",
- "lazycell",
  "proc-macro2",
  "quote",
  "regex",
@@ -1301,10 +1301,42 @@ dependencies = [
 ]
 
 [[package]]
-name = "cargo_toml"
-version = "0.16.3"
+name = "camino"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3f9629bc6c4388ea699781dc988c2b99766d7679b151c81990b4fa1208fafd3"
+checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
+dependencies = [
+ "serde 1.0.202",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24b1f0365a6c6bb4020cd05806fd0d33c44d38046b8bd7f0e40814b9763cabfc"
+dependencies = [
+ "serde 1.0.202",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver 1.0.23",
+ "serde 1.0.202",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "cargo_toml"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a98356df42a2eb1bd8f1793ae4ee4de48e384dd974ce5eac8eee802edb7492be"
 dependencies = [
  "serde 1.0.202",
  "toml 0.8.13",
@@ -1319,6 +1351,16 @@ dependencies = [
  "jobserver",
  "libc",
  "once_cell",
+]
+
+[[package]]
+name = "cee-scape"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d67dfb052149f779f77e9ce089cea126e00657e8f0d11dafc7901fde4291101"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -1433,12 +1475,13 @@ dependencies = [
 
 [[package]]
 name = "clap-cargo"
-version = "0.11.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25122ca6ebad5f53578c26638afd9f0160426969970dc37ec6c363ff6b082ebd"
+checksum = "23b2ea69cefa96b848b73ad516ad1d59a195cdf9263087d977f648a818c8b43e"
 dependencies = [
+ "anstyle",
+ "cargo_metadata",
  "clap",
- "doc-comment",
 ]
 
 [[package]]
@@ -1781,12 +1824,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "critical-section"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
-
-[[package]]
 name = "crossbeam"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2070,12 +2107,6 @@ dependencies = [
  "redox_users",
  "windows-sys 0.48.0",
 ]
-
-[[package]]
-name = "doc-comment"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "dyn-clone"
@@ -2769,9 +2800,9 @@ dependencies = [
 
 [[package]]
 name = "hash32"
-version = "0.2.1"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
 dependencies = [
  "byteorder",
 ]
@@ -2806,14 +2837,11 @@ dependencies = [
 
 [[package]]
 name = "heapless"
-version = "0.7.17"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
 dependencies = [
- "atomic-polyfill",
  "hash32",
- "rustc_version 0.4.0",
- "spin 0.9.8",
  "stable_deref_trait",
 ]
 
@@ -2843,6 +2871,12 @@ name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "hermit-abi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
 name = "hex"
@@ -2890,6 +2924,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4ce1f4656bae589a3fab938f9f09bf58645b7ed01a2c5f8a3c238e01a4ef78a"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+dependencies = [
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3230,6 +3273,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
+name = "is-terminal"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
+dependencies = [
+ "hermit-abi 0.4.0",
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "is_ci"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3345,12 +3405,6 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 dependencies = [
  "spin 0.5.2",
 ]
-
-[[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "leb128"
@@ -4067,9 +4121,13 @@ checksum = "4030760ffd992bef45b0ae3f10ce1aba99e33464c90d14dd7c039884963ddc7a"
 
 [[package]]
 name = "owo-colors"
-version = "3.5.0"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
+checksum = "fb37767f6569cd834a413442455e0f066d0d522de8630436e2a1761d9726ba56"
+dependencies = [
+ "supports-color 2.1.0",
+ "supports-color 3.0.1",
+]
 
 [[package]]
 name = "p256"
@@ -4301,9 +4359,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx"
-version = "0.11.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2102faa5ef4a7bf096fefcf67692b293583efd18f9236340ad3169807dfc2b73"
+checksum = "39464992d5b3cdda6b390efe51c27e849d2e93c1811e7610cf88f82d5b6a1a23"
 dependencies = [
  "atomic-traits",
  "bitflags 2.5.0",
@@ -4316,7 +4374,6 @@ dependencies = [
  "pgrx-pg-sys",
  "pgrx-sql-entity-graph",
  "seahash",
- "seq-macro",
  "serde 1.0.202",
  "serde_cbor",
  "serde_json",
@@ -4325,85 +4382,95 @@ dependencies = [
 ]
 
 [[package]]
-name = "pgrx-macros"
-version = "0.11.3"
+name = "pgrx-bindgen"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c26810d09910ec987a6708d48d243efb5f879331e01c6fec0893714d0eb12bae"
+checksum = "84b03b74332a89c852486c0a53c33e049fb56d7911e251ddd05b7820b2963592"
+dependencies = [
+ "bindgen",
+ "cc",
+ "clang-sys",
+ "eyre",
+ "pgrx-pg-config",
+ "proc-macro2",
+ "quote",
+ "shlex",
+ "syn 2.0.65",
+ "walkdir",
+]
+
+[[package]]
+name = "pgrx-macros"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "822e16af0dfc820dbd407b19538fde0def27c7d1913dea47a42c040c8bcf8b56"
 dependencies = [
  "pgrx-sql-entity-graph",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.65",
 ]
 
 [[package]]
 name = "pgrx-pg-config"
-version = "0.11.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b0099ba4b635dfe1e34afc8bca8be43e9577c5d726aaf1dc7dd23a78f6c8a60"
+checksum = "31061cc1a9f860d1302ba952ccf3b3d0eec59be94f0a32bcc8ba858fdd44a824"
 dependencies = [
  "cargo_toml",
- "dirs",
  "eyre",
+ "home",
  "owo-colors",
  "pathsearch",
  "serde 1.0.202",
- "serde_derive",
  "serde_json",
+ "thiserror",
  "toml 0.8.13",
  "url",
 ]
 
 [[package]]
 name = "pgrx-pg-sys"
-version = "0.11.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f40315259c41fede51eb23b791b48d0a112b0f47d0dcb6862b798d1fa1db6ea"
+checksum = "0225f2eeacf00702a705cbeb50252f4279169cd08501f73889b479d23a4250e1"
 dependencies = [
- "bindgen",
- "clang-sys",
- "eyre",
+ "cee-scape",
  "libc",
- "memoffset 0.9.1",
- "once_cell",
+ "pgrx-bindgen",
  "pgrx-macros",
- "pgrx-pg-config",
  "pgrx-sql-entity-graph",
- "proc-macro2",
- "quote",
  "serde 1.0.202",
- "shlex",
  "sptr",
- "syn 1.0.109",
- "walkdir",
 ]
 
 [[package]]
 name = "pgrx-sql-entity-graph"
-version = "0.11.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d47a4e991c8c66162c5d6b0fc2bd382e43a58fc893ce05a6a15ddcb1bf7eee4"
+checksum = "f9c9dfdc4b31b381405b9735b7d674680b42584ea2ef89f3668a21be57a39310"
 dependencies = [
  "convert_case",
  "eyre",
  "petgraph",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.65",
+ "thiserror",
  "unescape",
 ]
 
 [[package]]
 name = "pgrx-tests"
-version = "0.11.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3abc01e2bb930b072bd660d04c8eaa69a29d4727d5b2a641f946c603c1605e"
+checksum = "992bb74e9cd178a55eab23f7a4b890a5427a411bbaf9588c86d435a3664eb4d2"
 dependencies = [
  "clap-cargo",
  "eyre",
  "libc",
- "once_cell",
  "owo-colors",
+ "paste",
  "pgrx",
  "pgrx-macros",
  "pgrx-pg-config",
@@ -5999,9 +6066,6 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
-]
 
 [[package]]
 name = "spki"
@@ -6099,6 +6163,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "supports-color"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6398cde53adc3c4557306a96ce67b302968513830a77a95b2b17305d9719a89"
+dependencies = [
+ "is-terminal",
+ "is_ci",
+]
+
+[[package]]
+name = "supports-color"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8775305acf21c96926c900ad056abeef436701108518cf890020387236ac5a77"
+dependencies = [
+ "is_ci",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6140,9 +6223,9 @@ checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "sysinfo"
-version = "0.29.11"
+version = "0.30.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd727fc423c2060f6c92d9534cef765c65a6ed3f428a03d7def74a8c4348e666"
+checksum = "0a5b4ddaee55fb2bea2bf0e5000747e5f5c0de765e5a5ff87f4cd106439f4bb3"
 dependencies = [
  "cfg-if",
  "core-foundation-sys",
@@ -6150,7 +6233,7 @@ dependencies = [
  "ntapi",
  "once_cell",
  "rayon",
- "winapi",
+ "windows",
 ]
 
 [[package]]
@@ -7432,6 +7515,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+dependencies = [
+ "windows-core",
+ "windows-targets 0.52.5",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7745,6 +7838,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
+]
+
+[[package]]
+name = "yansi-term"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe5c30ade05e61656247b2e334a031dfd0cc466fadef865bdcdea8d537951bf1"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]

--- a/supabase-wrappers-macros/src/lib.rs
+++ b/supabase-wrappers-macros/src/lib.rs
@@ -96,7 +96,7 @@ pub fn wrappers_fdw(attr: TokenStream, item: TokenStream) -> TokenStream {
             fn #fn_validator_ident(options: Vec<Option<String>>, catalog: Option<pg_sys::Oid>) {
                 #ident::validator(options, catalog)
                     .map_err(|e| <super::#error_type_ident as Into<ErrorReport>>::into(e))
-                    .report();
+                    .unwrap_or_report();
             }
 
             pub(super) fn #fn_get_meta_ident() -> HashMap<String, String> {

--- a/supabase-wrappers/Cargo.toml
+++ b/supabase-wrappers/Cargo.toml
@@ -17,17 +17,18 @@ pg13 = ["pgrx/pg13", "pgrx-tests/pg13"]
 pg14 = ["pgrx/pg14", "pgrx-tests/pg14"]
 pg15 = ["pgrx/pg15", "pgrx-tests/pg15"]
 pg16 = ["pgrx/pg16", "pgrx-tests/pg16"]
+pg17 = ["pgrx/pg17", "pgrx-tests/pg17" ]
 pg_test = []
 
 [dependencies]
-pgrx = { version = "=0.11.3", default-features = false }
+pgrx = { version = "=0.12.5", default-features = false }
 thiserror = "1.0.48"
 tokio = { version = "1.35", features = ["rt", "net"] }
 uuid = { version = "1.2.2" }
 supabase-wrappers-macros = { version = "0.1", path = "../supabase-wrappers-macros" }
 
 [dev-dependencies]
-pgrx-tests = "=0.11.3"
+pgrx-tests = "=0.12.5"
 
 [package.metadata.docs.rs]
 features = ["pg15", "cshim"]

--- a/supabase-wrappers/Cargo.toml
+++ b/supabase-wrappers/Cargo.toml
@@ -21,14 +21,14 @@ pg17 = ["pgrx/pg17", "pgrx-tests/pg17" ]
 pg_test = []
 
 [dependencies]
-pgrx = { version = "=0.12.5", default-features = false }
+pgrx = { version = "=0.12.6", default-features = false }
 thiserror = "1.0.48"
 tokio = { version = "1.35", features = ["rt", "net"] }
 uuid = { version = "1.2.2" }
 supabase-wrappers-macros = { version = "0.1", path = "../supabase-wrappers-macros" }
 
 [dev-dependencies]
-pgrx-tests = "=0.12.5"
+pgrx-tests = "=0.12.6"
 
 [package.metadata.docs.rs]
 features = ["pg15", "cshim"]

--- a/supabase-wrappers/src/import_foreign_schema.rs
+++ b/supabase-wrappers/src/import_foreign_schema.rs
@@ -26,9 +26,9 @@ impl<E: Into<ErrorReport>, W: ForeignDataWrapper<E>> FdwState<E, W> {
 #[repr(u32)]
 #[derive(Debug, Clone)]
 pub enum ListType {
-    FdwImportSchemaAll = pgrx::pg_sys::ImportForeignSchemaType_FDW_IMPORT_SCHEMA_ALL,
-    FdwImportSchemaLimitTo = pgrx::pg_sys::ImportForeignSchemaType_FDW_IMPORT_SCHEMA_LIMIT_TO,
-    FdwImportSchemaExcept = pgrx::pg_sys::ImportForeignSchemaType_FDW_IMPORT_SCHEMA_EXCEPT,
+    FdwImportSchemaAll = pgrx::pg_sys::ImportForeignSchemaType::FDW_IMPORT_SCHEMA_ALL,
+    FdwImportSchemaLimitTo = pgrx::pg_sys::ImportForeignSchemaType::FDW_IMPORT_SCHEMA_LIMIT_TO,
+    FdwImportSchemaExcept = pgrx::pg_sys::ImportForeignSchemaType::FDW_IMPORT_SCHEMA_EXCEPT,
 }
 
 #[derive(Debug, Clone)]
@@ -66,13 +66,13 @@ pub(super) extern "C" fn import_foreign_schema<E: Into<ErrorReport>, W: ForeignD
                 .to_string(),
 
             list_type: match (*stmt).list_type {
-                pgrx::pg_sys::ImportForeignSchemaType_FDW_IMPORT_SCHEMA_ALL => {
+                pgrx::pg_sys::ImportForeignSchemaType::FDW_IMPORT_SCHEMA_ALL => {
                     ListType::FdwImportSchemaAll
                 }
-                pgrx::pg_sys::ImportForeignSchemaType_FDW_IMPORT_SCHEMA_LIMIT_TO => {
+                pgrx::pg_sys::ImportForeignSchemaType::FDW_IMPORT_SCHEMA_LIMIT_TO => {
                     ListType::FdwImportSchemaLimitTo
                 }
-                pgrx::pg_sys::ImportForeignSchemaType_FDW_IMPORT_SCHEMA_EXCEPT => {
+                pgrx::pg_sys::ImportForeignSchemaType::FDW_IMPORT_SCHEMA_EXCEPT => {
                     ListType::FdwImportSchemaExcept
                 }
                 // This should not happen, it's okay to default to FdwImportSchemaAll

--- a/supabase-wrappers/src/qual.rs
+++ b/supabase-wrappers/src/qual.rs
@@ -1,6 +1,13 @@
 use crate::prelude::*;
 use pgrx::pg_sys::Oid;
-use pgrx::{is_a, list::PgList, pg_sys, pg_sys::Datum, FromDatum, PgBuiltInOids, PgOid};
+use pgrx::{
+    datum::{Array, Date, JsonB, Timestamp},
+    is_a,
+    list::PgList,
+    pg_sys,
+    pg_sys::Datum,
+    FromDatum, PgBuiltInOids, PgOid,
+};
 use std::ffi::CStr;
 use std::os::raw::c_int;
 
@@ -12,44 +19,97 @@ pub(crate) unsafe fn form_array_from_datum(
     is_null: bool,
     typoid: pg_sys::Oid,
 ) -> Option<Vec<Cell>> {
-    if is_null {
-        return None;
-    }
-
     let oid = PgOid::from(typoid);
     match oid {
         PgOid::BuiltIn(PgBuiltInOids::BOOLARRAYOID) => {
-            Vec::<Cell>::from_polymorphic_datum(datum, false, pg_sys::BOOLOID)
+            Array::<bool>::from_polymorphic_datum(datum, is_null, pg_sys::BOOLOID).map(|arr| {
+                arr.iter()
+                    .filter(|v| v.is_some())
+                    .map(|v| Cell::Bool(v.expect("non-null array element")))
+                    .collect::<Vec<_>>()
+            })
         }
         PgOid::BuiltIn(PgBuiltInOids::CHARARRAYOID) => {
-            Vec::<Cell>::from_polymorphic_datum(datum, false, pg_sys::CHAROID)
+            Array::<i8>::from_polymorphic_datum(datum, is_null, pg_sys::CHAROID).map(|arr| {
+                arr.iter()
+                    .filter(|v| v.is_some())
+                    .map(|v| Cell::I8(v.expect("non-null array element")))
+                    .collect::<Vec<_>>()
+            })
         }
         PgOid::BuiltIn(PgBuiltInOids::INT2ARRAYOID) => {
-            Vec::<Cell>::from_polymorphic_datum(datum, false, pg_sys::INT2OID)
+            Array::<i16>::from_polymorphic_datum(datum, is_null, pg_sys::INT2OID).map(|arr| {
+                arr.iter()
+                    .filter(|v| v.is_some())
+                    .map(|v| Cell::I16(v.expect("non-null array element")))
+                    .collect::<Vec<_>>()
+            })
         }
         PgOid::BuiltIn(PgBuiltInOids::FLOAT4ARRAYOID) => {
-            Vec::<Cell>::from_polymorphic_datum(datum, false, pg_sys::FLOAT4OID)
+            Array::<f32>::from_polymorphic_datum(datum, is_null, pg_sys::FLOAT4OID).map(|arr| {
+                arr.iter()
+                    .filter(|v| v.is_some())
+                    .map(|v| Cell::F32(v.expect("non-null array element")))
+                    .collect::<Vec<_>>()
+            })
         }
         PgOid::BuiltIn(PgBuiltInOids::INT4ARRAYOID) => {
-            Vec::<Cell>::from_polymorphic_datum(datum, false, pg_sys::INT4OID)
+            Array::<i32>::from_polymorphic_datum(datum, is_null, pg_sys::INT4OID).map(|arr| {
+                arr.iter()
+                    .filter(|v| v.is_some())
+                    .map(|v| Cell::I32(v.expect("non-null array element")))
+                    .collect::<Vec<_>>()
+            })
         }
         PgOid::BuiltIn(PgBuiltInOids::FLOAT8ARRAYOID) => {
-            Vec::<Cell>::from_polymorphic_datum(datum, false, pg_sys::FLOAT8OID)
+            Array::<f64>::from_polymorphic_datum(datum, is_null, pg_sys::FLOAT8OID).map(|arr| {
+                arr.iter()
+                    .filter(|v| v.is_some())
+                    .map(|v| Cell::F64(v.expect("non-null array element")))
+                    .collect::<Vec<_>>()
+            })
         }
         PgOid::BuiltIn(PgBuiltInOids::INT8ARRAYOID) => {
-            Vec::<Cell>::from_polymorphic_datum(datum, false, pg_sys::INT8OID)
+            Array::<i64>::from_polymorphic_datum(datum, is_null, pg_sys::INT8OID).map(|arr| {
+                arr.iter()
+                    .filter(|v| v.is_some())
+                    .map(|v| Cell::I64(v.expect("non-null array element")))
+                    .collect::<Vec<_>>()
+            })
         }
         PgOid::BuiltIn(PgBuiltInOids::TEXTARRAYOID) => {
-            Vec::<Cell>::from_polymorphic_datum(datum, false, pg_sys::TEXTOID)
+            Array::<String>::from_polymorphic_datum(datum, is_null, pg_sys::TEXTOID).map(|arr| {
+                arr.iter()
+                    .filter(|v| v.is_some())
+                    .map(|v| Cell::String(v.expect("non-null array element")))
+                    .collect::<Vec<_>>()
+            })
         }
         PgOid::BuiltIn(PgBuiltInOids::DATEARRAYOID) => {
-            Vec::<Cell>::from_polymorphic_datum(datum, false, pg_sys::DATEOID)
+            Array::<Date>::from_polymorphic_datum(datum, is_null, pg_sys::DATEOID).map(|arr| {
+                arr.iter()
+                    .filter(|v| v.is_some())
+                    .map(|v| Cell::Date(v.expect("non-null array element")))
+                    .collect::<Vec<_>>()
+            })
         }
         PgOid::BuiltIn(PgBuiltInOids::TIMESTAMPARRAYOID) => {
-            Vec::<Cell>::from_polymorphic_datum(datum, false, pg_sys::TIMESTAMPOID)
+            Array::<Timestamp>::from_polymorphic_datum(datum, is_null, pg_sys::TIMESTAMPOID).map(
+                |arr| {
+                    arr.iter()
+                        .filter(|v| v.is_some())
+                        .map(|v| Cell::Timestamp(v.expect("non-null array element")))
+                        .collect::<Vec<_>>()
+                },
+            )
         }
         PgOid::BuiltIn(PgBuiltInOids::JSONBARRAYOID) => {
-            Vec::<Cell>::from_polymorphic_datum(datum, false, pg_sys::JSONBOID)
+            Array::<JsonB>::from_polymorphic_datum(datum, is_null, pg_sys::JSONBOID).map(|arr| {
+                arr.iter()
+                    .filter(|v| v.is_some())
+                    .map(|v| Cell::Json(v.expect("non-null array element")))
+                    .collect::<Vec<_>>()
+            })
         }
         _ => None,
     }
@@ -57,12 +117,12 @@ pub(crate) unsafe fn form_array_from_datum(
 
 pub(crate) unsafe fn get_operator(opno: pg_sys::Oid) -> pg_sys::Form_pg_operator {
     let htup = pg_sys::SearchSysCache1(
-        pg_sys::SysCacheIdentifier_OPEROID.try_into().unwrap(),
+        pg_sys::SysCacheIdentifier::OPEROID.try_into().unwrap(),
         opno.into(),
     );
     if htup.is_null() {
         pg_sys::ReleaseSysCache(htup);
-        pgrx::error!("cache lookup operator {} failed", opno);
+        pgrx::error!("cache lookup operator {:?} failed", opno);
     }
     let op = pg_sys::GETSTRUCT(htup) as pg_sys::Form_pg_operator;
     pg_sys::ReleaseSysCache(htup);
@@ -172,7 +232,7 @@ pub(crate) unsafe fn extract_from_null_test(
 
     let field = pg_sys::get_attname(baserel_id, (*var).varattno, false);
 
-    let opname = if (*expr).nulltesttype == pg_sys::NullTestType_IS_NULL {
+    let opname = if (*expr).nulltesttype == pg_sys::NullTestType::IS_NULL {
         "is".to_string()
     } else {
         "is not".to_string()
@@ -278,7 +338,7 @@ pub(crate) unsafe fn extract_from_bool_expr(
 ) -> Option<Qual> {
     let args: PgList<pg_sys::Node> = PgList::from_pg((*expr).args);
 
-    if (*expr).boolop != pg_sys::BoolExprType_NOT_EXPR || args.len() != 1 {
+    if (*expr).boolop != pg_sys::BoolExprType::NOT_EXPR || args.len() != 1 {
         return None;
     }
 
@@ -315,10 +375,10 @@ pub(crate) unsafe fn extract_from_boolean_test(
     let field = pg_sys::get_attname(baserel_id, (*var).varattno, false);
 
     let (opname, value) = match (*expr).booltesttype {
-        pg_sys::BoolTestType_IS_TRUE => ("is".to_string(), true),
-        pg_sys::BoolTestType_IS_FALSE => ("is".to_string(), false),
-        pg_sys::BoolTestType_IS_NOT_TRUE => ("is not".to_string(), true),
-        pg_sys::BoolTestType_IS_NOT_FALSE => ("is not".to_string(), false),
+        pg_sys::BoolTestType::IS_TRUE => ("is".to_string(), true),
+        pg_sys::BoolTestType::IS_FALSE => ("is".to_string(), false),
+        pg_sys::BoolTestType::IS_NOT_TRUE => ("is not".to_string(), true),
+        pg_sys::BoolTestType::IS_NOT_FALSE => ("is not".to_string(), false),
         _ => return None,
     };
 

--- a/supabase-wrappers/src/scan.rs
+++ b/supabase-wrappers/src/scan.rs
@@ -185,6 +185,8 @@ pub(super) extern "C" fn get_foreign_paths<E: Into<ErrorReport>, W: ForeignDataW
             ptr::null_mut(), // no pathkeys
             ptr::null_mut(), // no outer rel either
             ptr::null_mut(), // no extra plan
+            #[cfg(feature = "pg17")]
+            ptr::null_mut(), // no restrict info
             ptr::null_mut(), // no fdw_private data
         );
         pg_sys::add_path(baserel, &mut ((*path).path));

--- a/supabase-wrappers/src/utils.rs
+++ b/supabase-wrappers/src/utils.rs
@@ -338,6 +338,6 @@ impl<T, E: Into<ErrorReport>> ReportableError for Result<T, E> {
     type Output = T;
 
     fn report_unwrap(self) -> Self::Output {
-        self.map_err(|e| e.into()).report()
+        self.map_err(|e| e.into()).unwrap_or_report()
     }
 }

--- a/wrappers/Cargo.toml
+++ b/wrappers/Cargo.toml
@@ -160,7 +160,7 @@ all_fdws = [
 ]
 
 [dependencies]
-pgrx = { version = "=0.12.5" }
+pgrx = { version = "=0.12.6" }
 #supabase-wrappers = "0.1"
 supabase-wrappers = { path = "../supabase-wrappers", default-features = false }
 
@@ -246,4 +246,4 @@ thiserror = { version = "1.0.48", optional = true }
 anyhow  = { version = "1.0.81", optional = true }
 
 [dev-dependencies]
-pgrx-tests = "=0.12.5"
+pgrx-tests = "=0.12.6"

--- a/wrappers/Cargo.toml
+++ b/wrappers/Cargo.toml
@@ -5,7 +5,11 @@ edition = "2021"
 publish = false
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "lib"]
+
+[[bin]]
+name = "pgrx_embed_wrappers"
+path = "./src/bin/pgrx_embed.rs"
 
 [features]
 default = ["cshim", "pg15"]
@@ -14,6 +18,7 @@ pg13 = ["pgrx/pg13", "pgrx-tests/pg13", "supabase-wrappers/pg13"]
 pg14 = ["pgrx/pg14", "pgrx-tests/pg14", "supabase-wrappers/pg14"]
 pg15 = ["pgrx/pg15", "pgrx-tests/pg15", "supabase-wrappers/pg15"]
 pg16 = ["pgrx/pg16", "pgrx-tests/pg16", "supabase-wrappers/pg16"]
+pg17 = ["pgrx/pg17", "pgrx-tests/pg17", "supabase-wrappers/pg17"]
 pg_test = []
 
 helloworld_fdw = []
@@ -155,7 +160,7 @@ all_fdws = [
 ]
 
 [dependencies]
-pgrx = { version = "=0.11.3" }
+pgrx = { version = "=0.12.5" }
 #supabase-wrappers = "0.1"
 supabase-wrappers = { path = "../supabase-wrappers", default-features = false }
 
@@ -241,4 +246,4 @@ thiserror = { version = "1.0.48", optional = true }
 anyhow  = { version = "1.0.81", optional = true }
 
 [dev-dependencies]
-pgrx-tests = "=0.11.3"
+pgrx-tests = "=0.12.5"

--- a/wrappers/src/bin/pgrx_embed.rs
+++ b/wrappers/src/bin/pgrx_embed.rs
@@ -1,0 +1,1 @@
+::pgrx::pgrx_embed!();

--- a/wrappers/src/fdw/airtable_fdw/README.md
+++ b/wrappers/src/fdw/airtable_fdw/README.md
@@ -11,7 +11,7 @@ This is a foreign data wrapper for [Airtable](https://www.airtable.com). It is d
 
 | Version | Date       | Notes                                                |
 | ------- | ---------- | ---------------------------------------------------- |
-| 0.1.4   | 2024-09-30 | Support for pgrx 0.12.5                              |
+| 0.1.4   | 2024-09-30 | Support for pgrx 0.12.6                              |
 | 0.1.3   | 2023-10-20 | Added jsonb data types support                       |
 | 0.1.2   | 2023-07-19 | Added more data types support                        |
 | 0.1.1   | 2023-07-13 | Added fdw stats collection                           |

--- a/wrappers/src/fdw/airtable_fdw/README.md
+++ b/wrappers/src/fdw/airtable_fdw/README.md
@@ -11,6 +11,7 @@ This is a foreign data wrapper for [Airtable](https://www.airtable.com). It is d
 
 | Version | Date       | Notes                                                |
 | ------- | ---------- | ---------------------------------------------------- |
+| 0.1.4   | 2024-09-30 | Support for pgrx 0.12.5                              |
 | 0.1.3   | 2023-10-20 | Added jsonb data types support                       |
 | 0.1.2   | 2023-07-19 | Added more data types support                        |
 | 0.1.1   | 2023-07-13 | Added fdw stats collection                           |

--- a/wrappers/src/fdw/airtable_fdw/airtable_fdw.rs
+++ b/wrappers/src/fdw/airtable_fdw/airtable_fdw.rs
@@ -28,7 +28,7 @@ fn create_client(api_key: &str) -> Result<ClientWithMiddleware, AirtableFdwError
 }
 
 #[wrappers_fdw(
-    version = "0.1.3",
+    version = "0.1.4",
     author = "Ankur Goyal",
     website = "https://github.com/supabase/wrappers/tree/main/wrappers/src/fdw/airtable_fdw",
     error_type = "AirtableFdwError"

--- a/wrappers/src/fdw/airtable_fdw/result.rs
+++ b/wrappers/src/fdw/airtable_fdw/result.rs
@@ -194,7 +194,9 @@ impl AirtableRecord {
                     || Ok(None),
                     |val| {
                         if let Value::String(v) = val {
-                            Ok(pgrx::Date::from_str(v.as_str()).ok().map(Cell::Date))
+                            Ok(pgrx::prelude::Date::from_str(v.as_str())
+                                .ok()
+                                .map(Cell::Date))
                         } else {
                             Err(())
                         }
@@ -204,7 +206,7 @@ impl AirtableRecord {
                     || Ok(None),
                     |val| {
                         if let Value::String(v) = val {
-                            let n = pgrx::Timestamp::from_str(v.as_str())
+                            let n = pgrx::prelude::Timestamp::from_str(v.as_str())
                                 .ok()
                                 .map(Cell::Timestamp);
                             Ok(n)
@@ -217,7 +219,7 @@ impl AirtableRecord {
                     || Ok(None),
                     |val| {
                         if let Value::String(v) = val {
-                            let n = pgrx::TimestampWithTimeZone::from_str(v.as_str())
+                            let n = pgrx::prelude::TimestampWithTimeZone::from_str(v.as_str())
                                 .ok()
                                 .map(Cell::Timestamptz);
                             Ok(n)

--- a/wrappers/src/fdw/airtable_fdw/tests.rs
+++ b/wrappers/src/fdw/airtable_fdw/tests.rs
@@ -113,7 +113,7 @@ mod tests {
                 .select("SELECT timestamp_field FROM airtable_table", None, None)
                 .expect("No results for a given query")
                 .filter_map(|r| {
-                    r.get_by_name::<pgrx::Timestamp, _>("timestamp_field")
+                    r.get_by_name::<pgrx::prelude::Timestamp, _>("timestamp_field")
                         .expect("timestamp_field is missing")
                         .map(|v| v.to_iso_string())
                 })

--- a/wrappers/src/fdw/bigquery_fdw/README.md
+++ b/wrappers/src/fdw/bigquery_fdw/README.md
@@ -11,6 +11,7 @@ This is a foreign data wrapper for [BigQuery](https://cloud.google.com/bigquery)
 
 | Version | Date       | Notes                                                |
 | ------- | ---------- | ---------------------------------------------------- |
+| 0.1.5   | 2024-09-30 | Support for pgrx 0.12.5                              |
 | 0.1.4   | 2023-07-13 | Added fdw stats collection                           |
 | 0.1.3   | 2023-04-03 | Added support for `NUMERIC` type                     |
 | 0.1.2   | 2023-03-15 | Added subquery support for `table` option            |

--- a/wrappers/src/fdw/bigquery_fdw/README.md
+++ b/wrappers/src/fdw/bigquery_fdw/README.md
@@ -11,7 +11,7 @@ This is a foreign data wrapper for [BigQuery](https://cloud.google.com/bigquery)
 
 | Version | Date       | Notes                                                |
 | ------- | ---------- | ---------------------------------------------------- |
-| 0.1.5   | 2024-09-30 | Support for pgrx 0.12.5                              |
+| 0.1.5   | 2024-09-30 | Support for pgrx 0.12.6                              |
 | 0.1.4   | 2023-07-13 | Added fdw stats collection                           |
 | 0.1.3   | 2023-04-03 | Added support for `NUMERIC` type                     |
 | 0.1.2   | 2023-03-15 | Added subquery support for `table` option            |

--- a/wrappers/src/fdw/bigquery_fdw/bigquery_fdw.rs
+++ b/wrappers/src/fdw/bigquery_fdw/bigquery_fdw.rs
@@ -38,7 +38,7 @@ fn field_to_cell(rs: &ResultSet, field: &TableFieldSchema) -> BigQueryFdwResult<
             None => None,
         },
         FieldType::Timestamp => rs.get_f64_by_name(&field.name)?.map(|v| {
-            let ts = pgrx::to_timestamp(v);
+            let ts = pgrx::prelude::to_timestamp(v);
             Cell::Timestamp(ts.to_utc())
         }),
         _ => {
@@ -50,7 +50,7 @@ fn field_to_cell(rs: &ResultSet, field: &TableFieldSchema) -> BigQueryFdwResult<
 }
 
 #[wrappers_fdw(
-    version = "0.1.4",
+    version = "0.1.5",
     author = "Supabase",
     website = "https://github.com/supabase/wrappers/tree/main/wrappers/src/fdw/bigquery_fdw",
     error_type = "BigQueryFdwError"

--- a/wrappers/src/fdw/bigquery_fdw/mod.rs
+++ b/wrappers/src/fdw/bigquery_fdw/mod.rs
@@ -2,7 +2,7 @@
 
 use gcp_bigquery_client::error::BQError;
 use pgrx::pg_sys::panic::ErrorReport;
-use pgrx::{DateTimeConversionError, PgSqlErrorCode};
+use pgrx::{prelude::DateTimeConversionError, PgSqlErrorCode};
 use supabase_wrappers::prelude::{CreateRuntimeError, OptionsError};
 use thiserror::Error;
 

--- a/wrappers/src/fdw/clickhouse_fdw/README.md
+++ b/wrappers/src/fdw/clickhouse_fdw/README.md
@@ -11,7 +11,7 @@ This is a foreign data wrapper for [ClickHouse](https://clickhouse.com/). It is 
 
 | Version | Date       | Notes                                                |
 | ------- | ---------- | ---------------------------------------------------- |
-| 0.1.5   | 2024-09-30 | Support for pgrx 0.12.5                              |
+| 0.1.5   | 2024-09-30 | Support for pgrx 0.12.6                              |
 | 0.1.4   | 2024-09-10 | Added Nullable type suppport                         |
 | 0.1.3   | 2023-07-17 | Added sort and limit pushdown suppport               |
 | 0.1.2   | 2023-07-13 | Added fdw stats collection                           |

--- a/wrappers/src/fdw/clickhouse_fdw/README.md
+++ b/wrappers/src/fdw/clickhouse_fdw/README.md
@@ -11,6 +11,7 @@ This is a foreign data wrapper for [ClickHouse](https://clickhouse.com/). It is 
 
 | Version | Date       | Notes                                                |
 | ------- | ---------- | ---------------------------------------------------- |
+| 0.1.5   | 2024-09-30 | Support for pgrx 0.12.5                              |
 | 0.1.4   | 2024-09-10 | Added Nullable type suppport                         |
 | 0.1.3   | 2023-07-17 | Added sort and limit pushdown suppport               |
 | 0.1.2   | 2023-07-13 | Added fdw stats collection                           |

--- a/wrappers/src/fdw/clickhouse_fdw/clickhouse_fdw.rs
+++ b/wrappers/src/fdw/clickhouse_fdw/clickhouse_fdw.rs
@@ -2,7 +2,7 @@ use crate::stats;
 #[allow(deprecated)]
 use chrono::{DateTime, Datelike, NaiveDate, NaiveDateTime, Utc};
 use clickhouse_rs::{types, types::Block, types::SqlType, ClientHandle, Pool};
-use pgrx::to_timestamp;
+use pgrx::prelude::to_timestamp;
 use regex::{Captures, Regex};
 use std::collections::HashMap;
 
@@ -56,7 +56,8 @@ fn field_to_cell(row: &types::Row<types::Complex>, i: usize) -> ClickHouseFdwRes
         }
         SqlType::Date => {
             let value = row.get::<NaiveDate, usize>(i)?;
-            let dt = pgrx::Date::new(value.year(), value.month() as u8, value.day() as u8)?;
+            let dt =
+                pgrx::prelude::Date::new(value.year(), value.month() as u8, value.day() as u8)?;
             Ok(Some(Cell::Date(dt)))
         }
         SqlType::DateTime(_) => {
@@ -108,7 +109,7 @@ fn field_to_cell(row: &types::Row<types::Complex>, i: usize) -> ClickHouseFdwRes
             SqlType::Date => {
                 let value = row.get::<Option<NaiveDate>, usize>(i)?;
                 Ok(value
-                    .map(|t| pgrx::Date::new(t.year(), t.month() as u8, t.day() as u8))
+                    .map(|t| pgrx::prelude::Date::new(t.year(), t.month() as u8, t.day() as u8))
                     .transpose()?
                     .map(Cell::Date))
             }
@@ -130,7 +131,7 @@ fn field_to_cell(row: &types::Row<types::Complex>, i: usize) -> ClickHouseFdwRes
 }
 
 #[wrappers_fdw(
-    version = "0.1.4",
+    version = "0.1.5",
     author = "Supabase",
     website = "https://github.com/supabase/wrappers/tree/main/wrappers/src/fdw/clickhouse_fdw",
     error_type = "ClickHouseFdwError"

--- a/wrappers/src/fdw/cognito_fdw/README.md
+++ b/wrappers/src/fdw/cognito_fdw/README.md
@@ -10,4 +10,5 @@ This is a demo foreign data wrapper which is developed using [Wrappers](https://
 
 | Version | Date       | Notes                                                |
 | ------- | ---------- | ---------------------------------------------------- |
+| 0.1.2   | 2024-09-30 | Support for pgrx 0.12.5                              |
 | 0.1.0   | 2024-01-25 | Initial version                                      |

--- a/wrappers/src/fdw/cognito_fdw/README.md
+++ b/wrappers/src/fdw/cognito_fdw/README.md
@@ -10,5 +10,5 @@ This is a demo foreign data wrapper which is developed using [Wrappers](https://
 
 | Version | Date       | Notes                                                |
 | ------- | ---------- | ---------------------------------------------------- |
-| 0.1.2   | 2024-09-30 | Support for pgrx 0.12.5                              |
+| 0.1.2   | 2024-09-30 | Support for pgrx 0.12.6                              |
 | 0.1.0   | 2024-01-25 | Initial version                                      |

--- a/wrappers/src/fdw/cognito_fdw/cognito_client/row.rs
+++ b/wrappers/src/fdw/cognito_fdw/cognito_client/row.rs
@@ -71,10 +71,9 @@ impl IntoRow for UserType {
                     if let Some(created_at) = self.extract_attribute_value("created_at") {
                         let parsed_date = DateTime::parse_from_rfc3339(&created_at)
                             .expect("Failed to parse date");
-                        row.push(
-                            "created_at",
-                            Some(Cell::Timestamp(parsed_date.timestamp().into())),
-                        );
+                        let ts = pgrx::prelude::Timestamp::try_from(parsed_date.timestamp())
+                            .expect("valid timestamp");
+                        row.push("created_at", Some(Cell::Timestamp(ts)));
                     }
                 }
                 "email" => {

--- a/wrappers/src/fdw/cognito_fdw/cognito_fdw.rs
+++ b/wrappers/src/fdw/cognito_fdw/cognito_fdw.rs
@@ -16,7 +16,7 @@ use pgrx::PgSqlErrorCode;
 use thiserror::Error;
 
 #[wrappers_fdw(
-    version = "0.1.1",
+    version = "0.1.2",
     author = "Joel",
     website = "https://github.com/supabase/wrappers/tree/main/wrappers/src/fdw/cognito_fdw",
     error_type = "CognitoFdwError"

--- a/wrappers/src/fdw/mssql_fdw/README.md
+++ b/wrappers/src/fdw/mssql_fdw/README.md
@@ -10,7 +10,7 @@ This is a foreign data wrapper for [Microsoft SQL Server](https://www.microsoft.
 
 | Version | Date       | Notes                                                |
 | ------- | ---------- | ---------------------------------------------------- |
-| 0.1.2   | 2024-09-30 | Support for pgrx 0.12.5                              |
+| 0.1.2   | 2024-09-30 | Support for pgrx 0.12.6                              |
 | 0.1.1   | 2024-09-09 | Add boolean test qual support                        |
 | 0.1.0   | 2023-12-27 | Initial version                                      |
 

--- a/wrappers/src/fdw/mssql_fdw/README.md
+++ b/wrappers/src/fdw/mssql_fdw/README.md
@@ -10,6 +10,7 @@ This is a foreign data wrapper for [Microsoft SQL Server](https://www.microsoft.
 
 | Version | Date       | Notes                                                |
 | ------- | ---------- | ---------------------------------------------------- |
+| 0.1.2   | 2024-09-30 | Support for pgrx 0.12.5                              |
 | 0.1.1   | 2024-09-09 | Add boolean test qual support                        |
 | 0.1.0   | 2023-12-27 | Initial version                                      |
 

--- a/wrappers/src/fdw/mssql_fdw/mssql_fdw.rs
+++ b/wrappers/src/fdw/mssql_fdw/mssql_fdw.rs
@@ -1,6 +1,6 @@
 use crate::stats;
 use num_traits::cast::ToPrimitive;
-use pgrx::{to_timestamp, PgBuiltInOids, PgOid};
+use pgrx::{prelude::to_timestamp, PgBuiltInOids, PgOid};
 use std::collections::HashMap;
 use tiberius::{
     numeric::Decimal,
@@ -57,7 +57,7 @@ fn field_to_cell(src_row: &tiberius::Row, tgt_col: &Column) -> MssqlFdwResult<Op
                 let epoch = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap();
                 let seconds_from_epoch = v.signed_duration_since(epoch).num_seconds();
                 let ts = to_timestamp(seconds_from_epoch as f64);
-                Cell::Date(pgrx::Date::from(ts))
+                Cell::Date(pgrx::prelude::Date::from(ts))
             })
         }
         PgOid::BuiltIn(PgBuiltInOids::TIMESTAMPOID) => {
@@ -93,7 +93,7 @@ impl CellFormatter for MssqlCellFormatter {
 }
 
 #[wrappers_fdw(
-    version = "0.1.1",
+    version = "0.1.2",
     author = "Supabase",
     website = "https://github.com/supabase/wrappers/tree/main/wrappers/src/fdw/mssql_fdw",
     error_type = "MssqlFdwError"

--- a/wrappers/src/fdw/stripe_fdw/tests.rs
+++ b/wrappers/src/fdw/stripe_fdw/tests.rs
@@ -572,7 +572,10 @@ mod tests {
                 .collect::<Vec<_>>();
             assert_eq!(
                 results,
-                vec![("cus_QXg1o8vcGmoR32", Timestamp::from(287883090000000i64))]
+                vec![(
+                    "cus_QXg1o8vcGmoR32",
+                    Timestamp::try_from(287883090000000i64).unwrap()
+                )]
             );
 
             let results = c
@@ -846,9 +849,9 @@ mod tests {
                 vec![(
                     (
                         ("cus_QXg1o8vcGmoR32", "usd"),
-                        Timestamp::from(287883090000000i64)
+                        Timestamp::try_from(287883090000000i64).unwrap()
                     ),
-                    Timestamp::from(287883090000000i64)
+                    Timestamp::try_from(287883090000000i64).unwrap()
                 )]
             );
 

--- a/wrappers/src/fdw/wasm_fdw/README.md
+++ b/wrappers/src/fdw/wasm_fdw/README.md
@@ -6,7 +6,7 @@ This is Wasm foreign data wrapper host, please visit each Wasm foreign data wrap
 
 | Version | Date       | Notes                                                |
 | ------- | ---------- | ---------------------------------------------------- |
-| 0.1.3   | 2024-09-30 | Support for pgrx 0.12.5                              |
+| 0.1.3   | 2024-09-30 | Support for pgrx 0.12.6                              |
 | 0.1.2   | 2024-07-07 | Add fdw_package_checksum server option               |
 | 0.1.1   | 2024-07-05 | Fix missing wasm package cache dir issue             |
 | 0.1.0   | 2024-07-03 | Initial version                                      |

--- a/wrappers/src/fdw/wasm_fdw/README.md
+++ b/wrappers/src/fdw/wasm_fdw/README.md
@@ -6,6 +6,7 @@ This is Wasm foreign data wrapper host, please visit each Wasm foreign data wrap
 
 | Version | Date       | Notes                                                |
 | ------- | ---------- | ---------------------------------------------------- |
+| 0.1.3   | 2024-09-30 | Support for pgrx 0.12.5                              |
 | 0.1.2   | 2024-07-07 | Add fdw_package_checksum server option               |
 | 0.1.1   | 2024-07-05 | Fix missing wasm package cache dir issue             |
 | 0.1.0   | 2024-07-03 | Initial version                                      |

--- a/wrappers/src/fdw/wasm_fdw/bindings.rs
+++ b/wrappers/src/fdw/wasm_fdw/bindings.rs
@@ -38,13 +38,12 @@ impl TryFrom<GuestCell> for HostCell {
                 Ok(Self::Date(Date::from(ts)))
             }
             // convert 'pg epoch' (2000-01-01 00:00:00) to unix epoch
-            GuestCell::Timestamp(v) => {
-                Ok(Self::Timestamp(Timestamp::from(v - 946_684_800_000_000)))
-            }
-            GuestCell::Timestamptz(v) => {
-                let ts = Timestamp::from(v - 946_684_800_000_000);
-                Ok(Self::Timestamptz(TimestampWithTimeZone::from(ts)))
-            }
+            GuestCell::Timestamp(v) => Timestamp::try_from(v - 946_684_800_000_000)
+                .map(Self::Timestamp)
+                .map_err(Self::Error::msg),
+            GuestCell::Timestamptz(v) => TimestampWithTimeZone::try_from(v - 946_684_800_000_000)
+                .map(Self::Timestamptz)
+                .map_err(Self::Error::msg),
             GuestCell::Json(v) => {
                 let ret = serde_json::from_str(&v).map(|j| Self::Json(JsonB(j)))?;
                 Ok(ret)

--- a/wrappers/src/fdw/wasm_fdw/tests.rs
+++ b/wrappers/src/fdw/wasm_fdw/tests.rs
@@ -19,7 +19,7 @@ mod tests {
                 r#"CREATE SERVER snowflake_server
                      FOREIGN DATA WRAPPER wasm_wrapper
                      OPTIONS (
-                       fdw_package_url 'file://../../wasm-wrappers/fdw/snowflake_fdw/target/wasm32-unknown-unknown/release/snowflake_fdw.wasm',
+                       fdw_package_url 'file:///home/runner/work/wrappers/wrappers/wasm-wrappers/fdw/snowflake_fdw/target/wasm32-unknown-unknown/release/snowflake_fdw.wasm',
                        fdw_package_name 'supabase:snowflake-fdw',
                        fdw_package_version '>=0.1.0',
                        api_url 'http://localhost:8096/snowflake/{}',
@@ -64,7 +64,7 @@ mod tests {
                 r#"CREATE SERVER paddle_server
                      FOREIGN DATA WRAPPER wasm_wrapper
                      OPTIONS (
-                       fdw_package_url 'file://../../wasm-wrappers/fdw/paddle_fdw/target/wasm32-unknown-unknown/release/paddle_fdw.wasm',
+                       fdw_package_url 'file:///home/runner/work/wrappers/wrappers/wasm-wrappers/fdw/paddle_fdw/target/wasm32-unknown-unknown/release/paddle_fdw.wasm',
                        fdw_package_name 'supabase:paddle-fdw',
                        fdw_package_version '>=0.1.0',
                        api_url 'http://localhost:8096/paddle',
@@ -113,7 +113,7 @@ mod tests {
                 r#"CREATE SERVER notion_server
                      FOREIGN DATA WRAPPER wasm_wrapper
                      OPTIONS (
-                       fdw_package_url 'file://../../wasm-wrappers/fdw/notion_fdw/target/wasm32-unknown-unknown/release/notion_fdw.wasm',
+                       fdw_package_url 'file:///home/runner/work/wrappers/wrappers/wasm-wrappers/fdw/notion_fdw/target/wasm32-unknown-unknown/release/notion_fdw.wasm',
                        fdw_package_name 'supabase:notion-fdw',
                        fdw_package_version '>=0.1.0',
                        api_url 'http://localhost:8096/notion',

--- a/wrappers/src/fdw/wasm_fdw/wasm_fdw.rs
+++ b/wrappers/src/fdw/wasm_fdw/wasm_fdw.rs
@@ -107,15 +107,14 @@ fn download_component(
         fs::write(&path, bytes)?;
     }
 
-    Ok(Component::from_file(engine, &path).map_err(|err| {
+    Ok(Component::from_file(engine, &path).inspect_err(|_| {
         // remove the cache file if it cannot be loaded as component
         let _ = fs::remove_file(&path);
-        err
     })?)
 }
 
 #[wrappers_fdw(
-    version = "0.1.2",
+    version = "0.1.3",
     author = "Supabase",
     website = "https://github.com/supabase/wrappers/tree/main/wrappers/src/fdw/wasm_fdw",
     error_type = "WasmFdwError"


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to add support for pgrx v0.12.6 and also support for PG17. Fix #336 .

## What is the current behavior?

Current pgrx support is v0.11.3.

## What is the new behavior?

Support pgrx v0.12.6 and PG17.

## Additional context

The current workflow will fail because new version pgrx doesn't support Ubuntu 20 yet, wait for https://github.com/pgcentralfoundation/pgrx/pull/1885 to be released in upstream.
