### PR TITLE
docs: update Notion, Calendly and Cal.com Wasm FDW checksum

### DIFF
--- a/docs/catalog/cal.md
+++ b/docs/catalog/cal.md
@@ -37,7 +37,7 @@ The Cal.com API uses JSON formatted data, please refer to [Cal.com API docs](htt
 
 | Version | Wasm Package URL                                                                                | Checksum                                                           |
 | ------- | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
-| 0.1.0   | `https://github.com/supabase/wrappers/releases/download/wasm_cal_fdw_v0.1.0/cal_fdw.wasm` | `bca8a82d6c5f8da0aa58011940c4ddb40bb2c909c02dd89b488289c4fff890c1` |
+| 0.1.0   | `https://github.com/supabase/wrappers/releases/download/wasm_cal_fdw_v0.1.0/cal_fdw.wasm` | `4b8661caae0e4f7b5a1480ea297cf5681101320712cde914104b82f2b0954003` |
 
 ## Preparation
 
@@ -82,7 +82,7 @@ We need to provide Postgres with the credentials to access Cal.com and any addit
         fdw_package_url 'https://github.com/supabase/wrappers/releases/download/wasm_cal_fdw_v0.1.0/cal_fdw.wasm',
         fdw_package_name 'supabase:cal-fdw',
         fdw_package_version '0.1.0',
-        fdw_package_checksum 'bca8a82d6c5f8da0aa58011940c4ddb40bb2c909c02dd89b488289c4fff890c1',
+        fdw_package_checksum '4b8661caae0e4f7b5a1480ea297cf5681101320712cde914104b82f2b0954003',
         api_url 'https://api.cal.com/v2',  -- optional
         api_key_id '<key_ID>' -- The Key ID from above.
       );
@@ -97,7 +97,7 @@ We need to provide Postgres with the credentials to access Cal.com and any addit
         fdw_package_url 'https://github.com/supabase/wrappers/releases/download/wasm_cal_fdw_v0.1.0/cal_fdw.wasm',
         fdw_package_name 'supabase:cal-fdw',
         fdw_package_version '0.1.0',
-        fdw_package_checksum 'bca8a82d6c5f8da0aa58011940c4ddb40bb2c909c02dd89b488289c4fff890c1',
+        fdw_package_checksum '4b8661caae0e4f7b5a1480ea297cf5681101320712cde914104b82f2b0954003',
         api_url 'https://api.cal.com/v2',  -- optional
         api_key 'cal_live_1234...'  -- Cal.com API key
       );

--- a/docs/catalog/calendly.md
+++ b/docs/catalog/calendly.md
@@ -35,7 +35,7 @@ The Calendly API uses JSON formatted data, please refer to [Calendly API docs](h
 
 | Version | Wasm Package URL                                                                                | Checksum                                                           |
 | ------- | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
-| 0.1.0   | `https://github.com/supabase/wrappers/releases/download/wasm_calendly_fdw_v0.1.0/calendly_fdw.wasm` | `aa17f1ce2b48b5d8d6cee4f61df4d6b23e9a333c3e5c7a10cec9aae619c156b9` |
+| 0.1.0   | `https://github.com/supabase/wrappers/releases/download/wasm_calendly_fdw_v0.1.0/calendly_fdw.wasm` | `51a19fa4b8c40afb5dcf6dc2e009189aceeba65f30eec75d56a951d78fc8893f` |
 
 ## Preparation
 
@@ -80,7 +80,7 @@ We need to provide Postgres with the credentials to access Calendly and any addi
         fdw_package_url 'https://github.com/supabase/wrappers/releases/download/wasm_calendly_fdw_v0.1.0/calendly_fdw.wasm',
         fdw_package_name 'supabase:calendly-fdw',
         fdw_package_version '0.1.0',
-        fdw_package_checksum 'aa17f1ce2b48b5d8d6cee4f61df4d6b23e9a333c3e5c7a10cec9aae619c156b9',
+        fdw_package_checksum '51a19fa4b8c40afb5dcf6dc2e009189aceeba65f30eec75d56a951d78fc8893f',
         -- find your organization uri using foreign table 'calendly.current_user', see below example for details
         organization 'https://api.calendly.com/organizations/81da9c7f-3e19-434a-c3d2-0325e375cdef',
         api_url 'https://api.calendly.com',  -- optional
@@ -97,7 +97,7 @@ We need to provide Postgres with the credentials to access Calendly and any addi
         fdw_package_url 'https://github.com/supabase/wrappers/releases/download/wasm_calendly_fdw_v0.1.0/calendly_fdw.wasm',
         fdw_package_name 'supabase:calendly-fdw',
         fdw_package_version '0.1.0',
-        fdw_package_checksum 'aa17f1ce2b48b5d8d6cee4f61df4d6b23e9a333c3e5c7a10cec9aae619c156b9',
+        fdw_package_checksum '51a19fa4b8c40afb5dcf6dc2e009189aceeba65f30eec75d56a951d78fc8893f',
         -- find your organization uri using foreign table 'calendly.current_user', see below example for details
         organization 'https://api.calendly.com/organizations/81da9c7f-3e19-434a-c3d2-0325e375cdef',
         api_url 'https://api.calendly.com',  -- optional

--- a/docs/catalog/notion.md
+++ b/docs/catalog/notion.md
@@ -33,7 +33,7 @@ The Notion API uses JSON formatted data, please refer to [Notion API docs](https
 
 | Version | Wasm Package URL                                                                                | Checksum                                                           |
 | ------- | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
-| 0.1.0   | `https://github.com/supabase/wrappers/releases/download/wasm_notion_fdw_v0.1.0/notion_fdw.wasm` | `tbd` |
+| 0.1.0   | `https://github.com/supabase/wrappers/releases/download/wasm_notion_fdw_v0.1.0/notion_fdw.wasm` | `e017263d1fc3427cc1df8071d1182cdc9e2f00363344dddb8c195c5d398a2099` |
 
 ## Preparation
 
@@ -78,7 +78,7 @@ We need to provide Postgres with the credentials to access Notion, and any addit
         fdw_package_url 'https://github.com/supabase/wrappers/releases/download/wasm_notion_fdw_v0.1.0/notion_fdw.wasm',
         fdw_package_name 'supabase:notion-fdw',
         fdw_package_version '0.1.0',
-        fdw_package_checksum 'e31483cda6a3b36d38a09298bd5d00baf75cf705a533ecdc03a079c349f42d07',
+        fdw_package_checksum 'e017263d1fc3427cc1df8071d1182cdc9e2f00363344dddb8c195c5d398a2099',
         api_url 'https://api.notion.com/v1',  -- optional
         api_version '2022-06-28',  -- optional
         api_key_id '<key_ID>' -- The Key ID from above.
@@ -94,7 +94,7 @@ We need to provide Postgres with the credentials to access Notion, and any addit
         fdw_package_url 'https://github.com/supabase/wrappers/releases/download/wasm_notion_fdw_v0.1.0/notion_fdw.wasm',
         fdw_package_name 'supabase:notion-fdw',
         fdw_package_version '0.1.0',
-        fdw_package_checksum 'e31483cda6a3b36d38a09298bd5d00baf75cf705a533ecdc03a079c349f42d07',
+        fdw_package_checksum 'e017263d1fc3427cc1df8071d1182cdc9e2f00363344dddb8c195c5d398a2099',
         api_url 'https://api.notion.com/v1',  -- optional
         api_version '2022-06-28',  -- optional
         api_key 'secret_xxxxx'  -- Notion API key


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to update Notion, Calendly and Cal.com Wasm FDW checksum in their docs, as their releases have been updated due to #369.

## What is the current behavior?

N/A

## What is the new behavior?

N/A

## Additional context

N/A
