### PR TITLE
docs: fix spelling

### DIFF
--- a/docs/catalog/redis.md
+++ b/docs/catalog/redis.md
@@ -19,7 +19,7 @@ The Redis Wrapper allows you to read data from Redis within your Postgres databa
 
 ## Supported Redis Data Types
 
-All Redis value will be stored as `text` or `jsonb` column in Postgres, below are the supported Redis data types:
+All Redis values will be stored as `text` or `jsonb` columns in Postgres, below are the supported Redis data types:
 
 | Redis Type          | Foreign Table Type (src_type) |
 | ------------------- | ----------------------------- |


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update - Grammar fix in Redis documentation

## What is the current behavior?

In the Redis documentation (docs/catalog/redis.md), there is a grammatical error where the plural "values" doesn't match with the singular "column":
"All Redis value will be stored as `text` or `jsonb` column in Postgres"

## What is the new behavior?

Fixed the grammatical issue by using plural forms:
"All Redis values will be stored as `text` or `jsonb` columns in Postgres"

## Additional context

None