### PR TITLE
fix(clickhouse): integer type up-cast and down-cast

### DIFF
--- a/docs/catalog/clickhouse.md
+++ b/docs/catalog/clickhouse.md
@@ -164,7 +164,9 @@ This FDW supports `where`, `order by` and `limit` clause pushdown, as well as pa
 
 | Postgres Type      | ClickHouse Type   |
 | ------------------ | ----------------- |
-| boolean            | UInt8             |
+| boolean            | Bool              |
+| "char"             | Int8              |
+| smallint           | UInt8             |
 | smallint           | Int16             |
 | integer            | UInt16            |
 | integer            | Int32             |
@@ -188,7 +190,7 @@ This FDW supports `where`, `order by` and `limit` clause pushdown, as well as pa
 | integer[]          | Array(Int32)      |
 | bigint[]           | Array(Int64)      |
 | real[]             | Array(Float32)    |
-| double precision[] | Array(Float64)  |
+| double precision[] | Array(Float64)    |
 | text[]             | Array(String)     |
 | *                  | Nullable&lt;T&gt; |
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to fix some integer data type conversion issues between ClickHouse and Postgres.

## What is the current behavior?

Currently some of the integer data types conversion from ClickHouse -> Postgres:

- Bool -> missing
- Int8 -> missing
- UInt8 -> boolean
- Nullable(Bool) -> missing
- Nullable(Int8) -> missing
- Nullable(UInt8) -> boolean

## What is the new behavior?

Added some missing data type conversions:

From ClickHouse -> Postgres:

- Bool -> boolean
- Int8 -> "char"
- UInt8 -> smallint
- Nullable(Bool) -> boolean
- Nullable(Int8) -> "char"
- Nullable(UInt8) -> smallint

From Postgres -> ClickHouse, according to the target column type, we do below down casting:

- smallint -> UInt8
- integer -> UInt16
- bigint -> UInt32

## Additional context

N/A
