### PR TITLE
feat(clickhouse): add UUID data type support

### DIFF
--- a/docs/catalog/clickhouse.md
+++ b/docs/catalog/clickhouse.md
@@ -176,6 +176,7 @@ This FDW supports `where`, `order by` and `limit` clause pushdown, as well as pa
 | text             | String            |
 | date             | Date              |
 | timestamp        | DateTime          |
+| uuid             | UUID              |
 | *                | Nullable&lt;T&gt; |
 
 ## Limitations

--- a/wrappers/Cargo.toml
+++ b/wrappers/Cargo.toml
@@ -34,7 +34,15 @@ bigquery_fdw = [
     "yup-oauth2",
     "thiserror",
 ]
-clickhouse_fdw = ["clickhouse-rs", "chrono", "chrono-tz", "regex", "thiserror", "either"]
+clickhouse_fdw = [
+    "clickhouse-rs",
+    "chrono",
+    "chrono-tz",
+    "regex",
+    "thiserror",
+    "either",
+    "uuid",
+]
 stripe_fdw = [
     "http",
     "reqwest",

--- a/wrappers/src/fdw/clickhouse_fdw/README.md
+++ b/wrappers/src/fdw/clickhouse_fdw/README.md
@@ -11,6 +11,7 @@ This is a foreign data wrapper for [ClickHouse](https://clickhouse.com/). It is 
 
 | Version | Date       | Notes                                                |
 | ------- | ---------- | ---------------------------------------------------- |
+| 0.1.6   | 2025-05-06 | Added UUID data type support                         |
 | 0.1.5   | 2024-09-30 | Support for pgrx 0.12.6                              |
 | 0.1.4   | 2024-09-10 | Added Nullable type suppport                         |
 | 0.1.3   | 2023-07-17 | Added sort and limit pushdown suppport               |

--- a/wrappers/src/fdw/clickhouse_fdw/mod.rs
+++ b/wrappers/src/fdw/clickhouse_fdw/mod.rs
@@ -26,6 +26,9 @@ enum ClickHouseFdwError {
     #[error("datetime parse error: {0}")]
     DatetimeParseError(#[from] chrono::format::ParseError),
 
+    #[error("uuid parse error: {0}")]
+    UuidParseError(#[from] uuid::Error),
+
     #[error("{0}")]
     OptionsError(#[from] OptionsError),
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to add `UUID` data type support for Clickhouse FDW.

## What is the current behavior?

The `UUID` data type is not supported in Clickhouse FDW.

## What is the new behavior?

The `UUID` and `Nullable(UUID)` data type are supported in Clickhouse FDW.

## Additional context

- This PR also did some minor improvements on `date` and `timestamp` type conversion
- Added test cases for more data types, including UUID data type
