### PR TITLE
use edb pgrx fork, remove pg default

### DIFF
--- a/supabase-wrappers/Cargo.toml
+++ b/supabase-wrappers/Cargo.toml
@@ -11,9 +11,8 @@ categories = ["database"]
 keywords = ["database", "postgres", "postgresql", "extension"]
 
 [features]
-default = ["cshim", "pg15"]
+default = ["cshim"] # ["cshim", "pg15"] no PG version by default; needs to come from importing parent
 cshim = ["pgrx/cshim"]
-pg13 = ["pgrx/pg13", "pgrx-tests/pg13"]
 pg14 = ["pgrx/pg14", "pgrx-tests/pg14"]
 pg15 = ["pgrx/pg15", "pgrx-tests/pg15"]
 pg16 = ["pgrx/pg16", "pgrx-tests/pg16"]
@@ -21,17 +20,13 @@ pg17 = ["pgrx/pg17", "pgrx-tests/pg17" ]
 pg_test = []
 
 [dependencies]
-pgrx = { version = "=0.12.6", default-features = false }
+pgrx = { git = "https://github.com/EnterpriseDB/pgrx", branch = "develop-v0.12.8-edb" }
 thiserror = "1.0.48"
 tokio = { version = "1.35", features = ["rt", "net"] }
 uuid = { version = "1.2.2" }
 supabase-wrappers-macros = { version = "0.1", path = "../supabase-wrappers-macros" }
 
 [dev-dependencies]
-pgrx-tests = "=0.12.6"
+pgrx-tests = { git = "https://github.com/EnterpriseDB/pgrx", branch = "develop-v0.12.8-edb" }
 
-[package.metadata.docs.rs]
-features = ["pg15", "cshim"]
-no-default-features = true
-# Enable `#[cfg(docsrs)]` (https://docs.rs/about/builds#cross-compiling)
-rustc-args = ["--cfg", "docsrs"]
+


### PR DESCRIPTION
This draft PR links to the dev branch we use in aidb/pgfs.

it's branched off the current release tag `0.4.3`