### PR TITLE
ci: add Coveralls coverage report to CI

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,39 @@
+name: Code Coverage
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  code-coverage:
+    name: Code Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.81.0
+          components: llvm-tools-preview
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Generate code coverage
+        id: coverage
+        run: |
+          cargo llvm-cov test --workspace --exclude supabase-wrappers-macros --no-fail-fast --lcov --output-path lcov.info
+
+      - name: Coveralls upload
+        uses: coverallsapp/github-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: lcov.info
+          debug: true


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to add a CI workflow for uploading coverage report to Coveralls.

Coveralls reports page: https://coveralls.io/github/supabase/wrappers

## What is the current behavior?

No coverage reporting.

## What is the new behavior?

Coverage reporting is done in a new GitHub Action workflow, when code is pushed to `main` branch.

## Additional context

Ref:
- https://github.com/trane-project/trane/blob/master/.github/workflows/coverage.yaml
