### PR TITLE
fix(wasm): add missing `TIMESTAMPTZOID` type oid

### DIFF
--- a/wrappers/src/fdw/wasm_fdw/host/mod.rs
+++ b/wrappers/src/fdw/wasm_fdw/host/mod.rs
@@ -115,8 +115,9 @@ impl HostColumn for FdwHost {
             pg_sys::TEXTOID => TypeOid::String,
             pg_sys::DATEOID => TypeOid::Date,
             pg_sys::TIMESTAMPOID => TypeOid::Timestamp,
+            pg_sys::TIMESTAMPTZOID => TypeOid::Timestamptz,
             pg_sys::JSONBOID => TypeOid::Json,
-            _ => unimplemented!(),
+            _ => unimplemented!("column type oid not supported"),
         }
     }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to add a missing type oid for `TIMESTAMPTZOID` data type. Fix #373 .

## What is the current behavior?

The `TIMESTAMPTZOID` type is missed in `type_oid()` function.

## What is the new behavior?

Add missing `TIMESTAMPTZOID` type oid,

## Additional context

N/A
