### PR TITLE
docs: update docs for secret creation in Vault

### DIFF
--- a/docs/catalog/airtable.md
+++ b/docs/catalog/airtable.md
@@ -43,15 +43,12 @@ By default, Postgres stores FDW credentials inside `pg_catalog.pg_foreign_server
 Get your token from [Airtable's developer portal](https://airtable.com/create/tokens).
 
 ```sql
--- Save your Airtable API key in Vault
+-- Save your Airtable API key in Vault and retrieve the created `key_id`
 select vault.create_secret(
   '<Airtable API Key or PAT>', -- Airtable API key or Personal Access Token (PAT)
   'airtable',
   'Airtable API key for Wrappers'
 );
-
--- Retrieve the `key_id`
-select key_id from vault.decrypted_secrets where name = 'airtable';
 ```
 
 ### Connecting to Airtable

--- a/docs/catalog/auth0.md
+++ b/docs/catalog/auth0.md
@@ -40,15 +40,12 @@ create foreign data wrapper auth0_wrapper
 By default, Postgres stores FDW credentials inside `pg_catalog.pg_foreign_server` in plain text. Anyone with access to this table will be able to view these credentials. Wrappers is designed to work with [Vault](https://supabase.com/docs/guides/database/vault), which provides an additional level of security for storing credentials. We recommend using Vault to store your credentials.
 
 ```sql
--- Save your Auth0 API key in Vault
+-- Save your Auth0 API key in Vault and retrieve the created `key_id`
 select vault.create_secret(
   '<Auth0 API Key or PAT>', -- Auth0 API key or Personal Access Token (PAT)
   'auth0',
   'Auth0 API key for Wrappers'
 );
-
--- Retrieve the `key_id`
-select key_id from vault.decrypted_secrets where name = 'auth0';
 ```
 
 ### Connecting to Auth0

--- a/docs/catalog/bigquery.md
+++ b/docs/catalog/bigquery.md
@@ -40,7 +40,7 @@ create foreign data wrapper bigquery_wrapper
 By default, Postgres stores FDW credentials inside `pg_catalog.pg_foreign_server` in plain text. Anyone with access to this table will be able to view these credentials. Wrappers is designed to work with [Vault](https://supabase.com/docs/guides/database/vault), which provides an additional level of security for storing credentials. We recommend using Vault to store your credentials.
 
 ```sql
--- Save your BigQuery service account json in Vault
+-- Save your BigQuery service account json in Vault and retrieve the created `key_id`
 select vault.create_secret(
   '
     {
@@ -54,9 +54,6 @@ select vault.create_secret(
   'bigquery',
   'BigQuery service account json for Wrappers'
 );
-
--- Retrieve the `key_id`
-select key_id from vault.decrypted_secrets where name = 'bigquery';
 ```
 
 ### Connecting to BigQuery

--- a/docs/catalog/cal.md
+++ b/docs/catalog/cal.md
@@ -46,15 +46,12 @@ create foreign data wrapper wasm_wrapper
 By default, Postgres stores FDW credentials inside `pg_catalog.pg_foreign_server` in plain text. Anyone with access to this table will be able to view these credentials. Wrappers is designed to work with [Vault](https://supabase.com/docs/guides/database/vault), which provides an additional level of security for storing credentials. We recommend using Vault to store your credentials.
 
 ```sql
--- Save your Cal.com API key in Vault
+-- Save your Cal.com API key in Vault and retrieve the created `key_id`
 select vault.create_secret(
   '<Cal.com API key>', -- Cal.com API key
   'cal',
   'Cal.com API key for Wrappers'
 );
-
--- Retrieve the `key_id`
-select key_id from vault.decrypted_secrets where name = 'cal';
 ```
 
 ### Connecting to Cal.com

--- a/docs/catalog/calendly.md
+++ b/docs/catalog/calendly.md
@@ -46,15 +46,12 @@ create foreign data wrapper wasm_wrapper
 By default, Postgres stores FDW credentials inside `pg_catalog.pg_foreign_server` in plain text. Anyone with access to this table will be able to view these credentials. Wrappers is designed to work with [Vault](https://supabase.com/docs/guides/database/vault), which provides an additional level of security for storing credentials. We recommend using Vault to store your credentials.
 
 ```sql
--- Save your Calendly API key in Vault
+-- Save your Calendly API key in Vault and retrieve the created `key_id`
 select vault.create_secret(
   '<Calendly API key>', -- Calendly personal access token
   'calendly',
   'Calendly API key for Wrappers'
 );
-
--- Retrieve the `key_id`
-select key_id from vault.decrypted_secrets where name = 'calendly';
 ```
 
 ### Connecting to Calendly

--- a/docs/catalog/cfd1.md
+++ b/docs/catalog/cfd1.md
@@ -46,15 +46,12 @@ create foreign data wrapper wasm_wrapper
 By default, Postgres stores FDW credentials inside `pg_catalog.pg_foreign_server` in plain text. Anyone with access to this table will be able to view these credentials. Wrappers is designed to work with [Vault](https://supabase.com/docs/guides/database/vault), which provides an additional level of security for storing credentials. We recommend using Vault to store your credentials.
 
 ```sql
--- Save your D1 API token in Vault
+-- Save your D1 API token in Vault and retrieve the created `key_id`
 select vault.create_secret(
   '<D1 API token>', -- Cloudflare D1 API token
   'cfd1',
   'Cloudflare D1 API key for Wrappers'
 );
-
--- Retrieve the `key_id`
-select key_id from vault.decrypted_secrets where name = 'cfd1';
 ```
 
 ### Connecting to D1

--- a/docs/catalog/clerk.md
+++ b/docs/catalog/clerk.md
@@ -46,15 +46,12 @@ create foreign data wrapper wasm_wrapper
 By default, Postgres stores FDW credentials inside `pg_catalog.pg_foreign_server` in plain text. Anyone with access to this table will be able to view these credentials. Wrappers is designed to work with [Vault](https://supabase.com/docs/guides/database/vault), which provides an additional level of security for storing credentials. We recommend using Vault to store your credentials.
 
 ```sql
--- Save your Clerk API key in Vault
+-- Save your Clerk API key in Vault and retrieve the created `key_id`
 select vault.create_secret(
   '<Clerk API key>', -- Clerk API key
   'clerk',
   'Clerk API key for Wrappers'
 );
-
--- Retrieve the `key_id`
-select key_id from vault.decrypted_secrets where name = 'clerk';
 ```
 
 ### Connecting to Clerk

--- a/docs/catalog/clickhouse.md
+++ b/docs/catalog/clickhouse.md
@@ -40,15 +40,12 @@ create foreign data wrapper clickhouse_wrapper
 By default, Postgres stores FDW credentials inside `pg_catalog.pg_foreign_server` in plain text. Anyone with access to this table will be able to view these credentials. Wrappers is designed to work with [Vault](https://supabase.com/docs/guides/database/vault), which provides an additional level of security for storing credentials. We recommend using Vault to store your credentials.
 
 ```sql
--- Save your ClickHouse credential in Vault
+-- Save your ClickHouse credential in Vault and retrieve the created `key_id`
 select vault.create_secret(
   'tcp://default:@localhost:9000/default',
   'clickhouse',
   'ClickHouse credential for Wrappers'
 );
-
--- Retrieve the `key_id`
-select key_id from vault.decrypted_secrets where name = 'clickhouse';
 ```
 
 ### Connecting to ClickHouse

--- a/docs/catalog/cognito.md
+++ b/docs/catalog/cognito.md
@@ -40,15 +40,12 @@ create foreign data wrapper cognito_wrapper
 By default, Postgres stores FDW credentials inside `pg_catalog.pg_foreign_server` in plain text. Anyone with access to this table will be able to view these credentials. Wrappers are designed to work with [Vault](https://supabase.com/docs/guides/database/vault), which provides an additional level of security for storing credentials. We recommend using Vault to store your credentials.
 
 ```sql
--- Save your Cognito secret access key in Vault
+-- Save your Cognito secret access key in Vault and retrieve the created `key_id`
 select vault.create_secret(
   '<secret access key>',
   'cognito',
   'Cognito secret key for Wrappers'
 );
-
--- Retrieve the `key_id`
-select key_id from vault.decrypted_secrets where name = 'cognito';
 ```
 
 ### Connecting to Cognito

--- a/docs/catalog/firebase.md
+++ b/docs/catalog/firebase.md
@@ -41,7 +41,7 @@ create foreign data wrapper firebase_wrapper
 By default, Postgres stores FDW credentials inside `pg_catalog.pg_foreign_server` in plain text. Anyone with access to this table will be able to view these credentials. Wrappers is designed to work with [Vault](https://supabase.com/docs/guides/database/vault), which provides an additional level of security for storing credentials. We recommend using Vault to store your credentials.
 
 ```sql
--- Save your Firebase credentials in Vault
+-- Save your Firebase credentials in Vault and retrieve the created `key_id`
 select vault.create_secret(
   '{
       "type": "service_account",
@@ -51,9 +51,6 @@ select vault.create_secret(
   'firebase',
   'Firebase API key for Wrappers'
 );
-
--- Retrieve the `key_id`
-select key_id from vault.decrypted_secrets where name = 'firebase';
 ```
 
 ### Connecting to Firebase

--- a/docs/catalog/hubspot.md
+++ b/docs/catalog/hubspot.md
@@ -46,15 +46,12 @@ create foreign data wrapper wasm_wrapper
 By default, Postgres stores FDW credentials inside `pg_catalog.pg_foreign_server` in plain text. Anyone with access to this table will be able to view these credentials. Wrappers is designed to work with [Vault](https://supabase.com/docs/guides/database/vault), which provides an additional level of security for storing credentials. We recommend using Vault to store your credentials.
 
 ```sql
--- Save your HubSpot private apps access token in Vault
+-- Save your HubSpot private apps access token in Vault and retrieve the created `key_id`
 select vault.create_secret(
   '<HubSpot access token>', -- HubSpot private apps access token
   'hubspot',
   'HubSpot private apps access token for Wrappers'
 );
-
--- Retrieve the `key_id`
-select key_id from vault.decrypted_secrets where name = 'hubspot';
 ```
 
 ### Connecting to HubSpot

--- a/docs/catalog/logflare.md
+++ b/docs/catalog/logflare.md
@@ -40,15 +40,12 @@ create foreign data wrapper logflare_wrapper
 By default, Postgres stores FDW credentials inside `pg_catalog.pg_foreign_server` in plain text. Anyone with access to this table will be able to view these credentials. Wrappers is designed to work with [Vault](https://supabase.com/docs/guides/database/vault), which provides an additional level of security for storing credentials. We recommend using Vault to store your credentials.
 
 ```sql
--- Save your Logflare API key in Vault
+-- Save your Logflare API key in Vault and retrieve the created `key_id`
 select vault.create_secret(
   '<YOUR_SECRET>',
   'logflare',
   'Logflare API key for Wrappers'
 );
-
--- Retrieve the `key_id`
-select key_id from vault.decrypted_secrets where name = 'logflare';
 ```
 
 ### Connecting to Logflare

--- a/docs/catalog/mssql.md
+++ b/docs/catalog/mssql.md
@@ -40,15 +40,12 @@ create foreign data wrapper mssql_wrapper
 By default, Postgres stores FDW credentials inside `pg_catalog.pg_foreign_server` in plain text. Anyone with access to this table will be able to view these credentials. Wrappers is designed to work with [Vault](https://supabase.com/docs/guides/database/vault), which provides an additional level of security for storing credentials. We recommend using Vault to store your credentials.
 
 ```sql
--- Save your SQL Server connection string in Vault
+-- Save your SQL Server connection string in Vault and retrieve the created `key_id`
 select vault.create_secret(
   'Server=localhost,1433;User=sa;Password=my_password;Database=master;IntegratedSecurity=false;TrustServerCertificate=true;encrypt=DANGER_PLAINTEXT;ApplicationName=wrappers',
   'mssql',
   'MS SQL Server connection string for Wrappers'
 );
-
--- Retrieve the `key_id`
-select key_id from vault.decrypted_secrets where name = 'mssql';
 ```
 
 The connection string is an [ADO.NET connection string](https://learn.microsoft.com/en-us/dotnet/framework/data/adonet/connection-strings), which specifies connection parameters in semicolon-delimited string.

--- a/docs/catalog/notion.md
+++ b/docs/catalog/notion.md
@@ -47,15 +47,12 @@ create foreign data wrapper wasm_wrapper
 By default, Postgres stores FDW credentials inside `pg_catalog.pg_foreign_server` in plain text. Anyone with access to this table will be able to view these credentials. Wrappers is designed to work with [Vault](https://supabase.com/docs/guides/database/vault), which provides an additional level of security for storing credentials. We recommend using Vault to store your credentials.
 
 ```sql
--- Save your Notion API key in Vault
+-- Save your Notion API key in Vault and retrieve the created `key_id`
 select vault.create_secret(
   '<Notion API key>', -- Notion API key, should look like ntn_589513........
   'notion',
   'Notion API key for Wrappers'
 );
-
--- Retrieve the `key_id`
-select key_id from vault.decrypted_secrets where name = 'notion';
 ```
 
 > ⚠️ ** Getting a Notion API key**

--- a/docs/catalog/orb.md
+++ b/docs/catalog/orb.md
@@ -46,15 +46,12 @@ create foreign data wrapper wasm_wrapper
 By default, Postgres stores FDW credentials inside `pg_catalog.pg_foreign_server` in plain text. Anyone with access to this table will be able to view these credentials. Wrappers is designed to work with [Vault](https://supabase.com/docs/guides/database/vault), which provides an additional level of security for storing credentials. We recommend using Vault to store your credentials.
 
 ```sql
--- Save your Orb API key in Vault
+-- Save your Orb API key in Vault and retrieve the created `key_id`
 select vault.create_secret(
   '<Orb API key>', -- Orb API key
   'orb',
   'Orb API key for Wrappers'
 );
-
--- Retrieve the `key_id`
-select key_id from vault.decrypted_secrets where name = 'orb';
 ```
 
 ### Connecting to Orb

--- a/docs/catalog/paddle.md
+++ b/docs/catalog/paddle.md
@@ -47,15 +47,12 @@ create foreign data wrapper wasm_wrapper
 By default, Postgres stores FDW credentials inside `pg_catalog.pg_foreign_server` in plain text. Anyone with access to this table will be able to view these credentials. Wrappers is designed to work with [Vault](https://supabase.com/docs/guides/database/vault), which provides an additional level of security for storing credentials. We recommend using Vault to store your credentials.
 
 ```sql
--- Save your Paddle API key in Vault
+-- Save your Paddle API key in Vault and retrieve the created `key_id`
 select vault.create_secret(
   '<Paddle API key>', -- Paddle API key
   'paddle',
   'Paddle API key for Wrappers'
 );
-
--- Retrieve the `key_id`
-select key_id from vault.decrypted_secrets where name = 'paddle';
 ```
 
 ### Connecting to Paddle

--- a/docs/catalog/redis.md
+++ b/docs/catalog/redis.md
@@ -40,15 +40,12 @@ create foreign data wrapper redis_wrapper
 By default, Postgres stores FDW credentials inside `pg_catalog.pg_foreign_server` in plain text. Anyone with access to this table will be able to view these credentials. Wrappers is designed to work with [Vault](https://supabase.com/docs/guides/database/vault), which provides an additional level of security for storing credentials. We recommend using Vault to store your credentials.
 
 ```sql
--- Save your Redis connection URL in Vault
+-- Save your Redis connection URL in Vault and retrieve the created `key_id`
 select vault.create_secret(
   'redis://username:password@127.0.0.1:6379/db',
   'redis',
   'Redis connection URL for Wrappers'
 );
-
--- Retrieve the `key_id`
-select key_id from vault.decrypted_secrets where name = 'redis';
 ```
 
 ### Connecting to Redis

--- a/docs/catalog/s3.md
+++ b/docs/catalog/s3.md
@@ -55,7 +55,7 @@ create foreign data wrapper s3_wrapper
 By default, Postgres stores FDW credentials inside `pg_catalog.pg_foreign_server` in plain text. Anyone with access to this table will be able to view these credentials. Wrappers is designed to work with [Vault](https://supabase.com/docs/guides/database/vault), which provides an additional level of security for storing credentials. We recommend using Vault to store your credentials.
 
 ```sql
--- Save your AWS credentials in Vault
+-- Save your AWS credentials in Vault and retrieve the created `s3_access_key_id` and `s3_secret_access_key`
 select vault.create_secret(
   '<access key id>',
   's3_access_key_id',
@@ -66,10 +66,6 @@ select vault.create_secret(
   's3_secret_access_key',
   'AWS secret access key for Wrappers'
 );
-
--- Retrieve the `key_id`
-select key_id from vault.decrypted_secrets where name = 's3_access_key_id';
-select key_id from vault.decrypted_secrets where name = 's3_secret_access_key';
 ```
 
 ### Connecting to S3

--- a/docs/catalog/snowflake.md
+++ b/docs/catalog/snowflake.md
@@ -49,15 +49,12 @@ By default, Postgres stores FDW credentials inside `pg_catalog.pg_foreign_server
 This FDW uses key-pair authentication to access Snowflake SQL Rest API, please refer to [Snowflake docs](https://docs.snowflake.com/en/developer-guide/sql-api/authenticating#label-sql-api-authenticating-key-pair) for more details about the key-pair authentication.
 
 ```sql
--- Save your Snowflake private key in Vault
+-- Save your Snowflake private key in Vault and retrieve the created `key_id`
 select vault.create_secret(
   E'-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----',
   'snowflake',
   'Snowflake private key for Wrappers'
 );
-
--- Retrieve the `key_id`
-select key_id from vault.decrypted_secrets where name = 'snowflake';
 ```
 
 ### Connecting to Snowflake

--- a/docs/catalog/stripe.md
+++ b/docs/catalog/stripe.md
@@ -40,15 +40,12 @@ create foreign data wrapper stripe_wrapper
 By default, Postgres stores FDW credentials inside `pg_catalog.pg_foreign_server` in plain text. Anyone with access to this table will be able to view these credentials. Wrappers is designed to work with [Vault](https://supabase.com/docs/guides/database/vault), which provides an additional level of security for storing credentials. We recommend using Vault to store your credentials.
 
 ```sql
--- Save your Stripe API key in Vault
+-- Save your Stripe API key in Vault and retrieve the created `key_id`
 select vault.create_secret(
   '<Stripe API key>',
   'stripe',
   'Stripe API key for Wrappers'
 );
-
--- Retrieve the `key_id`
-select key_id from vault.decrypted_secrets where name = 'stripe';
 ```
 
 ### Connecting to Stripe


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to update docs to reflect the latest recommended way of secret creation in Vault. 

## What is the current behavior?

We were using `secret.key_id` to retrieve decrypted text from Vault.

## What is the new behavior?

We are using `secret.id` to retrieve decrypted text from Vault and fallback to use `secret.key_id`, so the docs need to be updated to reflect this change.

## Additional context

N/A
