### PR TITLE
chore: bump Wrappers version to 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6631,7 +6631,7 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "supabase-wrappers"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "pgrx",
  "pgrx-tests",
@@ -8496,7 +8496,7 @@ dependencies = [
 
 [[package]]
 name = "wrappers"
-version = "0.4.6"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "arrow-array",

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@
 | [Cloudflare D1](./wasm-wrappers/fdw/cfd1_fdw)   | A Wasm FDW for [Cloudflare D1](https://developers.cloudflare.com/d1/)         | ✅   | ✅     |
 | [Orb](./wasm-wrappers/fdw/orb_fdw)              | A Wasm FDW for [Orb](https://www.withorb.com/)                                | ✅   | ❌     |
 | [HubSpot](./wasm-wrappers/fdw/hubspot_fdw)      | A Wasm FDW for [HubSpot](https://www.hubspot.com/)                            | ✅   | ❌     |
+| [Slack](./wasm-wrappers/fdw/slack_fdw)          | A Wasm FDW for [Slack](https://www.slack.com/)                                | ✅   | ❌     |
 
 ### Warning
 

--- a/supabase-wrappers/Cargo.toml
+++ b/supabase-wrappers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "supabase-wrappers"
-version = "0.1.21"
+version = "0.1.22"
 edition = "2021"
 authors = ["Supabase Inc. https://supabase.com/"]
 license = "Apache-2.0"

--- a/wasm-wrappers/fdw/cal_fdw/src/lib.rs
+++ b/wasm-wrappers/fdw/cal_fdw/src/lib.rs
@@ -191,7 +191,7 @@ impl CalFdw {
 impl Guest for CalFdw {
     fn host_version_requirement() -> String {
         // semver ref: https://docs.rs/semver/latest/semver/enum.Op.html
-        "^0.2.0".to_string()
+        "^0.1.0".to_string()
     }
 
     fn init(ctx: &Context) -> FdwResult {

--- a/wasm-wrappers/fdw/calendly_fdw/src/lib.rs
+++ b/wasm-wrappers/fdw/calendly_fdw/src/lib.rs
@@ -190,7 +190,7 @@ impl CalendlyFdw {
 impl Guest for CalendlyFdw {
     fn host_version_requirement() -> String {
         // semver ref: https://docs.rs/semver/latest/semver/enum.Op.html
-        "^0.2.0".to_string()
+        "^0.1.0".to_string()
     }
 
     fn init(ctx: &Context) -> FdwResult {

--- a/wasm-wrappers/fdw/cfd1_fdw/src/lib.rs
+++ b/wasm-wrappers/fdw/cfd1_fdw/src/lib.rs
@@ -284,7 +284,7 @@ impl Cfd1Fdw {
 impl Guest for Cfd1Fdw {
     fn host_version_requirement() -> String {
         // semver ref: https://docs.rs/semver/latest/semver/enum.Op.html
-        "^0.2.0".to_string()
+        "^0.1.0".to_string()
     }
 
     fn init(ctx: &Context) -> FdwResult {

--- a/wasm-wrappers/fdw/clerk_fdw/src/lib.rs
+++ b/wasm-wrappers/fdw/clerk_fdw/src/lib.rs
@@ -172,7 +172,7 @@ impl ClerkFdw {
 impl Guest for ClerkFdw {
     fn host_version_requirement() -> String {
         // semver ref: https://docs.rs/semver/latest/semver/enum.Op.html
-        "^0.2.0".to_string()
+        "^0.1.0".to_string()
     }
 
     fn init(ctx: &Context) -> FdwResult {

--- a/wasm-wrappers/fdw/helloworld_fdw/src/lib.rs
+++ b/wasm-wrappers/fdw/helloworld_fdw/src/lib.rs
@@ -30,7 +30,7 @@ impl HelloWorldFdw {
 impl Guest for HelloWorldFdw {
     fn host_version_requirement() -> String {
         // semver ref: https://docs.rs/semver/latest/semver/enum.Op.html
-        "^0.2.0".to_string()
+        "^0.1.0".to_string()
     }
 
     fn init(_ctx: &Context) -> FdwResult {

--- a/wasm-wrappers/fdw/hubspot_fdw/src/lib.rs
+++ b/wasm-wrappers/fdw/hubspot_fdw/src/lib.rs
@@ -212,7 +212,7 @@ impl HubspotFdw {
 impl Guest for HubspotFdw {
     fn host_version_requirement() -> String {
         // semver ref: https://docs.rs/semver/latest/semver/enum.Op.html
-        "^0.2.0".to_string()
+        "^0.1.0".to_string()
     }
 
     fn init(ctx: &Context) -> FdwResult {

--- a/wasm-wrappers/fdw/notion_fdw/src/lib.rs
+++ b/wasm-wrappers/fdw/notion_fdw/src/lib.rs
@@ -399,7 +399,7 @@ impl NotionFdw {
 impl Guest for NotionFdw {
     fn host_version_requirement() -> String {
         // semver ref: https://docs.rs/semver/latest/semver/enum.Op.html
-        "^0.2.0".to_string()
+        "^0.1.0".to_string()
     }
 
     fn init(ctx: &Context) -> FdwResult {

--- a/wasm-wrappers/fdw/orb_fdw/src/lib.rs
+++ b/wasm-wrappers/fdw/orb_fdw/src/lib.rs
@@ -401,7 +401,7 @@ impl OrbFdw {
 impl Guest for OrbFdw {
     fn host_version_requirement() -> String {
         // semver ref: https://docs.rs/semver/latest/semver/enum.Op.html
-        "^0.2.0".to_string()
+        "^0.1.0".to_string()
     }
 
     fn init(ctx: &Context) -> FdwResult {

--- a/wasm-wrappers/fdw/paddle_fdw/src/lib.rs
+++ b/wasm-wrappers/fdw/paddle_fdw/src/lib.rs
@@ -236,7 +236,7 @@ impl PaddleFdw {
 impl Guest for PaddleFdw {
     fn host_version_requirement() -> String {
         // semver ref: https://docs.rs/semver/latest/semver/enum.Op.html
-        "^0.2.0".to_string()
+        "^0.1.0".to_string()
     }
 
     fn init(ctx: &Context) -> FdwResult {

--- a/wasm-wrappers/fdw/slack_fdw/src/lib.rs
+++ b/wasm-wrappers/fdw/slack_fdw/src/lib.rs
@@ -1084,7 +1084,7 @@ impl SlackFdw {
 impl Guest for SlackFdw {
     fn host_version_requirement() -> String {
         // semver ref: https://docs.rs/semver/latest/semver/enum.Op.html
-        "^0.2.0".to_string()
+        "^0.1.0".to_string()
     }
 
     fn init(ctx: &Context) -> FdwResult {

--- a/wasm-wrappers/fdw/snowflake_fdw/src/lib.rs
+++ b/wasm-wrappers/fdw/snowflake_fdw/src/lib.rs
@@ -272,7 +272,7 @@ impl SnowflakeFdw {
 impl Guest for SnowflakeFdw {
     fn host_version_requirement() -> String {
         // semver ref: https://docs.rs/semver/latest/semver/enum.Op.html
-        "^0.2.0".to_string()
+        "^0.1.0".to_string()
     }
 
     fn init(ctx: &Context) -> FdwResult {

--- a/wrappers/Cargo.toml
+++ b/wrappers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wrappers"
-version = "0.4.6"
+version = "0.5.0"
 edition = "2021"
 publish = false
 

--- a/wrappers/src/fdw/wasm_fdw/README.md
+++ b/wrappers/src/fdw/wasm_fdw/README.md
@@ -6,7 +6,7 @@ This is Wasm foreign data wrapper host, please visit each Wasm foreign data wrap
 
 | Version | Date       | Notes                                                |
 | ------- | ---------- | ---------------------------------------------------- |
-| 0.2.0   | 2025-04-30 | Add 'import foreign schema' support                  |
+| 0.1.5   | 2025-04-30 | Add 'import foreign schema' support                  |
 | 0.1.4   | 2024-12-09 | Improve remote wasm downloading and caching          |
 | 0.1.3   | 2024-09-30 | Support for pgrx 0.12.6                              |
 | 0.1.2   | 2024-07-07 | Add fdw_package_checksum server option               |

--- a/wrappers/src/fdw/wasm_fdw/wasm_fdw.rs
+++ b/wrappers/src/fdw/wasm_fdw/wasm_fdw.rs
@@ -210,7 +210,7 @@ fn save_to_cache(path: &Path, bytes: &[u8]) -> WasmFdwResult<()> {
 }
 
 #[wrappers_fdw(
-    version = "0.2.0",
+    version = "0.1.5",
     author = "Supabase",
     website = "https://github.com/supabase/wrappers/tree/main/wrappers/src/fdw/wasm_fdw",
     error_type = "WasmFdwError"


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to bump versions:

wrappers version: 0.4.6 -> 0.5.0
supabase-wrappers version: 0.1.21 -> 0.1.22
all Wasm wrappers version: 0.1.* -> 0.2.0

## What is the current behavior?

N/A

## What is the new behavior?

N/A

## Additional context

- Wasm FDW host version is adjusted to `0.1.5` for back compatibility, thus Wasm FDW guests are all adjusted to `~0.1.0` for their host version requirement.
