### PR TITLE
docs(redis): add SSL/TLS support docs to Redis FDW [DATAENG-919]

### DIFF
--- a/docs/catalog/redis.md
+++ b/docs/catalog/redis.md
@@ -48,6 +48,14 @@ select vault.create_secret(
 );
 ```
 
+!!! note
+
+    To connect to Redis over SSL/TLS, you can use `rediss://` protocol. For example,
+
+    ```
+    rediss://username:password@my-redis-12345.upstash.io:6379/#insecure
+    ```
+
 ### Connecting to Redis
 
 We need to provide Postgres with the credentials to connect to Redis. We can do this using the `create server` command:


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to add SSL/TLS support docs to Redis FDW.

## What is the current behavior?

Currently there is no docs for Redis SSL/TLS connection, although the Redis FDW supports it.

## What is the new behavior?

Added SSL/TLS connection docs.

## Additional context

N/A
