### PR TITLE
fix: [DATAENG-969] make wrappers extension relocatable

### DIFF
--- a/wrappers/wrappers.control
+++ b/wrappers/wrappers.control
@@ -2,5 +2,5 @@ comment = 'Foreign data wrappers developed by Supabase'
 default_version = '@CARGO_VERSION@'
 # commenting-out module_pathname results in this extension being built/run/tested in "versioned shared-object mode"
 #module_pathname = '$libdir/wrappers'
-relocatable = false
+relocatable = true
 superuser = false


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to make `wrappers` extension relocatable. 

## What is the current behavior?

The `wrappers` extension is not relocatable, e.g. `relocatable = false` in .control file.

## What is the new behavior?

The `wrappers` extension is relocatable, e.g. `relocatable = true` in .control file.

## Additional context

N/A
