### PR TITLE
ci(docs): deploy docs on tag push

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,10 +2,8 @@ name: Deploy docs
 
 on:
   push:
-    branches:
-      - main
-    paths:
-      - "docs/catalog/**"
+    tags:
+      - docs_v*
 
 permissions: {}
 


### PR DESCRIPTION
Deploy docs on push of tag `docs_v*` rather than on push to main. This will prevent docs from redeploying for unpublished changes.