### PR TITLE
chore: bump Wrappers version to 0.4.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6549,7 +6549,7 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "supabase-wrappers"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "pgrx",
  "pgrx-tests",
@@ -8369,7 +8369,7 @@ dependencies = [
 
 [[package]]
 name = "wrappers"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "anyhow",
  "arrow-array",

--- a/supabase-wrappers/Cargo.toml
+++ b/supabase-wrappers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "supabase-wrappers"
-version = "0.1.20"
+version = "0.1.21"
 edition = "2021"
 authors = ["Supabase Inc. https://supabase.com/"]
 license = "Apache-2.0"

--- a/wrappers/Cargo.toml
+++ b/wrappers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wrappers"
-version = "0.4.4"
+version = "0.4.5"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to bump versions:

- wrappers version to `0.4.5`
- supabase-wrappers version to `0.1.21`

## What is the current behavior?

N/A

## What is the new behavior?

N/A

## Additional context

N/A
