### PR TITLE
chore: add workflow for docs deploys

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,23 @@
+name: Deploy docs
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "docs/catalog/**"
+
+permissions: {}
+
+jobs:
+  deploy-docs:
+    runs-on: ubuntu-latest
+    env:
+      DOCS_REVALIDATION_KEY: ${{ secrets.DOCS_REVALIDATION_KEY }}
+    steps:
+      - name: Request docs revalidation
+        run: |
+          curl -X POST https://supabase.com/docs/api/revalidate \
+            -H 'Content-Type: application/json' \
+            -H 'Authorization: Bearer ${{ secrets.DOCS_REVALIDATION_KEY }}' \
+            -d '{"tags": ["wrappers"]}'


### PR DESCRIPTION
Add workflow to automatically revalidate the federated docs at supabase.com/docs when the docs/catalog directory is changed.

For more information on docs deployments, see the [deployment playbook](https://github.com/supabase/playbooks/blob/main/playbooks/docs/federated-docs-deploy.md).