### PR TITLE
fix upstream anstream security vulnerability

### DIFF
--- a/wrappers/Cargo.lock
+++ b/wrappers/Cargo.lock
@@ -119,7 +119,7 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.5.0"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f58811cfac344940f1a400b6e6231ce35171f614f26439e80f8c1465c5cc0c"
 dependencies = [


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to upgrade `anstream` dependency to fix https://github.com/supabase/wrappers/security/dependabot/55.

## What is the current behavior?

Current version is `0.5.0`.

## What is the new behavior?

Upgrade to version `0.6.8`.

## Additional context

N/A
