### PR TITLE
fix: explicitly define permissions in actions

### DIFF
--- a/.github/workflows/test_supabase_wrappers.yml
+++ b/.github/workflows/test_supabase_wrappers.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Run supabase_wrappers tests

--- a/.github/workflows/test_wrappers.yml
+++ b/.github/workflows/test_wrappers.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   # =============================================================
   # Native wrappers test


### PR DESCRIPTION
Small fix to some actions with explicit GITHUB_TOKEN permissions