### PR TITLE
ci: upgrade workflow runner to Ubuntu 24.04

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   code-coverage:
     name: Code Coverage
-    runs-on: ubuntu-20.04
+    runs-on: [larger-runner-4cpu]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -30,25 +30,14 @@ jobs:
 
       - run: |
           sudo apt remove -y postgres*
-          sudo apt-get install -y wget gnupg
-          sudo sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-          wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
-          sudo apt-get update -y -qq --fix-missing
-          sudo apt-get install -y \
-            clang-10 \
-            llvm-10 \
-            clang \
-            gcc \
-            make \
-            build-essential \
-            libz-dev \
-            zlib1g-dev \
-            strace \
-            libssl-dev \
-            pkg-config \
-            postgresql-15 \
-            postgresql-server-dev-15
-          sudo apt-get -y autoremove && sudo apt-get -y clean
+          sudo apt -y install curl ca-certificates build-essential pkg-config libssl-dev
+          sudo install -d /usr/share/postgresql-common/pgdg
+          sudo curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc
+          . /etc/os-release
+          sudo sh -c "echo 'deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $VERSION_CODENAME-pgdg main' > /etc/apt/sources.list.d/pgdg.list"
+          sudo apt update -y -qq --fix-missing
+          sudo apt -y install postgresql-client-15 postgresql-15 postgresql-server-dev-15
+          sudo apt -y autoremove && sudo apt -y clean
           sudo chmod a+rwx `/usr/lib/postgresql/15/bin/pg_config --pkglibdir` `/usr/lib/postgresql/15/bin/pg_config --sharedir`/extension /var/run/postgresql/
 
       - run: cargo install cargo-pgrx --version 0.12.9

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
         features:
           - "all_fdws"
         box:
-          - { runner: ubuntu-20.04, arch: amd64 }
+          - { runner: ubuntu-24.04, arch: amd64 }
           - { runner: arm-runner, arch: arm64 }
     runs-on: ${{ matrix.box.runner }}
     timeout-minutes: 90
@@ -56,17 +56,17 @@ jobs:
         run: |
           cd wrappers
 
-          # Add postgres package repo
-          sudo sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-          wget -qO- https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo tee /etc/apt/trusted.gpg.d/pgdg.asc &>/dev/null
-
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends git build-essential libpq-dev curl libreadline6-dev zlib1g-dev pkg-config cmake
-          sudo apt-get install -y --no-install-recommends libreadline-dev zlib1g-dev flex bison libxml2-dev libxslt-dev libssl-dev libxml2-utils xsltproc ccache
-          sudo apt-get install -y --no-install-recommends clang libclang-dev gcc tree
-
-          # Install requested postgres version
-          sudo apt install -y postgresql-${{ matrix.postgres }} postgresql-server-dev-${{ matrix.postgres }} -y
+          # Add postgres package repo and install requested postgres version
+          sudo apt remove -y postgres*
+          sudo apt -y install curl ca-certificates build-essential pkg-config libssl-dev
+          sudo install -d /usr/share/postgresql-common/pgdg
+          sudo curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc
+          . /etc/os-release
+          sudo sh -c "echo 'deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $VERSION_CODENAME-pgdg main' > /etc/apt/sources.list.d/pgdg.list"
+          sudo apt update -y -qq --fix-missing
+          sudo apt -y install postgresql-${{ matrix.postgres }} postgresql-server-dev-${{ matrix.postgres }}
+          sudo apt -y autoremove && sudo apt -y clean
+          sudo chmod a+rwx `/usr/lib/postgresql/${{ matrix.postgres }}/bin/pg_config --pkglibdir` `/usr/lib/postgresql/${{ matrix.postgres }}/bin/pg_config --sharedir`/extension /var/run/postgresql/
 
           # Ensure installed pg_config is first on path
           export PATH=$PATH:/usr/lib/postgresql/${{ matrix.postgres }}/bin

--- a/.github/workflows/test_supabase_wrappers.yml
+++ b/.github/workflows/test_supabase_wrappers.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   test:
     name: Run supabase_wrappers tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Checkout code
@@ -26,24 +26,14 @@ jobs:
 
     - run: |
         sudo apt remove -y postgres*
-        sudo apt-get install -y wget gnupg
-        sudo sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-        wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
-        sudo apt-get update -y -qq --fix-missing
-        sudo apt-get install -y \
-          clang-10 \
-          llvm-10 \
-          clang \
-          gcc \
-          make \
-          build-essential \
-          libz-dev \
-          zlib1g-dev \
-          strace \
-          libssl-dev \
-          pkg-config \
-          postgresql-15 \
-          postgresql-server-dev-15
+        sudo apt -y install curl ca-certificates build-essential pkg-config libssl-dev
+        sudo install -d /usr/share/postgresql-common/pgdg
+        sudo curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc
+        . /etc/os-release
+        sudo sh -c "echo 'deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $VERSION_CODENAME-pgdg main' > /etc/apt/sources.list.d/pgdg.list"
+        sudo apt update -y -qq --fix-missing
+        sudo apt -y install postgresql-client-15 postgresql-15 postgresql-server-dev-15
+        sudo apt -y autoremove && sudo apt -y clean
         sudo chmod a+rwx `/usr/lib/postgresql/15/bin/pg_config --pkglibdir` `/usr/lib/postgresql/15/bin/pg_config --sharedir`/extension /var/run/postgresql/
 
     - run: cargo install cargo-pgrx --version 0.12.9

--- a/.github/workflows/test_wrappers.yml
+++ b/.github/workflows/test_wrappers.yml
@@ -62,7 +62,7 @@ jobs:
   # =============================================================
   test_wasm:
     name: Run Wasm wrappers tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Checkout code
@@ -81,24 +81,14 @@ jobs:
 
     - run: |
         sudo apt remove -y postgres*
-        sudo apt-get install -y wget gnupg
-        sudo sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-        wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
-        sudo apt-get update -y -qq --fix-missing
-        sudo apt-get install -y \
-          clang-10 \
-          llvm-10 \
-          clang \
-          gcc \
-          make \
-          build-essential \
-          libz-dev \
-          zlib1g-dev \
-          strace \
-          libssl-dev \
-          pkg-config \
-          postgresql-15 \
-          postgresql-server-dev-15
+        sudo apt -y install curl ca-certificates build-essential pkg-config libssl-dev
+        sudo install -d /usr/share/postgresql-common/pgdg
+        sudo curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc
+        . /etc/os-release
+        sudo sh -c "echo 'deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $VERSION_CODENAME-pgdg main' > /etc/apt/sources.list.d/pgdg.list"
+        sudo apt update -y -qq --fix-missing
+        sudo apt -y install postgresql-client-15 postgresql-15 postgresql-server-dev-15
+        sudo apt -y autoremove && sudo apt -y clean
         sudo chmod a+rwx `/usr/lib/postgresql/15/bin/pg_config --pkglibdir` `/usr/lib/postgresql/15/bin/pg_config --sharedir`/extension /var/run/postgresql/
 
     - run: cargo install cargo-pgrx --version 0.12.9

--- a/.github/workflows/test_wrappers.yml
+++ b/.github/workflows/test_wrappers.yml
@@ -14,7 +14,7 @@ jobs:
   # =============================================================
   test_native:
     name: Run native wrappers tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Checkout code
@@ -33,24 +33,14 @@ jobs:
 
     - run: |
         sudo apt remove -y postgres*
-        sudo apt-get install -y wget gnupg
-        sudo sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-        wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
-        sudo apt-get update -y -qq --fix-missing
-        sudo apt-get install -y \
-          clang-10 \
-          llvm-10 \
-          clang \
-          gcc \
-          make \
-          build-essential \
-          libz-dev \
-          zlib1g-dev \
-          strace \
-          libssl-dev \
-          pkg-config \
-          postgresql-15 \
-          postgresql-server-dev-15
+        sudo apt -y install curl ca-certificates build-essential pkg-config libssl-dev
+        sudo install -d /usr/share/postgresql-common/pgdg
+        sudo curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc
+        . /etc/os-release
+        sudo sh -c "echo 'deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $VERSION_CODENAME-pgdg main' > /etc/apt/sources.list.d/pgdg.list"
+        sudo apt update -y -qq --fix-missing
+        sudo apt -y install postgresql-client-15 postgresql-15 postgresql-server-dev-15
+        sudo apt -y autoremove && sudo apt -y clean
         sudo chmod a+rwx `/usr/lib/postgresql/15/bin/pg_config --pkglibdir` `/usr/lib/postgresql/15/bin/pg_config --sharedir`/extension /var/run/postgresql/
 
     - run: cargo install cargo-pgrx --version 0.12.9


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to upgrade github action runner to Ubuntu 24.04 as Ubuntu 20.04 will be deprecated. A larger runner `larger-runner-4cpu` is also used for coverage workflow as it requires more disk space.

## What is the current behavior?

Current github action workflows are using Ubuntu 20.04 runner.

## What is the new behavior?

Upgrade github action workflows to use Ubuntu 24.04 runner.

## Additional context

Postgres installation steps are also updated for the new runner.
