### PR TITLE
feat(redis): add TLS connection support to Redis FDW

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,6 +180,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
 
 [[package]]
+name = "arc-swap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
 name = "arrayref"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3099,7 +3105,7 @@ dependencies = [
  "hyper 0.14.28",
  "log",
  "rustls 0.21.12",
- "rustls-native-certs",
+ "rustls-native-certs 0.6.3",
  "tokio",
  "tokio-rustls",
 ]
@@ -3911,9 +3917,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c165a9ab64cf766f73521c0dd2cfdff64f488b8f0b3e621face3462d3db536d7"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits 0.2.19",
@@ -5086,16 +5092,22 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "0.24.0"
+version = "0.27.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c580d9cbbe1d1b479e8d67cf9daf6a62c957e6846048408b80b43ac3f6af84cd"
+checksum = "81cccf17a692ce51b86564334614d72dcae1def0fd5ecebc9f02956da74352b5"
 dependencies = [
+ "arc-swap",
  "combine",
  "itoa",
+ "num-bigint",
  "percent-encoding",
+ "rustls 0.23.10",
+ "rustls-native-certs 0.7.3",
+ "rustls-pemfile 2.1.2",
+ "rustls-pki-types",
  "ryu",
  "sha1_smol",
- "socket2 0.4.10",
+ "socket2 0.5.7",
  "url",
 ]
 
@@ -5545,6 +5557,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05cff451f60db80f490f3c182b77c35260baace73209e9cdbbe526bfe3a4d402"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rustls-native-certs"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5552,6 +5578,19 @@ checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
 dependencies = [
  "openssl-probe",
  "rustls-pemfile 1.0.4",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 2.1.2",
+ "rustls-pki-types",
  "schannel",
  "security-framework",
 ]

--- a/docs/catalog/redis.md
+++ b/docs/catalog/redis.md
@@ -95,6 +95,22 @@ The connection URL format is:
 redis://[<username>][:<password>@]<hostname>[:port][/<db>]
 ```
 
+The connection URL also supports TLS:
+
+```
+rediss://[<username>][:<password>@]<hostname>[:port][/<db>]
+```
+
+To enable insecure mode, append `#insecure` at the end of the URL:
+
+```
+rediss://[<username>][:<password>@]<hostname>[:port]/[<db>]#insecure
+```
+
+!!! note
+
+    Client certificate and custom root certificates are not supported when using TLS.
+
 ## Creating Foreign Tables
 
 The Redis Wrapper supports data reads from Redis.

--- a/wrappers/Cargo.toml
+++ b/wrappers/Cargo.toml
@@ -224,7 +224,7 @@ tiberius = { version = "0.12.2", features = [
 num-traits = { version = "0.2.17", optional = true }
 
 # for redis_fdw
-redis = { version = "0.24.0", features = ["streams"], optional = true }
+redis = { version = "0.27.5", features = ["streams", "tls-rustls", "tls-rustls-insecure"], optional = true }
 
 # for wasm_fdw
 wasmtime = { version = "26.0.1", features = [

--- a/wrappers/src/fdw/redis_fdw/README.md
+++ b/wrappers/src/fdw/redis_fdw/README.md
@@ -10,5 +10,5 @@ This is a foreign data wrapper for [Redis](https://redis.io/). It is developed u
 
 | Version | Date       | Notes                                                |
 | ------- | ---------- | ---------------------------------------------------- |
+| 0.1.1   | 2024-11-28 | Added TLS support                                    |
 | 0.1.0   | 2023-12-29 | Initial version                                      |
-


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to add TLS connection support to Redis FDW, fix #368 .

## What is the current behavior?

The current Redis FDW doesn't support TLS connection `rediss://` in URL.

## What is the new behavior?

Added TLS connection support to URL, also with optional `insecure` mode.

## Additional context

- because there is no way to upload files to Wrappers, the client certificate and custom root certificates are not supported when using TLS.
- `redis` dependency lib is also upgraded to `0.27.5`

