### PR TITLE
chore: bump version to 0.4.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7838,7 +7838,7 @@ dependencies = [
 
 [[package]]
 name = "wrappers"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "arrow-array",

--- a/wrappers/Cargo.toml
+++ b/wrappers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wrappers"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to bump versions:

wrappers -> v0.4.4

## What is the current behavior?

N/A

## What is the new behavior?

N/A

## Additional context

N/A
