### PR TITLE
feat(cal): add booking insertion support

### DIFF
--- a/docs/catalog/index.md
+++ b/docs/catalog/index.md
@@ -13,7 +13,7 @@ hide:
 | Auth0       |   ✅   |   ❌   |   ❌   |   ❌   |    ❌    |    ❌     |
 | AWS Cognito |   ✅   |   ❌   |   ❌   |   ❌   |    ❌    |    ❌     |
 | BigQuery    |   ✅   |   ✅   |   ✅   |   ✅   |    ❌    |    ✅     |
-| Cal.com     |   ✅   |   ❌   |   ❌   |   ❌   |    ❌    |    ❌     |
+| Cal.com     |   ✅   |   ✅   |   ❌   |   ❌   |    ❌    |    ❌     |
 | Calendly    |   ✅   |   ❌   |   ❌   |   ❌   |    ❌    |    ❌     |
 | ClickHouse  |   ✅   |   ✅   |   ✅   |   ✅   |    ❌    |    ✅     |
 | Firebase    |   ✅   |   ❌   |   ❌   |   ❌   |    ❌    |    ❌     |


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to add data insertion support for `booking` object in Cal.com wrapper, so we can directly make a booking on Cal.com from Postgres database.

## What is the current behavior?

N/A

## What is the new behavior?

N/A

## Additional context

As `0.1.0` version number hasn't been officially released, it will be reused.
