### PR TITLE
chore: change Rust lints cfgs to warn

### DIFF
--- a/supabase-wrappers/Cargo.toml
+++ b/supabase-wrappers/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["database"]
 keywords = ["database", "postgres", "postgresql", "extension"]
 
 [lints.rust]
-unexpected_cfgs = { level = "allow", check-cfg = ['cfg(pgrx_embed)'] }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(pgrx_embed)'] }
 
 [features]
 default = ["pg15"]

--- a/wrappers/Cargo.toml
+++ b/wrappers/Cargo.toml
@@ -12,7 +12,7 @@ name = "pgrx_embed_wrappers"
 path = "./src/bin/pgrx_embed.rs"
 
 [lints.rust]
-unexpected_cfgs = { level = "allow", check-cfg = ['cfg(pgrx_embed)'] }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(pgrx_embed)'] }
 
 [features]
 default = ["pg15"]


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to change Rust lints cfgs from `allow` to `warn`.

## What is the current behavior?

The current Rust lints cfgs is `allow`, which is not necessary and `warn` level is enough.

## What is the new behavior?

Rust lints cfgs is changed to `warn` level.

## Additional context

N/A
