### PR TITLE
ci: install rustfmt for rust toolchain

### DIFF
--- a/.github/workflows/release_wasm_fdw.yml
+++ b/.github/workflows/release_wasm_fdw.yml
@@ -40,6 +40,12 @@ jobs:
           # install Wasm component
           cargo install cargo-component --version 0.13.2
 
+          # install rustfmt for the toolchain
+          rustup component add rustfmt
+
+          # show all installed packagies
+          cargo install --list
+
       - name: Build Wasm FDW
         run: |
           cd wasm-wrappers/fdw/${{ steps.extract_info.outputs.PROJECT }}


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to fix [this error in CI](https://github.com/supabase/wrappers/actions/runs/12080540385/job/33688063684):

```
error: 'rustfmt' is not installed for the toolchain '1.81.0-x86_64-unknown-linux-gnu'.
```

As we're using fixed version of Rust, `rustfmt` is also reinstalled for that toolchain.

## What is the current behavior?

N/A

## What is the new behavior?

N/A

## Additional context

N/A
