### PR TITLE
docs(wasm): update Cal.com wrapper wasm fdw checksum

### DIFF
--- a/docs/catalog/cal.md
+++ b/docs/catalog/cal.md
@@ -37,7 +37,7 @@ The Cal.com API uses JSON formatted data, please refer to [Cal.com API docs](htt
 
 | Version | Wasm Package URL                                                                                | Checksum                                                           |
 | ------- | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
-| 0.1.0   | `https://github.com/supabase/wrappers/releases/download/wasm_cal_fdw_v0.1.0/cal_fdw.wasm` | `tbd` |
+| 0.1.0   | `https://github.com/supabase/wrappers/releases/download/wasm_cal_fdw_v0.1.0/cal_fdw.wasm` | `4afe4fac8c51f2caa1de8483b3817d2cec3a14cd8a65a3942c8b4ff6c430f08a` |
 
 ## Preparation
 
@@ -82,7 +82,7 @@ We need to provide Postgres with the credentials to access Cal.com and any addit
         fdw_package_url 'https://github.com/supabase/wrappers/releases/download/wasm_cal_fdw_v0.1.0/cal_fdw.wasm',
         fdw_package_name 'supabase:cal-fdw',
         fdw_package_version '0.1.0',
-        fdw_package_checksum '4b8661caae0e4f7b5a1480ea297cf5681101320712cde914104b82f2b0954003',
+        fdw_package_checksum '4afe4fac8c51f2caa1de8483b3817d2cec3a14cd8a65a3942c8b4ff6c430f08a',
         api_url 'https://api.cal.com/v2',  -- optional
         api_key_id '<key_ID>' -- The Key ID from above.
       );
@@ -97,7 +97,7 @@ We need to provide Postgres with the credentials to access Cal.com and any addit
         fdw_package_url 'https://github.com/supabase/wrappers/releases/download/wasm_cal_fdw_v0.1.0/cal_fdw.wasm',
         fdw_package_name 'supabase:cal-fdw',
         fdw_package_version '0.1.0',
-        fdw_package_checksum '4b8661caae0e4f7b5a1480ea297cf5681101320712cde914104b82f2b0954003',
+        fdw_package_checksum '4afe4fac8c51f2caa1de8483b3817d2cec3a14cd8a65a3942c8b4ff6c430f08a',
         api_url 'https://api.cal.com/v2',  -- optional
         api_key 'cal_live_1234...'  -- Cal.com API key
       );


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to update Cal.com wasm fdw checksum in its document. This fdw has been added `booking` insertion support in #380 and hasn't been officially released, so we redo the release and reuse the same version number.

## What is the current behavior?

N/A

## What is the new behavior?

N/A

## Additional context

N/A
