### PR TITLE
feat: fallback to using secrets.id instead of secrets.key_id

### DIFF
--- a/supabase-wrappers/src/utils.rs
+++ b/supabase-wrappers/src/utils.rs
@@ -165,7 +165,7 @@ pub fn get_vault_secret(secret_id: &str) -> Option<String> {
         Ok(sid) => {
             let sid = sid.into_bytes();
             match Spi::get_one_with_args::<String>(
-                "select decrypted_secret from vault.decrypted_secrets where key_id = $1",
+                "select decrypted_secret from vault.decrypted_secrets where id = $1 or key_id = $1",
                 vec![(
                     PgBuiltInOids::UUIDOID.oid(),
                     pgrx::Uuid::from_bytes(sid).into_datum(),


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

We retrieve Vault secrets via `secrets.key_id`

## What is the new behavior?

Retrieve Vault secrets via `secrets.key_id` and `secrets.id`. This lets us eventually remove all usage of pgsodium (incl. `pgsodium.create_key`)