### PR TITLE
ci: make rust 1.81.0 as the default toolchain

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -21,10 +21,9 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: 1.81.0
-          components: llvm-tools-preview
+          components: llvm-tools-preview, rustfmt, clippy
           default: true
           override: true
-          components: rustfmt, clippy
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,6 +22,9 @@ jobs:
         with:
           toolchain: 1.81.0
           components: llvm-tools-preview
+          default: true
+          override: true
+          components: rustfmt, clippy
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
           # Ensure installed pg_config is first on path
           export PATH=$PATH:/usr/lib/postgresql/${{ matrix.postgres }}/bin
 
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --profile minimal --default-toolchain stable && \
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --profile minimal --default-toolchain 1.81.0 && \
             rustup --version && \
             rustc --version && \
             cargo --version

--- a/.github/workflows/test_supabase_wrappers.yml
+++ b/.github/workflows/test_supabase_wrappers.yml
@@ -17,6 +17,9 @@ jobs:
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: 1.81.0
+        default: true
+        override: true
+        components: rustfmt, clippy
 
     - run: |
         sudo apt remove -y postgres*

--- a/.github/workflows/test_wrappers.yml
+++ b/.github/workflows/test_wrappers.yml
@@ -24,6 +24,9 @@ jobs:
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: 1.81.0
+        default: true
+        override: true
+        components: rustfmt, clippy
 
     - run: |
         sudo apt remove -y postgres*
@@ -79,6 +82,9 @@ jobs:
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: 1.81.0
+        default: true
+        override: true
+        components: rustfmt, clippy
 
     - run: |
         sudo apt remove -y postgres*


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to make Rust 1.81.0 as the default toolchain in CI workflow, so to make the WASM fdw built is compatible with wasmtime host.

## What is the current behavior?

In the step `actions-rs/toolchain@v1`, the default toolchain is still `stable` although we specified the rust version 1.81.0.

## What is the new behavior?

Not only specify the rust version to 1.81.0, we also need to make it the default toolchain so the following steps are using the correct version of rust.

## Additional context

N/A
