### PR TITLE
ci: fix Rust version to 1.81.0 for Wasm wrappers test

### DIFF
--- a/.github/workflows/test_wrappers.yml
+++ b/.github/workflows/test_wrappers.yml
@@ -78,7 +78,7 @@ jobs:
 
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.81.0
 
     - run: |
         sudo apt remove -y postgres*


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to fix Rust toolchain to version 1.81.0 in Wasm wrappers testing CI pipeline. Fix testing issue in #399 .

## What is the current behavior?

N/A

## What is the new behavior?

N/A

## Additional context

N/A
