### PR TITLE
chore: generic error message for file load

### DIFF
--- a/wrappers/src/fdw/wasm_fdw/mod.rs
+++ b/wrappers/src/fdw/wasm_fdw/mod.rs
@@ -14,6 +14,9 @@ use self::bindings::supabase::wrappers::types::FdwError as GuestFdwError;
 
 #[derive(Error, Debug)]
 enum WasmFdwError {
+    #[error("invalid WebAssembly component")]
+    InvalidWasmComponent,
+
     #[error("guest fdw error: {0}")]
     GuestFdw(GuestFdwError),
 

--- a/wrappers/src/fdw/wasm_fdw/wasm_fdw.rs
+++ b/wrappers/src/fdw/wasm_fdw/wasm_fdw.rs
@@ -147,7 +147,10 @@ impl ForeignDataWrapper<WasmFdwError> for WasmFdw {
         let engine = Engine::new(&config)?;
 
         let component =
-            download_component(&rt, &engine, pkg_url, pkg_name, pkg_version, pkg_checksum)?;
+            match download_component(&rt, &engine, pkg_url, pkg_name, pkg_version, pkg_checksum) {
+                Ok(c) => c,
+                Err(_) => panic!("wasmtime error: failed to parse WebAssembly module"),
+            };
 
         let mut linker = Linker::new(&engine);
         Wrappers::add_to_linker(&mut linker, |host: &mut FdwHost| host)?;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When loading a wasm file (from the local filesystem), the error message could be used to enumerate files on the filesystem.

File exists - `/etc/passwd`
```
wrappers=# select * from wasm_out;
ERROR:  wasmtime error: failed to parse WebAssembly module
```

No such file - `/etc/nop`
```
wrappers=# select * from wasm_out;
ERROR:  wasmtime error: failed to read input file: /etc/nop
```

## What is the new behavior?

Gives a generic error message for file load failures to prevent file system enumeration.

File exists - `/etc/passwd`
```
wrappers=# select * from wasm_out;
ERROR:  wasmtime error: failed to parse WebAssembly module
```

No such file - `/etc/nop`
```
wrappers=# select * from wasm_out;
ERROR:  wasmtime error: failed to parse WebAssembly module
```
## Additional context

Add any other context or screenshots.
