### PR TITLE
fix(mssql): numeric data type conversion precision loss

### DIFF
--- a/wrappers/src/fdw/mssql_fdw/README.md
+++ b/wrappers/src/fdw/mssql_fdw/README.md
@@ -10,6 +10,7 @@ This is a foreign data wrapper for [Microsoft SQL Server](https://www.microsoft.
 
 | Version | Date       | Notes                                                |
 | ------- | ---------- | ---------------------------------------------------- |
+| 0.1.3   | 2025-02-12 | Fix Numeric type conversion error                    |
 | 0.1.2   | 2024-09-30 | Support for pgrx 0.12.6                              |
 | 0.1.1   | 2024-09-09 | Add boolean test qual support                        |
 | 0.1.0   | 2023-12-27 | Initial version                                      |

--- a/wrappers/src/fdw/mssql_fdw/mod.rs
+++ b/wrappers/src/fdw/mssql_fdw/mod.rs
@@ -23,6 +23,9 @@ enum MssqlFdwError {
     TiberiusError(#[from] tiberius::error::Error),
 
     #[error("{0}")]
+    PgrxNumericError(#[from] pgrx::datum::numeric_support::error::Error),
+
+    #[error("{0}")]
     CreateRuntimeError(#[from] CreateRuntimeError),
 
     #[error("{0}")]

--- a/wrappers/src/fdw/mssql_fdw/mssql_fdw.rs
+++ b/wrappers/src/fdw/mssql_fdw/mssql_fdw.rs
@@ -46,8 +46,9 @@ fn field_to_cell(src_row: &tiberius::Row, tgt_col: &Column) -> MssqlFdwResult<Op
         }
         PgOid::BuiltIn(PgBuiltInOids::NUMERICOID) => src_row
             .try_get::<Decimal, &str>(col_name)?
-            .and_then(|v| v.to_i128())
-            .map(pgrx::AnyNumeric::from)
+            .and_then(|v| v.to_f64())
+            .map(pgrx::AnyNumeric::try_from)
+            .transpose()?
             .map(Cell::Numeric),
         PgOid::BuiltIn(PgBuiltInOids::TEXTOID) => src_row
             .try_get::<&str, &str>(col_name)?
@@ -93,7 +94,7 @@ impl CellFormatter for MssqlCellFormatter {
 }
 
 #[wrappers_fdw(
-    version = "0.1.2",
+    version = "0.1.3",
     author = "Supabase",
     website = "https://github.com/supabase/wrappers/tree/main/wrappers/src/fdw/mssql_fdw",
     error_type = "MssqlFdwError"


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to fix the numeric data type conversion precision loss issue in MSSQL FDW, fix #416.

## What is the current behavior?

The `numeric` data type is converted to integer, which caused precision loss.

## What is the new behavior?

Use `f64` as the converted data type, so to keep number precision.

## Additional context

N/A
