### PR TITLE
fix: ClickHouse url change

### DIFF
--- a/docs/catalog/clickhouse.md
+++ b/docs/catalog/clickhouse.md
@@ -78,9 +78,13 @@ We need to provide Postgres with the credentials to connect to ClickHouse, and a
 Some connection string examples:
 
 - `tcp://user:password@host:9000/clicks?compression=lz4&ping_timeout=42ms`
-- `tcp://default:password@host:9440/default?connection_timeout=30s&ping_before_query=false&secure=true`
+- `tcp://default:PASSWORD@abc.eu-west-1.aws.clickhouse.cloud:9440/default?connection_timeout=30s&ping_before_query=false&secure=true`
 
-Check [more connection string parameters](https://github.com/suharev7/clickhouse-rs#dns).
+Check out [more connection string parameters](https://github.com/suharev7/clickhouse-rs#dns).
+
+!!! note
+
+    This ClickHouse FDW only supports native protocol port `9000` and `9440`, HTTP(S) port like `8123` and `8443` are not supported yet.
 
 ### Create a schema
 

--- a/docs/catalog/clickhouse.md
+++ b/docs/catalog/clickhouse.md
@@ -78,7 +78,7 @@ We need to provide Postgres with the credentials to connect to ClickHouse, and a
 Some connection string examples:
 
 - `tcp://user:password@host:9000/clicks?compression=lz4&ping_timeout=42ms`
-- `tcp://default:PASSWORD@abc.eu-west-1.aws.clickhouse.cloud:9440/default?connection_timeout=30s&ping_before_query=false&secure=true`
+- `tcp://default:password@host:9440/default?connection_timeout=30s&ping_before_query=false&secure=true`
 
 Check [more connection string parameters](https://github.com/suharev7/clickhouse-rs#dns).
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Supabase Docs - [ClickHouse](https://supabase.com/docs/guides/database/extensions/wrappers/clickhouse#connecting-to-clickhouse)

## What is the new behavior?

URL updated to be more generic and copy ClickHouse docs

## Additional context

Closes [31857](https://github.com/supabase/supabase/issues/31857) in supabase repo