### PR TITLE
Update auth0.md | removed reference to AirTable

### DIFF
--- a/docs/catalog/auth0.md
+++ b/docs/catalog/auth0.md
@@ -55,7 +55,7 @@ returning key_id;
 
 ### Connecting to Auth0
 
-We need to provide Postgres with the credentials to connect to Airtable, and any additional options. We can do this using the `create server` command:
+We need to provide Postgres with the credentials to connect to Auth0, and any additional options. We can do this using the `create server` command:
 
 === "With Vault"
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

Accidentally references Airtable in the Auth0 docs

## What is the new behavior?

fixed typo

## Additional context


