### PR TITLE
chore: bump Wrappers version to `0.5.1`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3590,8 +3590,8 @@ dependencies = [
 
 [[package]]
 name = "iceberg"
-version = "0.4.0"
-source = "git+https://github.com/burmecia/iceberg-rust?branch=main#a1eaf8669c818da89ce9d7fa2bccdf162767ae74"
+version = "0.5.0"
+source = "git+https://github.com/apache/iceberg-rust?rev=12485be4a30848213faea62740ad7cb5a41bd6f2#12485be4a30848213faea62740ad7cb5a41bd6f2"
 dependencies = [
  "anyhow",
  "apache-avro",
@@ -3640,8 +3640,8 @@ dependencies = [
 
 [[package]]
 name = "iceberg-catalog-rest"
-version = "0.4.0"
-source = "git+https://github.com/burmecia/iceberg-rust?branch=main#a1eaf8669c818da89ce9d7fa2bccdf162767ae74"
+version = "0.5.0"
+source = "git+https://github.com/apache/iceberg-rust?rev=12485be4a30848213faea62740ad7cb5a41bd6f2#12485be4a30848213faea62740ad7cb5a41bd6f2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3660,8 +3660,8 @@ dependencies = [
 
 [[package]]
 name = "iceberg-catalog-s3tables"
-version = "0.4.0"
-source = "git+https://github.com/burmecia/iceberg-rust?branch=main#a1eaf8669c818da89ce9d7fa2bccdf162767ae74"
+version = "0.5.0"
+source = "git+https://github.com/apache/iceberg-rust?rev=12485be4a30848213faea62740ad7cb5a41bd6f2#12485be4a30848213faea62740ad7cb5a41bd6f2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7266,7 +7266,7 @@ dependencies = [
 
 [[package]]
 name = "supabase-wrappers-macros"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9428,7 +9428,7 @@ dependencies = [
 
 [[package]]
 name = "wrappers"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "arrow-array",

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 | [Orb](./wasm-wrappers/fdw/orb_fdw)              | A Wasm FDW for [Orb](https://www.withorb.com/)                                | ✅   | ❌     |
 | [HubSpot](./wasm-wrappers/fdw/hubspot_fdw)      | A Wasm FDW for [HubSpot](https://www.hubspot.com/)                            | ✅   | ❌     |
 | [Slack](./wasm-wrappers/fdw/slack_fdw)          | A Wasm FDW for [Slack](https://www.slack.com/)                                | ✅   | ❌     |
-| [Apache Iceberg](./wrappers/fdw/iceberg_fdw)    | A FDW for [Apache Iceberg](https://iceberg.apache.org/)                       | ✅   | ❌     |
+| [Apache Iceberg](./wrappers/src/fdw/iceberg_fdw)| A FDW for [Apache Iceberg](https://iceberg.apache.org/)                       | ✅   | ❌     |
 
 ### Warning
 

--- a/docs/catalog/cal.md
+++ b/docs/catalog/cal.md
@@ -17,7 +17,7 @@ The Cal Wrapper is a WebAssembly(Wasm) foreign data wrapper which allows you to 
 
 | Version | Wasm Package URL                                                                                | Checksum                                                           | Required Wrappers Version |
 | ------- | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ | ------------------------- |
-| 0.2.0   | `https://github.com/supabase/wrappers/releases/download/wasm_cal_fdw_v0.2.0/cal_fdw.wasm`       | `tbd`                                                              | >=0.5.0                   |
+| 0.2.0   | `https://github.com/supabase/wrappers/releases/download/wasm_cal_fdw_v0.2.0/cal_fdw.wasm`       | `c9d14036b370758ce75871d69e9c842bc922703d02323b73397995f4cf14491b` | >=0.5.0                   |
 | 0.1.0   | `https://github.com/supabase/wrappers/releases/download/wasm_cal_fdw_v0.1.0/cal_fdw.wasm`       | `4afe4fac8c51f2caa1de8483b3817d2cec3a14cd8a65a3942c8b4ff6c430f08a` | >=0.4.0                   |
 
 ## Preparation

--- a/docs/catalog/calendly.md
+++ b/docs/catalog/calendly.md
@@ -17,7 +17,7 @@ The Calendly Wrapper is a WebAssembly(Wasm) foreign data wrapper which allows yo
 
 | Version | Wasm Package URL                                                                                    | Checksum                                                           | Required Wrappers Version |
 | ------- | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ | ------------------------- |
-| 0.2.0   | `https://github.com/supabase/wrappers/releases/download/wasm_calendly_fdw_v0.2.0/calendly_fdw.wasm` | `tbd`                                                              | >=0.5.0                   |
+| 0.2.0   | `https://github.com/supabase/wrappers/releases/download/wasm_calendly_fdw_v0.2.0/calendly_fdw.wasm` | `1d18021cc3618440107b0d37f0a811607fdc863d9841a5da1ff9d56bc9f44df1` | >=0.5.0                   |
 | 0.1.0   | `https://github.com/supabase/wrappers/releases/download/wasm_calendly_fdw_v0.1.0/calendly_fdw.wasm` | `51a19fa4b8c40afb5dcf6dc2e009189aceeba65f30eec75d56a951d78fc8893f` | >=0.4.0                   |
 
 ## Preparation

--- a/docs/catalog/cfd1.md
+++ b/docs/catalog/cfd1.md
@@ -17,7 +17,7 @@ The Cloudflare D1 Wrapper is a WebAssembly(Wasm) foreign data wrapper which allo
 
 | Version | Wasm Package URL                                                                                    | Checksum                                                           | Required Wrappers Version |
 | ------- | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ | ------------------------- |
-| 0.2.0   | `https://github.com/supabase/wrappers/releases/download/wasm_cfd1_fdw_v0.2.0/cfd1_fdw.wasm`         | `tbd`                                                              | >=0.5.0                   |
+| 0.2.0   | `https://github.com/supabase/wrappers/releases/download/wasm_cfd1_fdw_v0.2.0/cfd1_fdw.wasm`         | `0f1d022d9733b5dd0c39d65f35ffcfd86102e7ee53e72d8cf94749500c224c0d` | >=0.5.0                   |
 | 0.1.0   | `https://github.com/supabase/wrappers/releases/download/wasm_cfd1_fdw_v0.1.0/cfd1_fdw.wasm`         | `783232834bb29dbd3ee6b09618c16f8a847286e63d05c54397d56c3e703fad31` | >=0.4.0                   |
 
 ## Preparation

--- a/docs/catalog/clerk.md
+++ b/docs/catalog/clerk.md
@@ -17,7 +17,7 @@ The Clerk Wrapper is a WebAssembly(Wasm) foreign data wrapper which allows you t
 
 | Version | Wasm Package URL                                                                                    | Checksum                                                           | Required Wrappers Version |
 | ------- | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ | ------------------------- |
-| 0.2.0   | `https://github.com/supabase/wrappers/releases/download/wasm_clerk_fdw_v0.2.0/clerk_fdw.wasm`       | `tbd`                                                              | >=0.5.0                   |
+| 0.2.0   | `https://github.com/supabase/wrappers/releases/download/wasm_clerk_fdw_v0.2.0/clerk_fdw.wasm`       | `89337bb11779d4d654cd3e54391aabd02509d213db6995f7dd58951774bf0e37` | >=0.5.0                   |
 | 0.1.0   | `https://github.com/supabase/wrappers/releases/download/wasm_clerk_fdw_v0.1.0/clerk_fdw.wasm`       | `613be26b59fa4c074e0b93f0db617fcd7b468d4d02edece0b1f85fdb683ebdc4` | >=0.4.0                   |
 
 ## Preparation

--- a/docs/catalog/hubspot.md
+++ b/docs/catalog/hubspot.md
@@ -17,7 +17,7 @@ The HubSpot Wrapper is a WebAssembly(Wasm) foreign data wrapper which allows you
 
 | Version | Wasm Package URL                                                                                    | Checksum                                                           | Required Wrappers Version |
 | ------- | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ | ------------------------- |
-| 0.2.0   | `https://github.com/supabase/wrappers/releases/download/wasm_hubspot_fdw_v0.2.0/hubspot_fdw.wasm`   | `tbd`                                                              | >=0.5.0                   |
+| 0.2.0   | `https://github.com/supabase/wrappers/releases/download/wasm_hubspot_fdw_v0.2.0/hubspot_fdw.wasm`   | `223f0e8d7557bd24f51b58fb89dcd3c1431719105acca0754ce35dfd1139296a` | >=0.5.0                   |
 | 0.1.0   | `https://github.com/supabase/wrappers/releases/download/wasm_hubspot_fdw_v0.1.0/hubspot_fdw.wasm`   | `2cbf39e9e28aa732a225db09b2186a2342c44697d4fa047652d358e292ba5521` | >=0.4.0                   |
 
 ## Preparation

--- a/docs/catalog/notion.md
+++ b/docs/catalog/notion.md
@@ -17,7 +17,7 @@ The Notion Wrapper is a WebAssembly(Wasm) foreign data wrapper which allows you 
 
 | Version | Wasm Package URL                                                                                    | Checksum                                                           | Required Wrappers Version |
 | ------- | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ | ------------------------- |
-| 0.2.0   | `https://github.com/supabase/wrappers/releases/download/wasm_notion_fdw_v0.2.0/notion_fdw.wasm`     | `tbd`                                                              | >=0.5.0                   |
+| 0.2.0   | `https://github.com/supabase/wrappers/releases/download/wasm_notion_fdw_v0.2.0/notion_fdw.wasm`     | `719910b65a049f1d9b82dc4f5f1466457582bec855e1e487d5c3cc1e6f986dc6` | >=0.5.0                   |
 | 0.1.1   | `https://github.com/supabase/wrappers/releases/download/wasm_notion_fdw_v0.1.1/notion_fdw.wasm`     | `6dea3014f462aafd0c051c37d163fe326e7650c26a7eb5d8017a30634b5a46de` | >=0.4.0                   |
 | 0.1.0   | `https://github.com/supabase/wrappers/releases/download/wasm_notion_fdw_v0.1.0/notion_fdw.wasm`     | `e017263d1fc3427cc1df8071d1182cdc9e2f00363344dddb8c195c5d398a2099` | >=0.4.0                   |
 

--- a/docs/catalog/orb.md
+++ b/docs/catalog/orb.md
@@ -17,7 +17,7 @@ The Orb Wrapper is a WebAssembly(Wasm) foreign data wrapper which allows you to 
 
 | Version | Wasm Package URL                                                                                    | Checksum                                                           | Required Wrappers Version |
 | ------- | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ | ------------------------- |
-| 0.2.0   | `https://github.com/supabase/wrappers/releases/download/wasm_orb_fdw_v0.2.0/orb_fdw.wasm`           | `tbd`                                                              | >=0.5.0                   |
+| 0.2.0   | `https://github.com/supabase/wrappers/releases/download/wasm_orb_fdw_v0.2.0/orb_fdw.wasm`           | `f9dd3bd2a1ce3d8d7c9e0a4dae8086d5f1118b6099e9513e4e93deb2eb8a2b6c` | >=0.5.0                   |
 | 0.1.0   | `https://github.com/supabase/wrappers/releases/download/wasm_orb_fdw_v0.1.0/orb_fdw.wasm`           | `89153a0a570257c231b78561cc909766731c828324585a5b6e2aa553902cb73a` | >=0.4.0                   |
 
 ## Preparation

--- a/docs/catalog/paddle.md
+++ b/docs/catalog/paddle.md
@@ -17,7 +17,7 @@ The Paddle Wrapper is a WebAssembly(Wasm) foreign data wrapper which allows you 
 
 | Version | Wasm Package URL                                                                                    | Checksum                                                           | Required Wrappers Version |
 | ------- | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ | ------------------------- |
-| 0.2.0   | `https://github.com/supabase/wrappers/releases/download/wasm_paddle_fdw_v0.2.0/paddle_fdw.wasm`     | `tbd`                                                              | >=0.5.0                   |
+| 0.2.0   | `https://github.com/supabase/wrappers/releases/download/wasm_paddle_fdw_v0.2.0/paddle_fdw.wasm`     | `e788b29ae46c158643e1e1f229d94b28a9af8edbd3233f59c5a79053c25da213` | >=0.5.0                   |
 | 0.1.1   | `https://github.com/supabase/wrappers/releases/download/wasm_paddle_fdw_v0.1.1/paddle_fdw.wasm`     | `c5ac70bb2eef33693787b7d4efce9a83cde8d4fa40889d2037403a51263ba657` | >=0.4.0                   |
 | 0.1.0   | `https://github.com/supabase/wrappers/releases/download/wasm_paddle_fdw_v0.1.0/paddle_fdw.wasm`     | `7d0b902440ac2ef1af85d09807145247f14d1d8fd4d700227e5a4d84c8145409` | >=0.4.0                   |
 

--- a/docs/catalog/slack.md
+++ b/docs/catalog/slack.md
@@ -17,7 +17,7 @@ The Slack Wrapper is a WebAssembly (Wasm) foreign data wrapper which allows you 
 
 | Version | Wasm Package URL                                                                                    | Checksum                                                           | Required Wrappers Version |
 | ------- | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ | ------------------------- |
-| 0.2.0   | `https://github.com/supabase/wrappers/releases/download/wasm_slack_fdw_v0.2.0/slack_fdw.wasm`       | `tbd`                                                              | >=0.5.0                   |
+| 0.2.0   | `https://github.com/supabase/wrappers/releases/download/wasm_slack_fdw_v0.2.0/slack_fdw.wasm`       | `bfb0d22ffea2092c049773302c049162a2a57ddc265da59a83116bf29ed40c3a` | >=0.5.0                   |
 | 0.1.0   | `https://github.com/supabase/wrappers/releases/download/wasm_slack_fdw_v0.1.0/slack_fdw.wasm`       | `5b022b441c0007e31d792ecb1341bfffed1c29cb865eb0c7969989dff0e8fdc3` | >=0.4.0                   |
 | 0.0.6   | `https://github.com/supabase/wrappers/releases/download/wasm_slack_fdw_v0.0.6/slack_fdw.wasm`       | `349cb556f87a0233e25eb608a77e840531bc87f1acf9916856268bdcdd9973e2` | >=0.4.0                   |
 

--- a/docs/catalog/snowflake.md
+++ b/docs/catalog/snowflake.md
@@ -17,7 +17,7 @@ The Snowflake Wrapper is a WebAssembly(Wasm) foreign data wrapper which allows y
 
 | Version | Wasm Package URL                                                                                      | Checksum                                                           | Required Wrappers Version |
 | ------- | ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ | ------------------------- |
-| 0.2.0   | `https://github.com/supabase/wrappers/releases/download/wasm_snowflake_fdw_v0.2.0/snowflake_fdw.wasm` | `tbd`                                                              | >=0.5.0                   |
+| 0.2.0   | `https://github.com/supabase/wrappers/releases/download/wasm_snowflake_fdw_v0.2.0/snowflake_fdw.wasm` | `921b18a1e9c20c4ef5a09af17b5d76fd6ebe56d41bcfa565b74a530420532437` | >=0.5.0                   |
 | 0.1.1   | `https://github.com/supabase/wrappers/releases/download/wasm_snowflake_fdw_v0.1.1/snowflake_fdw.wasm` | `7aaafc7edc1726bc93ddc04452d41bda9e1a264a1df2ea9bf1b00b267543b860` | >=0.4.0                   |
 | 0.1.0   | `https://github.com/supabase/wrappers/releases/download/wasm_snowflake_fdw_v0.1.0/snowflake_fdw.wasm` | `2fb46fd8afa63f3975dadf772338106b609b131861849356e0c09dde032d1af8` | >=0.4.0                   |
 

--- a/supabase-wrappers-macros/Cargo.toml
+++ b/supabase-wrappers-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "supabase-wrappers-macros"
-version = "0.1.17"
+version = "0.1.18"
 authors = ["Supabase Inc. https://supabase.com/"]
 license = "Apache-2.0"
 description = "Postgres Foreign Data Wrapper development framework macros for supabase-wrappers"

--- a/wrappers/Cargo.toml
+++ b/wrappers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wrappers"
-version = "0.5.0"
+version = "0.5.1"
 publish = false
 homepage = "https://github.com/supabase/wrappers/tree/main/wrappers"
 repository = "https://github.com/supabase/wrappers/tree/main/wrappers"
@@ -283,9 +283,9 @@ anyhow  = { version = "1.0.81", optional = true }
 uuid = { version = "1.16.0", optional = true }
 
 # for iceberg_fdw
-iceberg = { git = "https://github.com/burmecia/iceberg-rust", branch = "main", package="iceberg", optional = true }
-iceberg-catalog-s3tables = { git = "https://github.com/burmecia/iceberg-rust", branch = "main", package="iceberg-catalog-s3tables", optional = true }
-iceberg-catalog-rest = { git = "https://github.com/burmecia/iceberg-rust", branch = "main", package="iceberg-catalog-rest", optional = true }
+iceberg = { git = "https://github.com/apache/iceberg-rust", rev = "12485be4a30848213faea62740ad7cb5a41bd6f2", package = "iceberg", optional = true }
+iceberg-catalog-s3tables = { git = "https://github.com/apache/iceberg-rust", rev = "12485be4a30848213faea62740ad7cb5a41bd6f2", package="iceberg-catalog-s3tables", optional = true }
+iceberg-catalog-rest = { git = "https://github.com/apache/iceberg-rust", rev = "12485be4a30848213faea62740ad7cb5a41bd6f2", package="iceberg-catalog-rest", optional = true }
 rust_decimal = { version = "1.37.1", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to bump Wrappers version to `0.5.1`.

## What is the current behavior?

N/A

## What is the new behavior?

N/A

## Additional context

- upstream Iceberg dependency has [merged our patch](https://github.com/apache/iceberg-rust/pull/1347), so we switched back to use the upstream Iceberg
- all the Wasm wrappers v0.2.0 checksum are updated
- a few other minor fixes