### PR TITLE
docs(auth0): add missing `url` server option

### DIFF
--- a/docs/catalog/auth0.md
+++ b/docs/catalog/auth0.md
@@ -58,6 +58,7 @@ We need to provide Postgres with the credentials to connect to Auth0, and any ad
     create server auth0_server
       foreign data wrapper auth0_wrapper
       options (
+        url 'https://dev-<tenant-id>.us.auth0.com/api/v2/users',
         api_key_id '<key_ID>' -- The Key ID from above.
       );
     ```


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to add the missing `url` server option in Auth0 FDW docs.

## What is the current behavior?

N/A

## What is the new behavior?

N/A

## Additional context

N/A
