### PR TITLE
ci: fix rust toolchain and component version

### DIFF
--- a/.github/workflows/release_wasm_fdw.yml
+++ b/.github/workflows/release_wasm_fdw.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Rust
         run: |
           # install Rust
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --profile minimal --default-toolchain stable && \
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --profile minimal --default-toolchain 1.81.0 && \
             rustup --version && \
             rustc --version && \
             cargo --version
@@ -38,7 +38,7 @@ jobs:
           rustup target add wasm32-unknown-unknown
 
           # install Wasm component
-          cargo install cargo-component --locked
+          cargo install cargo-component --version 0.13.2
 
       - name: Build Wasm FDW
         run: |

--- a/.github/workflows/test_supabase_wrappers.yml
+++ b/.github/workflows/test_supabase_wrappers.yml
@@ -16,7 +16,7 @@ jobs:
 
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.81.0
 
     - run: |
         sudo apt remove -y postgres*

--- a/.github/workflows/test_wrappers.yml
+++ b/.github/workflows/test_wrappers.yml
@@ -23,7 +23,7 @@ jobs:
 
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.81.0
 
     - run: |
         sudo apt remove -y postgres*


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to fix Rust toolchain and Wasm Component version in github workflow.

## What is the current behavior?

The current workflows didn't fix Rust toolchain and Wasm Component version, so they used latest version which may not compatible with existing Wasm Wrappers.

## What is the new behavior?

Fix Rust toolchain version to `1.81.0` and Wasm Component version to `0.13.2` in workflow so we can make sure get same result each time the workflow runs. 

## Additional context

After this PR is merged, we need to redo release for below Wasm FDWs as they were release with latest version of Rust which isn't compatible with Wrappers 0.4.3.

- Notion Wasm FDW 
- Calendly Wasm FDW 
- Cal.com Wasm FDW 
