### PR TITLE
docs: [DATAENG-916] update Vault encryption method

### DIFF
--- a/docs/catalog/airtable.md
+++ b/docs/catalog/airtable.md
@@ -43,13 +43,15 @@ By default, Postgres stores FDW credentials inside `pg_catalog.pg_foreign_server
 Get your token from [Airtable's developer portal](https://airtable.com/create/tokens).
 
 ```sql
--- Save your Airtable API key in Vault and retrieve the `key_id`
-insert into vault.secrets (name, secret)
-values (
+-- Save your Airtable API key in Vault
+select vault.create_secret(
+  '<Airtable API Key or PAT>', -- Airtable API key or Personal Access Token (PAT)
   'airtable',
-  '<Airtable API Key or PAT>' -- Airtable API key or Personal Access Token (PAT)
-)
-returning key_id;
+  'Airtable API key for Wrappers'
+);
+
+-- Retrieve the `key_id`
+select key_id from vault.decrypted_secrets where name = 'airtable';
 ```
 
 ### Connecting to Airtable

--- a/docs/catalog/auth0.md
+++ b/docs/catalog/auth0.md
@@ -40,13 +40,15 @@ create foreign data wrapper auth0_wrapper
 By default, Postgres stores FDW credentials inside `pg_catalog.pg_foreign_server` in plain text. Anyone with access to this table will be able to view these credentials. Wrappers is designed to work with [Vault](https://supabase.com/docs/guides/database/vault), which provides an additional level of security for storing credentials. We recommend using Vault to store your credentials.
 
 ```sql
--- Save your Auth0 API key in Vault and retrieve the `key_id`
-insert into vault.secrets (name, secret)
-values (
+-- Save your Auth0 API key in Vault
+select vault.create_secret(
+  '<Auth0 API Key or PAT>', -- Auth0 API key or Personal Access Token (PAT)
   'auth0',
-  '<Auth0 API Key or PAT>' -- Auth0 API key or Personal Access Token (PAT)
-)
-returning key_id;
+  'Auth0 API key for Wrappers'
+);
+
+-- Retrieve the `key_id`
+select key_id from vault.decrypted_secrets where name = 'auth0';
 ```
 
 ### Connecting to Auth0

--- a/docs/catalog/bigquery.md
+++ b/docs/catalog/bigquery.md
@@ -40,10 +40,8 @@ create foreign data wrapper bigquery_wrapper
 By default, Postgres stores FDW credentials inside `pg_catalog.pg_foreign_server` in plain text. Anyone with access to this table will be able to view these credentials. Wrappers is designed to work with [Vault](https://supabase.com/docs/guides/database/vault), which provides an additional level of security for storing credentials. We recommend using Vault to store your credentials.
 
 ```sql
--- Save your BigQuery service account json in Vault and retrieve the `key_id`
-insert into vault.secrets (name, secret)
-values (
-  'bigquery',
+-- Save your BigQuery service account json in Vault
+select vault.create_secret(
   '
     {
       "type": "service_account",
@@ -52,9 +50,13 @@ values (
       "private_key": "-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n",
       ...
     }
-  '
-)
-returning key_id;
+  ',
+  'bigquery',
+  'BigQuery service account json for Wrappers'
+);
+
+-- Retrieve the `key_id`
+select key_id from vault.decrypted_secrets where name = 'bigquery';
 ```
 
 ### Connecting to BigQuery

--- a/docs/catalog/cal.md
+++ b/docs/catalog/cal.md
@@ -46,13 +46,15 @@ create foreign data wrapper wasm_wrapper
 By default, Postgres stores FDW credentials inside `pg_catalog.pg_foreign_server` in plain text. Anyone with access to this table will be able to view these credentials. Wrappers is designed to work with [Vault](https://supabase.com/docs/guides/database/vault), which provides an additional level of security for storing credentials. We recommend using Vault to store your credentials.
 
 ```sql
--- Save your Cal.com API key in Vault and retrieve the `key_id`
-insert into vault.secrets (name, secret)
-values (
+-- Save your Cal.com API key in Vault
+select vault.create_secret(
+  '<Cal.com API key>', -- Cal.com API key
   'cal',
-  '<Cal.com API key>' -- Cal.com API key
-)
-returning key_id;
+  'Cal.com API key for Wrappers'
+);
+
+-- Retrieve the `key_id`
+select key_id from vault.decrypted_secrets where name = 'cal';
 ```
 
 ### Connecting to Cal.com

--- a/docs/catalog/calendly.md
+++ b/docs/catalog/calendly.md
@@ -46,13 +46,15 @@ create foreign data wrapper wasm_wrapper
 By default, Postgres stores FDW credentials inside `pg_catalog.pg_foreign_server` in plain text. Anyone with access to this table will be able to view these credentials. Wrappers is designed to work with [Vault](https://supabase.com/docs/guides/database/vault), which provides an additional level of security for storing credentials. We recommend using Vault to store your credentials.
 
 ```sql
--- Save your Calendly API key in Vault and retrieve the `key_id`
-insert into vault.secrets (name, secret)
-values (
+-- Save your Calendly API key in Vault
+select vault.create_secret(
+  '<Calendly API key>', -- Calendly personal access token
   'calendly',
-  '<Calendly API key>' -- Calendly personal access token
-)
-returning key_id;
+  'Calendly API key for Wrappers'
+);
+
+-- Retrieve the `key_id`
+select key_id from vault.decrypted_secrets where name = 'calendly';
 ```
 
 ### Connecting to Calendly

--- a/docs/catalog/cfd1.md
+++ b/docs/catalog/cfd1.md
@@ -46,13 +46,15 @@ create foreign data wrapper wasm_wrapper
 By default, Postgres stores FDW credentials inside `pg_catalog.pg_foreign_server` in plain text. Anyone with access to this table will be able to view these credentials. Wrappers is designed to work with [Vault](https://supabase.com/docs/guides/database/vault), which provides an additional level of security for storing credentials. We recommend using Vault to store your credentials.
 
 ```sql
--- Save your D1 API token in Vault and retrieve the `key_id`
-insert into vault.secrets (name, secret)
-values (
+-- Save your D1 API token in Vault
+select vault.create_secret(
+  '<D1 API token>', -- Cloudflare D1 API token
   'cfd1',
-  '<D1 API token>' -- Cloudflare D1 API token
-)
-returning key_id;
+  'Cloudflare D1 API key for Wrappers'
+);
+
+-- Retrieve the `key_id`
+select key_id from vault.decrypted_secrets where name = 'cfd1';
 ```
 
 ### Connecting to D1

--- a/docs/catalog/clerk.md
+++ b/docs/catalog/clerk.md
@@ -46,13 +46,15 @@ create foreign data wrapper wasm_wrapper
 By default, Postgres stores FDW credentials inside `pg_catalog.pg_foreign_server` in plain text. Anyone with access to this table will be able to view these credentials. Wrappers is designed to work with [Vault](https://supabase.com/docs/guides/database/vault), which provides an additional level of security for storing credentials. We recommend using Vault to store your credentials.
 
 ```sql
--- Save your Clerk API key in Vault and retrieve the `key_id`
-insert into vault.secrets (name, secret)
-values (
+-- Save your Clerk API key in Vault
+select vault.create_secret(
+  '<Clerk API key>', -- Clerk API key
   'clerk',
-  '<Clerk API key>' -- Clerk API key 
-)
-returning key_id;
+  'Clerk API key for Wrappers'
+);
+
+-- Retrieve the `key_id`
+select key_id from vault.decrypted_secrets where name = 'clerk';
 ```
 
 ### Connecting to Clerk

--- a/docs/catalog/clickhouse.md
+++ b/docs/catalog/clickhouse.md
@@ -40,13 +40,15 @@ create foreign data wrapper clickhouse_wrapper
 By default, Postgres stores FDW credentials inside `pg_catalog.pg_foreign_server` in plain text. Anyone with access to this table will be able to view these credentials. Wrappers is designed to work with [Vault](https://supabase.com/docs/guides/database/vault), which provides an additional level of security for storing credentials. We recommend using Vault to store your credentials.
 
 ```sql
--- Save your ClickHouse credential in Vault and retrieve the `key_id`
-insert into vault.secrets (name, secret)
-values (
+-- Save your ClickHouse credential in Vault
+select vault.create_secret(
+  'tcp://default:@localhost:9000/default',
   'clickhouse',
-  'tcp://default:@localhost:9000/default'
-)
-returning key_id;
+  'ClickHouse credential for Wrappers'
+);
+
+-- Retrieve the `key_id`
+select key_id from vault.decrypted_secrets where name = 'clickhouse';
 ```
 
 ### Connecting to ClickHouse

--- a/docs/catalog/cognito.md
+++ b/docs/catalog/cognito.md
@@ -40,12 +40,15 @@ create foreign data wrapper cognito_wrapper
 By default, Postgres stores FDW credentials inside `pg_catalog.pg_foreign_server` in plain text. Anyone with access to this table will be able to view these credentials. Wrappers are designed to work with [Vault](https://supabase.com/docs/guides/database/vault), which provides an additional level of security for storing credentials. We recommend using Vault to store your credentials.
 
 ```sql
-insert into vault.secrets (name, secret)
-values (
-  'cognito_secret_access_key',
-  '<secret access key>'
-)
-returning key_id;
+-- Save your Cognito secret access key in Vault
+select vault.create_secret(
+  '<secret access key>',
+  'cognito',
+  'Cognito secret key for Wrappers'
+);
+
+-- Retrieve the `key_id`
+select key_id from vault.decrypted_secrets where name = 'cognito';
 ```
 
 ### Connecting to Cognito

--- a/docs/catalog/firebase.md
+++ b/docs/catalog/firebase.md
@@ -41,17 +41,19 @@ create foreign data wrapper firebase_wrapper
 By default, Postgres stores FDW credentials inside `pg_catalog.pg_foreign_server` in plain text. Anyone with access to this table will be able to view these credentials. Wrappers is designed to work with [Vault](https://supabase.com/docs/guides/database/vault), which provides an additional level of security for storing credentials. We recommend using Vault to store your credentials.
 
 ```sql
--- Save your Firebase credentials in Vault and retrieve the `key_id`
-insert into vault.secrets (name, secret)
-values (
-  'firebase',
+-- Save your Firebase credentials in Vault
+select vault.create_secret(
   '{
       "type": "service_account",
       "project_id": "your_gcp_project_id",
       ...
-  }'
-)
-returning key_id;
+  }',
+  'firebase',
+  'Firebase API key for Wrappers'
+);
+
+-- Retrieve the `key_id`
+select key_id from vault.decrypted_secrets where name = 'firebase';
 ```
 
 ### Connecting to Firebase

--- a/docs/catalog/hubspot.md
+++ b/docs/catalog/hubspot.md
@@ -46,13 +46,15 @@ create foreign data wrapper wasm_wrapper
 By default, Postgres stores FDW credentials inside `pg_catalog.pg_foreign_server` in plain text. Anyone with access to this table will be able to view these credentials. Wrappers is designed to work with [Vault](https://supabase.com/docs/guides/database/vault), which provides an additional level of security for storing credentials. We recommend using Vault to store your credentials.
 
 ```sql
--- Save your HubSpot private apps access token in Vault and retrieve the `key_id`
-insert into vault.secrets (name, secret)
-values (
+-- Save your HubSpot private apps access token in Vault
+select vault.create_secret(
+  '<HubSpot access token>', -- HubSpot private apps access token
   'hubspot',
-  '<HubSpot access token>' -- HubSpot private apps access token
-)
-returning key_id;
+  'HubSpot private apps access token for Wrappers'
+);
+
+-- Retrieve the `key_id`
+select key_id from vault.decrypted_secrets where name = 'hubspot';
 ```
 
 ### Connecting to HubSpot

--- a/docs/catalog/logflare.md
+++ b/docs/catalog/logflare.md
@@ -40,13 +40,15 @@ create foreign data wrapper logflare_wrapper
 By default, Postgres stores FDW credentials inside `pg_catalog.pg_foreign_server` in plain text. Anyone with access to this table will be able to view these credentials. Wrappers is designed to work with [Vault](https://supabase.com/docs/guides/database/vault), which provides an additional level of security for storing credentials. We recommend using Vault to store your credentials.
 
 ```sql
--- Save your Logflare API key in Vault and retrieve the `key_id`
-insert into vault.secrets (name, secret)
-values (
+-- Save your Logflare API key in Vault
+select vault.create_secret(
+  '<YOUR_SECRET>',
   'logflare',
-  'YOUR_SECRET'
-)
-returning key_id;
+  'Logflare API key for Wrappers'
+);
+
+-- Retrieve the `key_id`
+select key_id from vault.decrypted_secrets where name = 'logflare';
 ```
 
 ### Connecting to Logflare

--- a/docs/catalog/mssql.md
+++ b/docs/catalog/mssql.md
@@ -40,13 +40,15 @@ create foreign data wrapper mssql_wrapper
 By default, Postgres stores FDW credentials inside `pg_catalog.pg_foreign_server` in plain text. Anyone with access to this table will be able to view these credentials. Wrappers is designed to work with [Vault](https://supabase.com/docs/guides/database/vault), which provides an additional level of security for storing credentials. We recommend using Vault to store your credentials.
 
 ```sql
--- Save your SQL Server connection string in Vault and retrieve the `key_id`
-insert into vault.secrets (name, secret)
-values (
+-- Save your SQL Server connection string in Vault
+select vault.create_secret(
+  'Server=localhost,1433;User=sa;Password=my_password;Database=master;IntegratedSecurity=false;TrustServerCertificate=true;encrypt=DANGER_PLAINTEXT;ApplicationName=wrappers',
   'mssql',
-  'Server=localhost,1433;User=sa;Password=my_password;Database=master;IntegratedSecurity=false;TrustServerCertificate=true;encrypt=DANGER_PLAINTEXT;ApplicationName=wrappers'
-)
-returning key_id;
+  'MS SQL Server connection string for Wrappers'
+);
+
+-- Retrieve the `key_id`
+select key_id from vault.decrypted_secrets where name = 'mssql';
 ```
 
 The connection string is an [ADO.NET connection string](https://learn.microsoft.com/en-us/dotnet/framework/data/adonet/connection-strings), which specifies connection parameters in semicolon-delimited string.

--- a/docs/catalog/notion.md
+++ b/docs/catalog/notion.md
@@ -47,13 +47,15 @@ create foreign data wrapper wasm_wrapper
 By default, Postgres stores FDW credentials inside `pg_catalog.pg_foreign_server` in plain text. Anyone with access to this table will be able to view these credentials. Wrappers is designed to work with [Vault](https://supabase.com/docs/guides/database/vault), which provides an additional level of security for storing credentials. We recommend using Vault to store your credentials.
 
 ```sql
--- Save your Notion API key in Vault and retrieve the `key_id`
-insert into vault.secrets (name, secret)
-values (
+-- Save your Notion API key in Vault
+select vault.create_secret(
+  '<Notion API key>', -- Notion API key, should look like ntn_589513........
   'notion',
-  '<Notion API key>' -- should look like ntn_589513........
-)
-returning key_id; -- copy this Vault key id for the next step
+  'Notion API key for Wrappers'
+);
+
+-- Retrieve the `key_id`
+select key_id from vault.decrypted_secrets where name = 'notion';
 ```
 
 > ⚠️ ** Getting a Notion API key**

--- a/docs/catalog/orb.md
+++ b/docs/catalog/orb.md
@@ -46,13 +46,15 @@ create foreign data wrapper wasm_wrapper
 By default, Postgres stores FDW credentials inside `pg_catalog.pg_foreign_server` in plain text. Anyone with access to this table will be able to view these credentials. Wrappers is designed to work with [Vault](https://supabase.com/docs/guides/database/vault), which provides an additional level of security for storing credentials. We recommend using Vault to store your credentials.
 
 ```sql
--- Save your Orb API key in Vault and retrieve the `key_id`
-insert into vault.secrets (name, secret)
-values (
+-- Save your Orb API key in Vault
+select vault.create_secret(
+  '<Orb API key>', -- Orb API key
   'orb',
-  '<Orb API key>' -- Orb API key 
-)
-returning key_id;
+  'Orb API key for Wrappers'
+);
+
+-- Retrieve the `key_id`
+select key_id from vault.decrypted_secrets where name = 'orb';
 ```
 
 ### Connecting to Orb

--- a/docs/catalog/paddle.md
+++ b/docs/catalog/paddle.md
@@ -47,13 +47,15 @@ create foreign data wrapper wasm_wrapper
 By default, Postgres stores FDW credentials inside `pg_catalog.pg_foreign_server` in plain text. Anyone with access to this table will be able to view these credentials. Wrappers is designed to work with [Vault](https://supabase.com/docs/guides/database/vault), which provides an additional level of security for storing credentials. We recommend using Vault to store your credentials.
 
 ```sql
--- Save your Paddle API key in Vault and retrieve the `key_id`
-insert into vault.secrets (name, secret)
-values (
+-- Save your Paddle API key in Vault
+select vault.create_secret(
+  '<Paddle API key>', -- Paddle API key
   'paddle',
-  '<Paddle API key>' -- Paddle API key
-)
-returning key_id;
+  'Paddle API key for Wrappers'
+);
+
+-- Retrieve the `key_id`
+select key_id from vault.decrypted_secrets where name = 'paddle';
 ```
 
 ### Connecting to Paddle

--- a/docs/catalog/redis.md
+++ b/docs/catalog/redis.md
@@ -40,13 +40,15 @@ create foreign data wrapper redis_wrapper
 By default, Postgres stores FDW credentials inside `pg_catalog.pg_foreign_server` in plain text. Anyone with access to this table will be able to view these credentials. Wrappers is designed to work with [Vault](https://supabase.com/docs/guides/database/vault), which provides an additional level of security for storing credentials. We recommend using Vault to store your credentials.
 
 ```sql
--- Save your Redis connection URL in Vault and retrieve the `key_id`
-insert into vault.secrets (name, secret)
-values (
-  'redis_conn_url',
-  'redis://username:password@127.0.0.1:6379/db'
-)
-returning key_id;
+-- Save your Redis connection URL in Vault
+select vault.create_secret(
+  'redis://username:password@127.0.0.1:6379/db',
+  'redis',
+  'Redis connection URL for Wrappers'
+);
+
+-- Retrieve the `key_id`
+select key_id from vault.decrypted_secrets where name = 'redis';
 ```
 
 ### Connecting to Redis

--- a/docs/catalog/s3.md
+++ b/docs/catalog/s3.md
@@ -55,20 +55,21 @@ create foreign data wrapper s3_wrapper
 By default, Postgres stores FDW credentials inside `pg_catalog.pg_foreign_server` in plain text. Anyone with access to this table will be able to view these credentials. Wrappers is designed to work with [Vault](https://supabase.com/docs/guides/database/vault), which provides an additional level of security for storing credentials. We recommend using Vault to store your credentials.
 
 ```sql
--- Save your AWS credential in Vault and retrieve the `key_id`
-insert into vault.secrets (name, secret)
-values (
-  'vault_access_key_id',
-  '<access key id>'
-)
-returning key_id;
-
-insert into vault.secrets (name, secret)
-values (
-  'vault_secret_access_key',
+-- Save your AWS credentials in Vault
+select vault.create_secret(
+  '<access key id>',
+  's3_access_key_id',
+  'AWS access key for Wrappers'
+);
+select vault.create_secret(
   '<secret access key>'
-)
-returning key_id;
+  's3_secret_access_key',
+  'AWS secret access key for Wrappers'
+);
+
+-- Retrieve the `key_id`
+select key_id from vault.decrypted_secrets where name = 's3_access_key_id';
+select key_id from vault.decrypted_secrets where name = 's3_secret_access_key';
 ```
 
 ### Connecting to S3
@@ -81,8 +82,8 @@ We need to provide Postgres with the credentials to connect to S3, and any addit
     create server s3_server
       foreign data wrapper s3_wrapper
       options (
-        vault_access_key_id '<your vault_access_key_id from above>',
-        vault_secret_access_key '<your vault_secret_access_key from above>',
+        vault_access_key_id '<your s3_access_key_id from above>',
+        vault_secret_access_key '<your s3_secret_access_key from above>',
         aws_region 'us-east-1'
       );
     ```

--- a/docs/catalog/snowflake.md
+++ b/docs/catalog/snowflake.md
@@ -49,13 +49,15 @@ By default, Postgres stores FDW credentials inside `pg_catalog.pg_foreign_server
 This FDW uses key-pair authentication to access Snowflake SQL Rest API, please refer to [Snowflake docs](https://docs.snowflake.com/en/developer-guide/sql-api/authenticating#label-sql-api-authenticating-key-pair) for more details about the key-pair authentication.
 
 ```sql
--- Save your Snowflake private key in Vault and retrieve the `key_id`
-insert into vault.secrets (name, secret)
-values (
+-- Save your Snowflake private key in Vault
+select vault.create_secret(
+  E'-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----',
   'snowflake',
-  E'-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----'
-)
-returning key_id;
+  'Snowflake private key for Wrappers'
+);
+
+-- Retrieve the `key_id`
+select key_id from vault.decrypted_secrets where name = 'snowflake';
 ```
 
 ### Connecting to Snowflake

--- a/docs/catalog/stripe.md
+++ b/docs/catalog/stripe.md
@@ -40,13 +40,15 @@ create foreign data wrapper stripe_wrapper
 By default, Postgres stores FDW credentials inside `pg_catalog.pg_foreign_server` in plain text. Anyone with access to this table will be able to view these credentials. Wrappers is designed to work with [Vault](https://supabase.com/docs/guides/database/vault), which provides an additional level of security for storing credentials. We recommend using Vault to store your credentials.
 
 ```sql
--- Save your Stripe API key in Vault and retrieve the `key_id`
-insert into vault.secrets (name, secret)
-values (
+-- Save your Stripe API key in Vault
+select vault.create_secret(
+  '<Stripe API key>',
   'stripe',
-  '<Stripe API key>'
-)
-returning key_id;
+  'Stripe API key for Wrappers'
+);
+
+-- Retrieve the `key_id`
+select key_id from vault.decrypted_secrets where name = 'stripe';
 ```
 
 ### Connecting to Stripe


### PR DESCRIPTION
## What kind of change does this PR introduce?

It is now recommended to use `vault.create_secret` to save credential in Vault, this PR is to update all wrappers docs to use that function rather than using `insert into vault.secrets`.

## What is the current behavior?

N/A

## What is the new behavior?

N/A

## Additional context

N/A
