### PR TITLE
ci: set login credentials for clickhouse testing

### DIFF
--- a/wrappers/.ci/docker-compose-native.yaml
+++ b/wrappers/.ci/docker-compose-native.yaml
@@ -30,8 +30,13 @@ services:
     ports:
       - "9000:9000" # native interface
       - "8123:8123" # http interface
+    environment:
+      CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1
+      CLICKHOUSE_USER: default
+      CLICKHOUSE_PASSWORD: default
+      CLICKHOUSE_DB: default
     healthcheck:
-      test: sleep 4 && wget --no-verbose --tries=1 --spider http://localhost:8123/?query=SELECT%201 || exit 1
+      test: sleep 4 && wget --no-verbose --tries=1 --spider http://default:default@127.0.0.1:8123/?query=SELECT%201 || exit 1
       interval: 10s
       timeout: 5s
       retries: 20

--- a/wrappers/src/fdw/clickhouse_fdw/tests.rs
+++ b/wrappers/src/fdw/clickhouse_fdw/tests.rs
@@ -9,7 +9,7 @@ mod tests {
     #[pg_test]
     fn clickhouse_smoketest() {
         Spi::connect(|mut c| {
-            let clickhouse_pool = ch::Pool::new("tcp://default:@localhost:9000/default");
+            let clickhouse_pool = ch::Pool::new("tcp://default:default@localhost:9000/default");
 
             let rt = create_async_runtime().expect("failed to create runtime");
             let mut handle = rt
@@ -37,7 +37,7 @@ mod tests {
                 r#"CREATE SERVER my_clickhouse_server
                          FOREIGN DATA WRAPPER clickhouse_wrapper
                          OPTIONS (
-                           conn_string 'tcp://default:@localhost:9000/default'
+                           conn_string 'tcp://default:default@localhost:9000/default'
                          )"#,
                 None,
                 None,


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to set login credentials used for clickhouse testing.

## What is the current behavior?

The current login credentials for clickhouse isn't set, so it defaults to username=default and no password, but latest clickhouse container doesn't hold that true.

## What is the new behavior?

Explicitly set login credentials for clickhouse container so the test can success.

## Additional context

N/A
