### PR TITLE
feat(stripe): [DATAENG-875] add schema import support to Stripe FDW

### DIFF
--- a/docs/catalog/stripe.md
+++ b/docs/catalog/stripe.md
@@ -118,6 +118,27 @@ The Stripe Wrapper supports data read and modify from Stripe API.
 | [Topups](#top-ups)                            |   ✅   |   ❌   |   ❌   |   ❌   |    ❌    |
 | [Transfers](#transfers)                       |   ✅   |   ❌   |   ❌   |   ❌   |    ❌    |
 
+We can use SQL [import foreign schema](https://www.postgresql.org/docs/current/sql-importforeignschema.html) to import foreign table definitions from Stripe.
+
+For example, using below SQL can automatically create foreign tables in the `stripe` schema.
+
+```sql
+-- create all the foreign tables
+import foreign schema stripe from server stripe_server into stripe;
+
+-- or, create "checkout_sessions", "customers" and "balance" tables only
+import foreign schema stripe
+   limit to ("checkout_sessions", "customers", "balance")
+   from server stripe_server into stripe;
+
+-- or, create all foreign tables except "checkout_sessions" and "billing_meters"
+import foreign schema stripe
+   except ("checkout_sessions", "billing_meters")
+   from server stripe_server into stripe;
+```
+
+The full list of the foreign tables is below:
+
 ### Accounts
 
 This is an object representing a Stripe account.
@@ -625,7 +646,7 @@ Ref: [Stripe docs](https://docs.stripe.com/api/billing/meter)
 #### Usage
 
 ```sql
-create foreign table stripe.meter (
+create foreign table stripe.billing_meter (
   id text,
   display_name text,
   event_name text,

--- a/wrappers/src/fdw/stripe_fdw/README.md
+++ b/wrappers/src/fdw/stripe_fdw/README.md
@@ -10,6 +10,7 @@ This is a foreign data wrapper for [Stripe](https://stripe.com/) developed using
 
 | Version | Date       | Notes                                                |
 | ------- | ---------- | ---------------------------------------------------- |
+| 0.1.12  | 2025-03-06 | Added import foreign schema support                  |
 | 0.1.11  | 2024-09-20 | Added Meter object                                   |
 | 0.1.10  | 2024-08-26 | Added 'api_key_name' server option                   |
 | 0.1.9   | 2024-07-01 | Added 'api_version' server option                    |

--- a/wrappers/src/fdw/stripe_fdw/tests.rs
+++ b/wrappers/src/fdw/stripe_fdw/tests.rs
@@ -23,489 +23,39 @@ mod tests {
                 None,
                 None,
             ).unwrap();
-
+            c.update(r#"CREATE SCHEMA IF NOT EXISTS stripe"#, None, None)
+                .unwrap();
             c.update(
-                r#"
-                CREATE FOREIGN TABLE stripe_accounts (
-                  id text,
-                  business_type text,
-                  country text,
-                  email text,
-                  type text,
-                  created timestamp,
-                  attrs jsonb
-                )
-                SERVER my_stripe_server
-                OPTIONS (
-                    object 'accounts'    -- source object in stripe, required
-                  )
-             "#,
+                r#"IMPORT FOREIGN SCHEMA stripe FROM SERVER my_stripe_server INTO stripe"#,
                 None,
                 None,
             )
             .unwrap();
-
             c.update(
-                r#"
-                CREATE FOREIGN TABLE stripe_balance (
-                  balance_type text,
-                  amount bigint,
-                  currency text,
-                  attrs jsonb
-                )
-                SERVER my_stripe_server
-                OPTIONS (
-                    object 'balance'    -- source object in stripe, required
-                  )
-             "#,
+                r#"IMPORT FOREIGN SCHEMA stripe FROM SERVER my_stripe_server INTO stripe"#,
                 None,
                 None,
             )
             .unwrap();
-
             c.update(
-                r#"
-                CREATE FOREIGN TABLE stripe_balance_transactions (
-                  id text,
-                  amount bigint,
-                  currency text,
-                  description text,
-                  fee bigint,
-                  net bigint,
-                  status text,
-                  type text,
-                  created timestamp,
-                  attrs jsonb
-                )
-                SERVER my_stripe_server
-                OPTIONS (
-                    object 'balance_transactions'    -- source object in stripe, required
-                  )
-             "#,
+                r#"IMPORT FOREIGN SCHEMA stripe
+                  LIMIT TO ("checkout_sessions", "customers", "balance", "non-exists")
+                  FROM SERVER my_stripe_server INTO stripe"#,
                 None,
                 None,
             )
             .unwrap();
-
             c.update(
-                r#"
-                CREATE FOREIGN TABLE stripe_charges (
-                  id text,
-                  amount bigint,
-                  currency text,
-                  customer text,
-                  description text,
-                  invoice text,
-                  payment_intent text,
-                  status text,
-                  created timestamp,
-                  attrs jsonb
-                )
-                SERVER my_stripe_server
-                OPTIONS (
-                    object 'charges'    -- source object in stripe, required
-                  )
-             "#,
-                None,
-                None,
-            )
-            .unwrap();
-
-            c.update(
-                r#"
-                CREATE FOREIGN TABLE stripe_customers (
-                  id text,
-                  email text,
-                  name text,
-                  description text,
-                  created timestamp,
-                  attrs jsonb
-                )
-                SERVER my_stripe_server
-                OPTIONS (
-                    object 'customers',    -- source object in stripe, required
-                    rowid_column 'id'
-                )
-             "#,
-                None,
-                None,
-            )
-            .unwrap();
-
-            c.update(
-                r#"
-                CREATE FOREIGN TABLE stripe_disputes (
-                  id text,
-                  amount bigint,
-                  currency text,
-                  charge text,
-                  payment_intent text,
-                  reason text,
-                  status text,
-                  created timestamp,
-                  attrs jsonb
-                )
-                SERVER my_stripe_server
-                OPTIONS (
-                    object 'disputes'    -- source object in stripe, required
-                )
-             "#,
-                None,
-                None,
-            )
-            .unwrap();
-
-            c.update(
-                r#"
-                CREATE FOREIGN TABLE stripe_events (
-                  id text,
-                  type text,
-                  api_version text,
-                  created timestamp,
-                  attrs jsonb
-                )
-                SERVER my_stripe_server
-                OPTIONS (
-                    object 'events'    -- source object in stripe, required
-                )
-             "#,
-                None,
-                None,
-            )
-            .unwrap();
-
-            c.update(
-                r#"
-                CREATE FOREIGN TABLE stripe_files (
-                  id text,
-                  filename text,
-                  purpose text,
-                  title text,
-                  size bigint,
-                  type text,
-                  url text,
-                  created timestamp,
-                  expires_at timestamp,
-                  attrs jsonb
-                )
-                SERVER my_stripe_server
-                OPTIONS (
-                    object 'files'    -- source object in stripe, required
-                )
-             "#,
-                None,
-                None,
-            )
-            .unwrap();
-
-            c.update(
-                r#"
-                CREATE FOREIGN TABLE stripe_file_links (
-                  id text,
-                  file text,
-                  url text,
-                  created timestamp,
-                  expired bool,
-                  expires_at timestamp,
-                  attrs jsonb
-                )
-                SERVER my_stripe_server
-                OPTIONS (
-                    object 'file_links'    -- source object in stripe, required
-                )
-             "#,
-                None,
-                None,
-            )
-            .unwrap();
-
-            c.update(
-                r#"
-                CREATE FOREIGN TABLE stripe_invoices (
-                  id text,
-                  customer text,
-                  subscription text,
-                  status text,
-                  total bigint,
-                  currency text,
-                  period_start timestamp,
-                  period_end timestamp,
-                  attrs jsonb
-                )
-                SERVER my_stripe_server
-                OPTIONS (
-                    object 'invoices'    -- source object in stripe, required
-                  )
-             "#,
-                None,
-                None,
-            )
-            .unwrap();
-
-            c.update(
-                r#"
-                CREATE FOREIGN TABLE stripe_payment_intents (
-                  id text,
-                  customer text,
-                  amount bigint,
-                  currency text,
-                  payment_method text,
-                  created timestamp,
-                  attrs jsonb
-                )
-                SERVER my_stripe_server
-                OPTIONS (
-                    object 'payment_intents'    -- source object in stripe, required
-                  )
-             "#,
-                None,
-                None,
-            )
-            .unwrap();
-
-            c.update(
-                r#"
-                CREATE FOREIGN TABLE stripe_payouts (
-                  id text,
-                  amount bigint,
-                  currency text,
-                  arrival_date timestamp,
-                  description text,
-                  statement_descriptor text,
-                  status text,
-                  created timestamp,
-                  attrs jsonb
-                )
-                SERVER my_stripe_server
-                OPTIONS (
-                    object 'payouts'    -- source object in stripe, required
-                  )
-             "#,
-                None,
-                None,
-            )
-            .unwrap();
-
-            c.update(
-                r#"
-                CREATE FOREIGN TABLE stripe_prices (
-                  id text,
-                  active bool,
-                  currency text,
-                  product text,
-                  unit_amount bigint,
-                  type text,
-                  created timestamp,
-                  attrs jsonb
-                )
-                SERVER my_stripe_server
-                OPTIONS (
-                    object 'prices'    -- source object in stripe, required
-                  )
-             "#,
-                None,
-                None,
-            )
-            .unwrap();
-
-            c.update(
-                r#"
-                CREATE FOREIGN TABLE stripe_products (
-                  id text,
-                  name text,
-                  active bool,
-                  default_price text,
-                  description text,
-                  created timestamp,
-                  updated timestamp,
-                  attrs jsonb
-                )
-                SERVER my_stripe_server
-                OPTIONS (
-                    object 'products',    -- source object in stripe, required
-                    rowid_column 'id'
-                  )
-             "#,
-                None,
-                None,
-            )
-            .unwrap();
-
-            c.update(
-                r#"
-                CREATE FOREIGN TABLE stripe_refunds (
-                  id text,
-                  amount bigint,
-                  currency text,
-                  charge text,
-                  payment_intent text,
-                  reason text,
-                  status text,
-                  created timestamp,
-                  attrs jsonb
-                )
-                SERVER my_stripe_server
-                OPTIONS (
-                    object 'refunds'    -- source object in stripe, required
-                  )
-             "#,
-                None,
-                None,
-            )
-            .unwrap();
-
-            c.update(
-                r#"
-                CREATE FOREIGN TABLE stripe_setup_attempts (
-                  id text,
-                  application text,
-                  customer text,
-                  on_behalf_of text,
-                  payment_method text,
-                  setup_intent text,
-                  status text,
-                  usage text,
-                  created timestamp,
-                  attrs jsonb
-                )
-                SERVER my_stripe_server
-                OPTIONS (
-                    object 'setup_attempts'    -- source object in stripe, required
-                  )
-             "#,
-                None,
-                None,
-            )
-            .unwrap();
-
-            c.update(
-                r#"
-                CREATE FOREIGN TABLE stripe_setup_intents (
-                  id text,
-                  client_secret text,
-                  customer text,
-                  description text,
-                  payment_method text,
-                  status text,
-                  usage text,
-                  created timestamp,
-                  attrs jsonb
-                )
-                SERVER my_stripe_server
-                OPTIONS (
-                    object 'setup_intents'    -- source object in stripe, required
-                  )
-             "#,
-                None,
-                None,
-            )
-            .unwrap();
-
-            c.update(
-                r#"
-                CREATE FOREIGN TABLE stripe_subscriptions (
-                  id text,
-                  customer text,
-                  currency text,
-                  current_period_start timestamp,
-                  current_period_end timestamp,
-                  attrs jsonb
-                )
-                SERVER my_stripe_server
-                OPTIONS (
-                  object 'subscriptions',    -- source object in stripe, required
-                  rowid_column 'id'
-                )
-             "#,
-                None,
-                None,
-            )
-            .unwrap();
-
-            c.update(
-                r#"
-                CREATE FOREIGN TABLE stripe_topups (
-                  id text,
-                  amount bigint,
-                  currency text,
-                  description text,
-                  status text,
-                  created timestamp,
-                  attrs jsonb
-                )
-                SERVER my_stripe_server
-                OPTIONS (
-                  object 'topups'    -- source object in stripe, required
-                )
-             "#,
-                None,
-                None,
-            )
-            .unwrap();
-
-            c.update(
-                r#"
-                CREATE FOREIGN TABLE stripe_transfers (
-                  id text,
-                  amount bigint,
-                  currency text,
-                  description text,
-                  destination text,
-                  created timestamp,
-                  attrs jsonb
-                )
-                SERVER my_stripe_server
-                OPTIONS (
-                  object 'transfers'    -- source object in stripe, required
-                )
-             "#,
-                None,
-                None,
-            )
-            .unwrap();
-
-            c.update(
-                r#"
-                CREATE FOREIGN TABLE billing_meters (
-                  id text,
-                  display_name text,
-                  event_name text,
-                  event_time_window text,
-                  status text,
-                  attrs jsonb
-                )
-                SERVER my_stripe_server
-                OPTIONS (
-                  object 'billing/meters'
-                )
-             "#,
-                None,
-                None,
-            )
-            .unwrap();
-
-            c.update(
-                r#"
-                CREATE FOREIGN TABLE checkout_sessions (
-                  id text,
-                  customer text,
-                  payment_intent text,
-                  subscription text,
-                  attrs jsonb
-                )
-                SERVER my_stripe_server
-                OPTIONS (
-                  object 'checkout/sessions',
-                  rowid_column 'id'
-                )
-             "#,
+                r#"IMPORT FOREIGN SCHEMA stripe
+                  EXCEPT ("checkout_sessions", "customers", "balance", "non-exists")
+                  FROM SERVER my_stripe_server INTO stripe"#,
                 None,
                 None,
             )
             .unwrap();
 
             let results = c
-                .select("SELECT * FROM stripe_accounts", None, None)
+                .select("SELECT * FROM stripe.accounts", None, None)
                 .unwrap()
                 .filter_map(|r| {
                     r.get_by_name::<&str, _>("email")
@@ -518,7 +68,7 @@ mod tests {
 
             let results = c
                 .select(
-                    "SELECT * FROM stripe_balance WHERE balance_type IS NOT NULL",
+                    "SELECT * FROM stripe.balance WHERE balance_type IS NOT NULL",
                     None,
                     None,
                 )
@@ -536,7 +86,7 @@ mod tests {
             );
 
             let results = c
-                .select("SELECT * FROM stripe_balance_transactions", None, None)
+                .select("SELECT * FROM stripe.balance_transactions", None, None)
                 .unwrap()
                 .filter_map(|r| {
                     r.get_by_name::<i64, _>("amount")
@@ -550,7 +100,7 @@ mod tests {
             assert_eq!(results, vec![((((100, "usd"), 0), "available"), "charge")]);
 
             let results = c
-                .select("SELECT * FROM stripe_charges", None, None)
+                .select("SELECT * FROM stripe.charges", None, None)
                 .unwrap()
                 .filter_map(|r| {
                     r.get_by_name::<i64, _>("amount")
@@ -562,7 +112,7 @@ mod tests {
             assert_eq!(results, vec![((100, "usd"), "succeeded")]);
 
             let results = c
-                .select("SELECT * FROM stripe_customers", None, None)
+                .select("SELECT * FROM stripe.customers", None, None)
                 .unwrap()
                 .filter_map(|r| {
                     r.get_by_name::<&str, _>("id")
@@ -580,7 +130,7 @@ mod tests {
 
             let results = c
                 .select(
-                    "SELECT attrs->>'id' as id FROM stripe_customers",
+                    "SELECT attrs->>'id' as id FROM stripe.customers",
                     None,
                     None,
                 )
@@ -590,7 +140,11 @@ mod tests {
             assert_eq!(results, vec!["cus_QXg1o8vcGmoR32"]);
 
             let results = c
-                .select("SELECT id, display_name FROM billing_meters", None, None)
+                .select(
+                    "SELECT id, display_name FROM stripe.billing_meters",
+                    None,
+                    None,
+                )
                 .unwrap()
                 .filter_map(|r| r.get_by_name::<&str, _>("id").unwrap())
                 .collect::<Vec<_>>();
@@ -598,7 +152,7 @@ mod tests {
 
             let results = c
                 .select(
-                    "SELECT attrs->>'id' as id FROM checkout_sessions",
+                    "SELECT attrs->>'id' as id FROM stripe.checkout_sessions",
                     None,
                     None,
                 )
@@ -615,7 +169,7 @@ mod tests {
             //
             // let results = c
             //     .select(
-            //         "SELECT * FROM stripe_customers where id = 'non_exists'",
+            //         "SELECT * FROM stripe.customers where id = 'non_exists'",
             //         None,
             //         None,
             //     ).unwrap()
@@ -624,7 +178,7 @@ mod tests {
             // assert!(results.is_empty());
 
             let results = c
-                .select("SELECT * FROM stripe_disputes", None, None)
+                .select("SELECT * FROM stripe.disputes", None, None)
                 .unwrap()
                 .filter_map(|r| {
                     r.get_by_name::<&str, _>("id")
@@ -639,7 +193,7 @@ mod tests {
             );
 
             let results = c
-                .select("SELECT * FROM stripe_events", None, None)
+                .select("SELECT * FROM stripe.events", None, None)
                 .unwrap()
                 .filter_map(|r| {
                     r.get_by_name::<&str, _>("id")
@@ -653,7 +207,7 @@ mod tests {
             );
 
             let results = c
-                .select("SELECT * FROM stripe_files", None, None)
+                .select("SELECT * FROM stripe.files", None, None)
                 .unwrap()
                 .filter_map(|r| {
                     r.get_by_name::<&str, _>("id")
@@ -678,7 +232,7 @@ mod tests {
             );
 
             let results = c
-                .select("SELECT * FROM stripe_file_links", None, None)
+                .select("SELECT * FROM stripe.file_links", None, None)
                 .unwrap()
                 .filter_map(|r| {
                     r.get_by_name::<&str, _>("id")
@@ -699,7 +253,7 @@ mod tests {
             );
 
             let results = c
-                .select("SELECT * FROM stripe_invoices", None, None)
+                .select("SELECT * FROM stripe.invoices", None, None)
                 .unwrap()
                 .filter_map(|r| {
                     r.get_by_name::<&str, _>("customer")
@@ -715,7 +269,7 @@ mod tests {
             );
 
             let results = c
-                .select("SELECT * FROM stripe_payment_intents", None, None)
+                .select("SELECT * FROM stripe.payment_intents", None, None)
                 .unwrap()
                 .filter_map(|r| {
                     r.get_by_name::<i64, _>("amount")
@@ -726,7 +280,7 @@ mod tests {
             assert_eq!(results, vec![(1099, "usd")]);
 
             let results = c
-                .select("SELECT * FROM stripe_payouts", None, None)
+                .select("SELECT * FROM stripe.payouts", None, None)
                 .unwrap()
                 .filter_map(|r| {
                     r.get_by_name::<&str, _>("id")
@@ -742,7 +296,7 @@ mod tests {
             );
 
             let results = c
-                .select("SELECT * FROM stripe_prices", None, None)
+                .select("SELECT * FROM stripe.prices", None, None)
                 .unwrap()
                 .filter_map(|r| {
                     r.get_by_name::<&str, _>("id")
@@ -765,7 +319,7 @@ mod tests {
             );
 
             let results = c
-                .select("SELECT * FROM stripe_products", None, None)
+                .select("SELECT * FROM stripe.products", None, None)
                 .unwrap()
                 .filter_map(|r| {
                     r.get_by_name::<&str, _>("name")
@@ -780,7 +334,7 @@ mod tests {
             );
 
             let results = c
-                .select("SELECT * FROM stripe_refunds", None, None)
+                .select("SELECT * FROM stripe.refunds", None, None)
                 .unwrap()
                 .filter_map(|r| {
                     r.get_by_name::<&str, _>("id")
@@ -796,7 +350,7 @@ mod tests {
             );
 
             let results = c
-                .select("SELECT * FROM stripe_setup_attempts where setup_intent='seti_1Pgag7B7WZ01zgkWSgwGdb8Z'", None, None).unwrap()
+                .select("SELECT * FROM stripe.setup_attempts where setup_intent='seti_1Pgag7B7WZ01zgkWSgwGdb8Z'", None, None).unwrap()
                 .filter_map(|r| {
                     r.get_by_name::<&str, _>("id")
                         .unwrap()
@@ -813,7 +367,7 @@ mod tests {
             );
 
             let results = c
-                .select("SELECT * FROM stripe_setup_intents", None, None)
+                .select("SELECT * FROM stripe.setup_intents", None, None)
                 .unwrap()
                 .filter_map(|r| {
                     r.get_by_name::<&str, _>("id")
@@ -831,7 +385,7 @@ mod tests {
             );
 
             let results = c
-                .select("SELECT * FROM stripe_subscriptions", None, None)
+                .select("SELECT * FROM stripe.subscriptions", None, None)
                 .unwrap()
                 .filter_map(|r| {
                     r.get_by_name::<&str, _>("customer")
@@ -856,7 +410,7 @@ mod tests {
             );
 
             let results = c
-                .select("SELECT * FROM stripe_topups", None, None)
+                .select("SELECT * FROM stripe.topups", None, None)
                 .unwrap()
                 .filter_map(|r| {
                     r.get_by_name::<&str, _>("id")
@@ -872,7 +426,7 @@ mod tests {
             );
 
             let results = c
-                .select("SELECT * FROM stripe_transfers", None, None)
+                .select("SELECT * FROM stripe.transfers", None, None)
                 .unwrap()
                 .filter_map(|r| {
                     r.get_by_name::<&str, _>("id")
@@ -899,7 +453,7 @@ mod tests {
             // test insert
             c.update(
                 r#"
-                INSERT INTO stripe_customers(email, name, description)
+                INSERT INTO stripe.customers(email, name, description)
                 VALUES ('test@test.com', 'test name', null)
                 "#,
                 None,
@@ -908,7 +462,7 @@ mod tests {
 
             let results = c
                 .select(
-                    "SELECT * FROM stripe_customers WHERE email = 'test@test.com'",
+                    "SELECT * FROM stripe.customers WHERE email = 'test@test.com'",
                     None,
                     None,
                 ).unwrap()
@@ -925,7 +479,7 @@ mod tests {
             // test update
             c.update(
                 r#"
-                UPDATE stripe_customers
+                UPDATE stripe.customers
                 SET description = 'hello fdw'
                 WHERE email = 'test@test.com'
                 "#,
@@ -935,7 +489,7 @@ mod tests {
 
             let results = c
                 .select(
-                    "SELECT * FROM stripe_customers WHERE email = 'test@test.com'",
+                    "SELECT * FROM stripe.customers WHERE email = 'test@test.com'",
                     None,
                     None,
                 ).unwrap()
@@ -953,7 +507,7 @@ mod tests {
             // test delete
             c.update(
                 r#"
-                DELETE FROM stripe_customers WHERE email = 'test@test.com'
+                DELETE FROM stripe.customers WHERE email = 'test@test.com'
                 "#,
                 None,
                 None,
@@ -961,7 +515,7 @@ mod tests {
 
             let results = c
                 .select(
-                    "SELECT * FROM stripe_customers WHERE email = 'test@test.com'",
+                    "SELECT * FROM stripe.customers WHERE email = 'test@test.com'",
                     None,
                     None,
                 ).unwrap()


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to add `import foreign schema` support to Stripe FDW.

## What is the current behavior?

Currently we have to manually create all the foreign tables with DDL specified in the docs.

## What is the new behavior?

We can use `import foreign schema` SQL to automatically import all foreign table definitions. For example,

```sql
-- create all the foreign tables
import foreign schema stripe from server stripe_server into stripe;

-- or, create "checkout_sessions", "customers" and "balance" tables only
import foreign schema stripe
   limit to ("checkout_sessions", "customers", "balance")
   from server stripe_server into stripe;

-- or, create all foreign tables except "checkout_sessions" and "billing_meters"
import foreign schema stripe
   except ("checkout_sessions", "billing_meters")
   from server stripe_server into stripe;
```

## Additional context

ATM, this feature is for Stripe FDW only.
