### PR TITLE
chore: bump pgrx to v0.14.3

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -40,7 +40,7 @@ jobs:
           sudo apt -y autoremove && sudo apt -y clean
           sudo chmod a+rwx `/usr/lib/postgresql/15/bin/pg_config --pkglibdir` `/usr/lib/postgresql/15/bin/pg_config --sharedir`/extension /var/run/postgresql/
 
-      - run: cargo install cargo-pgrx --version 0.12.9
+      - run: cargo install cargo-pgrx --version 0.14.3
       - run: cargo pgrx init --pg15 /usr/lib/postgresql/15/bin/pg_config
 
       - name: Build docker images

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
         extension_name:
           - wrappers
         pgrx_version:
-          - 0.12.9
+          - 0.14.3
         postgres: [14, 15, 16, 17]
         features:
           - "all_fdws"
@@ -147,7 +147,7 @@ jobs:
           cd ${package_dir}/usr/share/postgresql/${{ matrix.postgres }}/extension
           cp -s ../../../../../var/lib/postgresql/extension/${{ matrix.extension_name }}.control .
           cp -s ../../../../../var/lib/postgresql/extension/${{ matrix.extension_name }}*.sql .
-          cd ../../../../../.. 
+          cd ../../../../../..
 
           mkdir -p ${package_dir}/DEBIAN
           touch ${package_dir}/DEBIAN/control
@@ -160,7 +160,7 @@ jobs:
           # Create deb package
           sudo chown -R root:root ${package_dir}
           sudo chmod -R 00755 ${package_dir}
-          sudo dpkg-deb --build --root-owner-group ${package_dir} 
+          sudo dpkg-deb --build --root-owner-group ${package_dir}
 
       - name: Get upload url
         run: echo UPLOAD_URL=$(curl --silent https://api.github.com/repos/${{ github.repository }}/releases/latest | jq .upload_url --raw-output) >> $GITHUB_ENV

--- a/.github/workflows/test_supabase_wrappers.yml
+++ b/.github/workflows/test_supabase_wrappers.yml
@@ -36,7 +36,7 @@ jobs:
         sudo apt -y autoremove && sudo apt -y clean
         sudo chmod a+rwx `/usr/lib/postgresql/15/bin/pg_config --pkglibdir` `/usr/lib/postgresql/15/bin/pg_config --sharedir`/extension /var/run/postgresql/
 
-    - run: cargo install cargo-pgrx --version 0.12.9
+    - run: cargo install cargo-pgrx --version 0.14.3
     - run: cargo pgrx init --pg15 /usr/lib/postgresql/15/bin/pg_config
 
     - name: Format code

--- a/.github/workflows/test_wrappers.yml
+++ b/.github/workflows/test_wrappers.yml
@@ -43,7 +43,7 @@ jobs:
         sudo apt -y autoremove && sudo apt -y clean
         sudo chmod a+rwx `/usr/lib/postgresql/15/bin/pg_config --pkglibdir` `/usr/lib/postgresql/15/bin/pg_config --sharedir`/extension /var/run/postgresql/
 
-    - run: cargo install cargo-pgrx --version 0.12.9
+    - run: cargo install cargo-pgrx --version 0.14.3
     - run: cargo pgrx init --pg15 /usr/lib/postgresql/15/bin/pg_config
 
     - name: Format code
@@ -91,7 +91,7 @@ jobs:
         sudo apt -y autoremove && sudo apt -y clean
         sudo chmod a+rwx `/usr/lib/postgresql/15/bin/pg_config --pkglibdir` `/usr/lib/postgresql/15/bin/pg_config --sharedir`/extension /var/run/postgresql/
 
-    - run: cargo install cargo-pgrx --version 0.12.9
+    - run: cargo install cargo-pgrx --version 0.14.3
     - run: cargo pgrx init --pg15 /usr/lib/postgresql/15/bin/pg_config
     - run: cargo install cargo-component --version 0.21.1
     - run: rustup target add wasm32-unknown-unknown

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,12 +106,12 @@ dependencies = [
 
 [[package]]
 name = "annotate-snippets"
-version = "0.9.2"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccaf7e9dfbb6ab22c82e473cd1a8a7bd313c19a5b7e40970f3d89ef5a5c9e81e"
+checksum = "710e8eae58854cdc1790fcb56cca04d712a17be849eeb81da2a724bf4bae2bc4"
 dependencies = [
- "unicode-width 0.1.14",
- "yansi-term",
+ "anstyle",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -164,12 +164,12 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.7"
+version = "3.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+checksum = "6680de5231bd6ee4c6191b8a1325daa282b415391ec9d3a37bd34f2060dc73fa"
 dependencies = [
  "anstyle",
- "once_cell",
+ "once_cell_polyfill",
  "windows-sys 0.59.0",
 ]
 
@@ -516,9 +516,9 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a2b323ccce0a1d90b449fd71f2a06ca7faa7c54c2751f06c9bd851fc061059"
+checksum = "1237c0ae75a0f3765f58910ff9cdd0a12eeb39ab2f4c7de23262f337f0aacbb3"
 dependencies = [
  "async-lock 3.4.0",
  "cfg-if",
@@ -526,8 +526,8 @@ dependencies = [
  "futures-io",
  "futures-lite 2.6.0",
  "parking",
- "polling 3.7.4",
- "rustix 0.38.44",
+ "polling 3.8.0",
+ "rustix 1.0.7",
  "slab",
  "tracing",
  "windows-sys 0.59.0",
@@ -599,7 +599,7 @@ version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "637e00349800c0bdf8bfc21ebbc0b6524abea702b0da4168ac00d070d0c0b9f3"
 dependencies = [
- "async-io 2.4.0",
+ "async-io 2.4.1",
  "async-lock 3.4.0",
  "atomic-waker",
  "cfg-if",
@@ -674,12 +674,12 @@ dependencies = [
 
 [[package]]
 name = "atomic-traits"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b29ec3788e96fb4fdb275ccb9d62811f2fa903d76c5eb4dd6fe7d09a7ed5871f"
+checksum = "707f750b93bd1b739cf9ddf85f8fe7c97a4a62c60ccf8b6f232514bd9103bedc"
 dependencies = [
  "cfg-if",
- "rustc_version 0.3.3",
+ "rustc_version",
 ]
 
 [[package]]
@@ -797,9 +797,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-cognitoidentityprovider"
-version = "1.81.0"
+version = "1.83.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef8d5d7f21213ae1c68c15ce5fabad492c777fd094466632a6e253356e5f9deb"
+checksum = "c0e89555b3c2375cd34daf21dc764eed37dac9214bf44fad2f9da338d50f4d73"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -819,9 +819,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.86.0"
+version = "1.88.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0303d28521eae1dbf1bf29e772029204cf9e126da7aa763e5391ff2131bcc2ac"
+checksum = "5ffc2a1c6dfd4585ad423350c04da3c8be831c9f418e58e8c837656054ec45f8"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -853,9 +853,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3tables"
-version = "1.20.0"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aeb8d50940ff852885f372f3099eeadc70f7d4917389b39f4c7a1b8e6c372bc"
+checksum = "f6c845ea2d9c2168620c3ca6ab6561e248d3d3818770f98737bb1fe81113b6ef"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -875,9 +875,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.68.0"
+version = "1.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd5f01ea61fed99b5fe4877abff6c56943342a56ff145e9e0c7e2494419008be"
+checksum = "83447efb7179d8e2ad2afb15ceb9c113debbc2ecdf109150e338e2e28b86190b"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -897,9 +897,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.69.0"
+version = "1.71.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27454e4c55aaa4ef65647e3a1cf095cb834ca6d54e959e2909f1fef96ad87860"
+checksum = "c5f9bfbbda5e2b9fe330de098f14558ee8b38346408efe9f2e9cee82dc1636a4"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -919,9 +919,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.69.0"
+version = "1.71.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffd6ef5d00c94215960fabcdf2d9fe7c090eed8be482d66d47b92d4aba1dd4aa"
+checksum = "e17b984a66491ec08b4f4097af8911251db79296b3e4a763060b45805746264f"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1047,7 +1047,7 @@ dependencies = [
  "hyper 0.14.32",
  "hyper 1.6.0",
  "hyper-rustls 0.24.2",
- "hyper-rustls 0.27.5",
+ "hyper-rustls 0.27.6",
  "hyper-util",
  "pin-project-lite",
  "rustls 0.21.12",
@@ -1173,7 +1173,7 @@ dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "rustc_version 0.4.1",
+ "rustc_version",
  "tracing",
 ]
 
@@ -1300,9 +1300,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.70.1"
+version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
+checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
 dependencies = [
  "annotate-snippets",
  "bitflags 2.9.1",
@@ -1312,7 +1312,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 1.1.0",
+ "rustc-hash 2.1.1",
  "shlex",
  "syn 2.0.101",
 ]
@@ -1562,7 +1562,7 @@ checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver 1.0.26",
+ "semver",
  "serde 1.0.219",
  "serde_json",
  "thiserror 1.0.69",
@@ -1570,9 +1570,9 @@ dependencies = [
 
 [[package]]
 name = "cargo_toml"
-version = "0.19.2"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a98356df42a2eb1bd8f1793ae4ee4de48e384dd974ce5eac8eee802edb7492be"
+checksum = "02260d489095346e5cafd04dea8e8cb54d1d74fcd759022a9b72986ebe9a1257"
 dependencies = [
  "serde 1.0.219",
  "toml 0.8.22",
@@ -1589,9 +1589,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.23"
+version = "1.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4ac86a9e5bc1e2b3449ab9d7d3a6a405e3d1bb28d7b9be8614f55846ae3766"
+checksum = "16595d3be041c03b09d08d0858631facccee9221e579704070e6e9e4915d3bc7"
 dependencies = [
  "jobserver",
  "libc",
@@ -1919,9 +1919,9 @@ checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "convert_case"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+checksum = "baaaa0ecca5b51987b9423ccdc971514dd8b0bb7b4060b983d3664dad3f1f89f"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -1938,9 +1938,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2141,7 +2141,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
 dependencies = [
- "rustc_version 0.4.1",
+ "rustc_version",
 ]
 
 [[package]]
@@ -2676,9 +2676,9 @@ dependencies = [
 
 [[package]]
 name = "ethnum"
-version = "1.5.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0939f82868b77ef93ce3c3c3daf2b3c526b456741da5a1a4559e590965b6026b"
+checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
 
 [[package]]
 name = "event-listener"
@@ -2794,7 +2794,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1045398c1bfd89168b5fd3f1fc11f6e70b34f6f66300c87d44d3de849463abf1"
 dependencies = [
  "bitflags 2.9.1",
- "rustc_version 0.4.1",
+ "rustc_version",
 ]
 
 [[package]]
@@ -3255,12 +3255,6 @@ checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hermit-abi"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
-
-[[package]]
-name = "hermit-abi"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f154ce46856750ed433c8649605bf7ed2de3bc35fd9d2a9f30cddd873c80cb08"
@@ -3439,7 +3433,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.9",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -3485,11 +3479,10 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.5"
+version = "0.27.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
+checksum = "03a01595e11bdcec50946522c32dde3fc6914743000a68b93000965f2f02406d"
 dependencies = [
- "futures-util",
  "http 1.3.1",
  "hyper 1.6.0",
  "hyper-util",
@@ -3499,7 +3492,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.2",
  "tower-service",
- "webpki-roots 0.26.11",
+ "webpki-roots 1.0.0",
 ]
 
 [[package]]
@@ -3558,7 +3551,7 @@ dependencies = [
  "hyper 1.6.0",
  "libc",
  "pin-project-lite",
- "socket2 0.5.9",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -4486,13 +4479,13 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4510,7 +4503,7 @@ dependencies = [
  "loom",
  "parking_lot 0.12.3",
  "portable-atomic",
- "rustc_version 0.4.1",
+ "rustc_version",
  "smallvec",
  "tagptr",
  "thiserror 1.0.69",
@@ -4734,6 +4727,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-foundation"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166"
+dependencies = [
+ "bitflags 2.9.1",
+]
+
+[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4752,10 +4754,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
-name = "opendal"
-version = "0.53.2"
+name = "once_cell_polyfill"
+version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ff9e9656d1cb3c58582ea18e6d9e71076a7ab2614207821d1242d7da2daed5"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
+name = "opendal"
+version = "0.53.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f947c4efbca344c1a125753366033c8107f552b2e3f8251815ed1908f116ca3e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5098,17 +5106,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
-name = "pest"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "198db74531d58c70a361c42201efde7e2591e976d518caf7662a47dc5720e7b6"
-dependencies = [
- "memchr",
- "thiserror 2.0.12",
- "ucd-trie",
-]
-
-[[package]]
 name = "petgraph"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5129,10 +5126,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "pgrx"
-version = "0.12.9"
+name = "petgraph"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "227bf7e162ce710994306a97bc56bb3fe305f21120ab6692e2151c48416f5c0d"
+checksum = "7a98c6720655620a521dcc722d0ad66cd8afd5d86e34a89ef691c50b7b24de06"
+dependencies = [
+ "fixedbitset 0.5.7",
+ "hashbrown 0.15.3",
+ "indexmap 2.9.0",
+ "serde 1.0.219",
+]
+
+[[package]]
+name = "pgrx"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dffb5a99b514090574a668078a28394317d30bbb33a8b6d651342ebd945e81b"
 dependencies = [
  "atomic-traits",
  "bitflags 2.9.1",
@@ -5148,23 +5157,24 @@ dependencies = [
  "serde 1.0.219",
  "serde_cbor",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "uuid",
 ]
 
 [[package]]
 name = "pgrx-bindgen"
-version = "0.12.9"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cbcd956c2da35baaf0a116e6f6a49a6c2fbc8f6b332f66d6fd060bfd00615f"
+checksum = "e9e43f241932f230af1ed713fac06133a074efb12a80705db7f679627551b5a8"
 dependencies = [
- "bindgen 0.70.1",
+ "bindgen 0.71.1",
  "cc",
  "clang-sys",
  "eyre",
  "pgrx-pg-config",
  "proc-macro2",
  "quote",
+ "regex",
  "shlex",
  "syn 2.0.101",
  "walkdir",
@@ -5172,9 +5182,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-macros"
-version = "0.12.9"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2f4291450d65e4deb770ce57ea93e22353d97950566222429cd166ebdf6f938"
+checksum = "0c97650c7bb75290fc0b7e1a80bc5cea74e541015369a6558f72fb3da0c0e95e"
 dependencies = [
  "pgrx-sql-entity-graph",
  "proc-macro2",
@@ -5184,9 +5194,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-config"
-version = "0.12.9"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86a64a4c6e4e43e73cf8d3379d9533df98ded45c920e1ba8131c979633d74132"
+checksum = "6a370f7f6127487e50be58aaf6544439352ff667e9ab6e5e6b24fb77f794315b"
 dependencies = [
  "cargo_toml",
  "eyre",
@@ -5195,16 +5205,16 @@ dependencies = [
  "pathsearch",
  "serde 1.0.219",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "toml 0.8.22",
  "url",
 ]
 
 [[package]]
 name = "pgrx-pg-sys"
-version = "0.12.9"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63a5dc64f2a8226434118aa2c4700450fa42b04f29488ad98268848b21c1a4ec"
+checksum = "aa062f644530005641b5cdc4b5d1303c70ffa38bd1089699035ea46adac41b6d"
 dependencies = [
  "cee-scape",
  "libc",
@@ -5217,25 +5227,25 @@ dependencies = [
 
 [[package]]
 name = "pgrx-sql-entity-graph"
-version = "0.12.9"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d81cc2e851c7e36b2f47c03e22d64d56c1d0e762fbde0039ba2cd490cfef3615"
+checksum = "fc58ca1db80bc9b38e38be7d65e3dd6ba2813083410e7a81ed9db70147c40f86"
 dependencies = [
  "convert_case",
  "eyre",
- "petgraph 0.6.5",
+ "petgraph 0.8.1",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "unescape",
 ]
 
 [[package]]
 name = "pgrx-tests"
-version = "0.12.9"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c2dd5d674cb7d92024709543da06d26723a2f7450c02083116b232587160929"
+checksum = "e9ec4957e116035f87c2fb475b7c95554b44400d66e25842d6edb2491ed6c883"
 dependencies = [
  "clap-cargo",
  "eyre",
@@ -5247,12 +5257,15 @@ dependencies = [
  "pgrx-pg-config",
  "postgres",
  "proptest",
- "rand 0.8.5",
+ "rand 0.9.1",
  "regex",
  "serde 1.0.219",
  "serde_json",
+ "shlex",
  "sysinfo",
- "thiserror 1.0.69",
+ "tempfile",
+ "thiserror 2.0.12",
+ "winapi",
 ]
 
 [[package]]
@@ -5392,15 +5405,15 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "3.7.4"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f"
+checksum = "b53a684391ad002dd6a596ceb6c74fd004fdce75f4be2e3f615068abbea5fd50"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
- "hermit-abi 0.4.0",
+ "hermit-abi 0.5.1",
  "pin-project-lite",
- "rustix 0.38.44",
+ "rustix 1.0.7",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -5821,7 +5834,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls 0.23.27",
- "socket2 0.5.9",
+ "socket2 0.5.10",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -5858,7 +5871,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.9",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -6003,26 +6016,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rayon"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "redis"
 version = "0.27.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6040,7 +6033,7 @@ dependencies = [
  "rustls-pki-types",
  "ryu",
  "sha1_smol",
- "socket2 0.5.9",
+ "socket2 0.5.10",
  "url",
 ]
 
@@ -6233,7 +6226,7 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.6.0",
- "hyper-rustls 0.27.5",
+ "hyper-rustls 0.27.6",
  "hyper-tls 0.6.0",
  "hyper-util",
  "ipnet",
@@ -6478,20 +6471,11 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
-dependencies = [
- "semver 0.11.0",
-]
-
-[[package]]
-name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver 1.0.26",
+ "semver",
 ]
 
 [[package]]
@@ -6651,9 +6635,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
 name = "rusty-fork"
@@ -6795,7 +6779,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
 dependencies = [
  "bitflags 2.9.1",
- "core-foundation 0.10.0",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -6813,29 +6797,11 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 dependencies = [
  "serde 1.0.219",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9900206b54a3527fdc7b8a938bffd94a568bac4f4aa8113b209df75a09c0dec2"
-dependencies = [
- "pest",
 ]
 
 [[package]]
@@ -7158,9 +7124,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -7355,17 +7321,15 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.30.13"
+version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a5b4ddaee55fb2bea2bf0e5000747e5f5c0de765e5a5ff87f4cd106439f4bb3"
+checksum = "a4b93974b3d3aeaa036504b8eefd4c039dced109171c1ae973f1dc63b2c7e4b2"
 dependencies = [
- "cfg-if",
- "core-foundation-sys",
  "libc",
+ "memchr",
  "ntapi",
- "once_cell",
- "rayon",
- "windows 0.52.0",
+ "objc2-core-foundation",
+ "windows 0.57.0",
 ]
 
 [[package]]
@@ -7636,9 +7600,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.45.0"
+version = "1.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165"
+checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
 dependencies = [
  "backtrace",
  "bytes",
@@ -7647,7 +7611,7 @@ dependencies = [
  "parking_lot 0.12.3",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.9",
+ "socket2 0.5.10",
  "tokio-macros",
  "windows-sys 0.52.0",
 ]
@@ -7693,7 +7657,7 @@ dependencies = [
  "postgres-protocol",
  "postgres-types",
  "rand 0.9.1",
- "socket2 0.5.9",
+ "socket2 0.5.10",
  "tokio",
  "tokio-util",
  "whoami",
@@ -8047,12 +8011,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
-name = "ucd-trie"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
-
-[[package]]
 name = "uds_windows"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8185,9 +8143,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
+checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
 dependencies = [
  "getrandom 0.3.3",
  "js-sys",
@@ -8292,7 +8250,7 @@ dependencies = [
  "ptree",
  "reqwest 0.12.15",
  "secrecy",
- "semver 1.0.26",
+ "semver",
  "serde 1.0.219",
  "serde_json",
  "sha256",
@@ -8367,7 +8325,7 @@ dependencies = [
  "pbjson-types",
  "prost 0.12.6",
  "prost-types 0.12.6",
- "semver 1.0.26",
+ "semver",
  "serde 1.0.219",
  "serde_with",
  "thiserror 1.0.69",
@@ -8541,12 +8499,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.230.0"
+version = "0.231.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4349d0943718e6e434b51b9639e876293093dca4b96384fb136ab5bd5ce6660"
+checksum = "e62baf58bc14f219d1d12d082ea99860acb479b582e8f3d292d8a7c8f756091c"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.230.0",
+ "wasmparser 0.231.0",
 ]
 
 [[package]]
@@ -8585,7 +8543,7 @@ checksum = "9dbe55c8f9d0dbd25d9447a5a889ff90c0cc3feaa7395310d3d826b2c703eaab"
 dependencies = [
  "bitflags 2.9.1",
  "indexmap 2.9.0",
- "semver 1.0.26",
+ "semver",
 ]
 
 [[package]]
@@ -8597,19 +8555,19 @@ dependencies = [
  "bitflags 2.9.1",
  "hashbrown 0.15.3",
  "indexmap 2.9.0",
- "semver 1.0.26",
+ "semver",
  "serde 1.0.219",
 ]
 
 [[package]]
 name = "wasmparser"
-version = "0.230.0"
+version = "0.231.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808198a69b5a0535583370a51d459baa14261dfab04800c4864ee9e1a14346ed"
+checksum = "b1ddaf0d6e069fcd98801b1bf030e3648897d9f09c45ac9ef566d068aca1b76f"
 dependencies = [
  "bitflags 2.9.1",
  "indexmap 2.9.0",
- "semver 1.0.26",
+ "semver",
 ]
 
 [[package]]
@@ -8658,7 +8616,7 @@ dependencies = [
  "psm",
  "pulley-interpreter",
  "rustix 1.0.7",
- "semver 1.0.26",
+ "semver",
  "serde 1.0.219",
  "serde_derive",
  "smallvec",
@@ -8749,7 +8707,7 @@ dependencies = [
  "log",
  "object",
  "postcard",
- "semver 1.0.26",
+ "semver",
  "serde 1.0.219",
  "serde_derive",
  "smallvec",
@@ -8844,22 +8802,22 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "230.0.0"
+version = "231.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8edac03c5fa691551531533928443faf3dc61a44f814a235c7ec5d17b7b34f1"
+checksum = "6258b542d232ac51c0426de6ae0efb31fc9e89f64fe3a525aff1524a06a13417"
 dependencies = [
  "bumpalo",
  "leb128fmt",
  "memchr",
  "unicode-width 0.2.0",
- "wasm-encoder 0.230.0",
+ "wasm-encoder 0.231.0",
 ]
 
 [[package]]
 name = "wat"
-version = "1.230.0"
+version = "1.231.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d77d62229e38db83eac32bacb5f61ebb952366ab0dae90cf2b3c07a65eea894"
+checksum = "97eec2bd34dcd2a2cea1c501fed0c25171cfd02900716d8357639797fa629c2e"
 dependencies = [
  "wast",
 ]
@@ -8989,11 +8947,11 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.52.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
 dependencies = [
- "windows-core 0.52.0",
+ "windows-core 0.57.0",
  "windows-targets 0.52.6",
 ]
 
@@ -9021,10 +8979,13 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.52.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
 dependencies = [
+ "windows-implement 0.57.0",
+ "windows-interface 0.57.0",
+ "windows-result 0.1.2",
  "windows-targets 0.52.6",
 ]
 
@@ -9034,10 +8995,10 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.0",
+ "windows-interface 0.59.1",
  "windows-link",
- "windows-result",
+ "windows-result 0.3.4",
  "windows-strings 0.4.2",
 ]
 
@@ -9054,9 +9015,31 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "windows-implement"
 version = "0.60.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9096,9 +9079,18 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
 dependencies = [
- "windows-result",
+ "windows-result 0.3.4",
  "windows-strings 0.3.1",
  "windows-targets 0.53.0",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -9418,7 +9410,7 @@ dependencies = [
  "id-arena",
  "indexmap 2.9.0",
  "log",
- "semver 1.0.26",
+ "semver",
  "serde 1.0.219",
  "serde_derive",
  "serde_json",
@@ -9464,7 +9456,7 @@ dependencies = [
  "reqwest-retry",
  "rust_decimal",
  "rustls 0.23.27",
- "semver 1.0.26",
+ "semver",
  "serde 1.0.219",
  "serde_json",
  "sha2",
@@ -9532,15 +9524,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "yansi-term"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe5c30ade05e61656247b2e334a031dfd0cc466fadef865bdcdea8d537951bf1"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "yoke"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9577,7 +9560,7 @@ dependencies = [
  "http 1.3.1",
  "http-body-util",
  "hyper 1.6.0",
- "hyper-rustls 0.27.5",
+ "hyper-rustls 0.27.6",
  "hyper-util",
  "log",
  "percent-encoding",

--- a/supabase-wrappers/Cargo.toml
+++ b/supabase-wrappers/Cargo.toml
@@ -16,7 +16,6 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(pgrx_embed)'] }
 
 [features]
 default = ["pg15"]
-pg12 = ["pgrx/pg12", "pgrx-tests/pg12"]
 pg13 = ["pgrx/pg13", "pgrx-tests/pg13"]
 pg14 = ["pgrx/pg14", "pgrx-tests/pg14"]
 pg15 = ["pgrx/pg15", "pgrx-tests/pg15"]
@@ -25,14 +24,14 @@ pg17 = ["pgrx/pg17", "pgrx-tests/pg17"]
 pg_test = []
 
 [dependencies]
-pgrx = { version = "=0.12.9", default-features = false }
+pgrx = { version = "=0.14.3", default-features = false }
 thiserror = "1.0.63"
 tokio = { version = "1.43", features = ["rt", "net"] }
 uuid = { version = "1.10.0" }
 supabase-wrappers-macros = { version = "0.1", path = "../supabase-wrappers-macros" }
 
 [dev-dependencies]
-pgrx-tests = "=0.12.9"
+pgrx-tests = "=0.14.3"
 
 [package.metadata.docs.rs]
 features = ["pg15"]

--- a/supabase-wrappers/src/import_foreign_schema.rs
+++ b/supabase-wrappers/src/import_foreign_schema.rs
@@ -45,7 +45,10 @@ pub struct ImportForeignSchemaStmt {
 }
 
 #[pg_guard]
-pub(super) extern "C-unwind" fn import_foreign_schema<E: Into<ErrorReport>, W: ForeignDataWrapper<E>>(
+pub(super) extern "C-unwind" fn import_foreign_schema<
+    E: Into<ErrorReport>,
+    W: ForeignDataWrapper<E>,
+>(
     stmt: *mut pg_sys::ImportForeignSchemaStmt,
     server_oid: pg_sys::Oid,
 ) -> *mut pg_sys::List {

--- a/supabase-wrappers/src/import_foreign_schema.rs
+++ b/supabase-wrappers/src/import_foreign_schema.rs
@@ -45,7 +45,7 @@ pub struct ImportForeignSchemaStmt {
 }
 
 #[pg_guard]
-pub(super) extern "C" fn import_foreign_schema<E: Into<ErrorReport>, W: ForeignDataWrapper<E>>(
+pub(super) extern "C-unwind" fn import_foreign_schema<E: Into<ErrorReport>, W: ForeignDataWrapper<E>>(
     stmt: *mut pg_sys::ImportForeignSchemaStmt,
     server_oid: pg_sys::Oid,
 ) -> *mut pg_sys::List {

--- a/supabase-wrappers/src/modify.rs
+++ b/supabase-wrappers/src/modify.rs
@@ -136,7 +136,7 @@ pub(super) extern "C" fn add_foreign_update_targets(
 
 #[cfg(not(feature = "pg13"))]
 #[pg_guard]
-pub(super) extern "C" fn add_foreign_update_targets(
+pub(super) extern "C-unwind" fn add_foreign_update_targets(
     root: *mut pg_sys::PlannerInfo,
     rtindex: pg_sys::Index,
     _target_rte: *mut pg_sys::RangeTblEntry,
@@ -162,7 +162,7 @@ pub(super) extern "C" fn add_foreign_update_targets(
 }
 
 #[pg_guard]
-pub(super) extern "C" fn plan_foreign_modify<E: Into<ErrorReport>, W: ForeignDataWrapper<E>>(
+pub(super) extern "C-unwind" fn plan_foreign_modify<E: Into<ErrorReport>, W: ForeignDataWrapper<E>>(
     root: *mut pg_sys::PlannerInfo,
     plan: *mut pg_sys::ModifyTable,
     result_relation: pg_sys::Index,
@@ -204,7 +204,7 @@ pub(super) extern "C" fn plan_foreign_modify<E: Into<ErrorReport>, W: ForeignDat
                 let ftable_id = rel.oid();
 
                 // refresh leftover memory context
-                let ctx_name = format!("Wrappers_modify_{}", ftable_id.as_u32());
+                let ctx_name = format!("Wrappers_modify_{}", ftable_id.to_u32());
                 let ctx = memctx::refresh_wrappers_memctx(&ctx_name);
 
                 // create modify state
@@ -247,7 +247,7 @@ pub(super) extern "C" fn plan_foreign_modify<E: Into<ErrorReport>, W: ForeignDat
 }
 
 #[pg_guard]
-pub(super) extern "C" fn begin_foreign_modify<E: Into<ErrorReport>, W: ForeignDataWrapper<E>>(
+pub(super) extern "C-unwind" fn begin_foreign_modify<E: Into<ErrorReport>, W: ForeignDataWrapper<E>>(
     mtstate: *mut pg_sys::ModifyTableState,
     rinfo: *mut pg_sys::ResultRelInfo,
     fdw_private: *mut pg_sys::List,
@@ -280,7 +280,7 @@ pub(super) extern "C" fn begin_foreign_modify<E: Into<ErrorReport>, W: ForeignDa
 }
 
 #[pg_guard]
-pub(super) extern "C" fn exec_foreign_insert<E: Into<ErrorReport>, W: ForeignDataWrapper<E>>(
+pub(super) extern "C-unwind" fn exec_foreign_insert<E: Into<ErrorReport>, W: ForeignDataWrapper<E>>(
     _estate: *mut pg_sys::EState,
     rinfo: *mut pg_sys::ResultRelInfo,
     slot: *mut pg_sys::TupleTableSlot,
@@ -309,7 +309,7 @@ unsafe fn get_rowid_cell<E: Into<ErrorReport>, W: ForeignDataWrapper<E>>(
 }
 
 #[pg_guard]
-pub(super) extern "C" fn exec_foreign_delete<E: Into<ErrorReport>, W: ForeignDataWrapper<E>>(
+pub(super) extern "C-unwind" fn exec_foreign_delete<E: Into<ErrorReport>, W: ForeignDataWrapper<E>>(
     _estate: *mut pg_sys::EState,
     rinfo: *mut pg_sys::ResultRelInfo,
     slot: *mut pg_sys::TupleTableSlot,
@@ -331,7 +331,7 @@ pub(super) extern "C" fn exec_foreign_delete<E: Into<ErrorReport>, W: ForeignDat
 }
 
 #[pg_guard]
-pub(super) extern "C" fn exec_foreign_update<E: Into<ErrorReport>, W: ForeignDataWrapper<E>>(
+pub(super) extern "C-unwind" fn exec_foreign_update<E: Into<ErrorReport>, W: ForeignDataWrapper<E>>(
     _estate: *mut pg_sys::EState,
     rinfo: *mut pg_sys::ResultRelInfo,
     slot: *mut pg_sys::TupleTableSlot,
@@ -375,7 +375,7 @@ pub(super) extern "C" fn exec_foreign_update<E: Into<ErrorReport>, W: ForeignDat
 }
 
 #[pg_guard]
-pub(super) extern "C" fn end_foreign_modify<E: Into<ErrorReport>, W: ForeignDataWrapper<E>>(
+pub(super) extern "C-unwind" fn end_foreign_modify<E: Into<ErrorReport>, W: ForeignDataWrapper<E>>(
     _estate: *mut pg_sys::EState,
     rinfo: *mut pg_sys::ResultRelInfo,
 ) {

--- a/supabase-wrappers/src/modify.rs
+++ b/supabase-wrappers/src/modify.rs
@@ -162,7 +162,10 @@ pub(super) extern "C-unwind" fn add_foreign_update_targets(
 }
 
 #[pg_guard]
-pub(super) extern "C-unwind" fn plan_foreign_modify<E: Into<ErrorReport>, W: ForeignDataWrapper<E>>(
+pub(super) extern "C-unwind" fn plan_foreign_modify<
+    E: Into<ErrorReport>,
+    W: ForeignDataWrapper<E>,
+>(
     root: *mut pg_sys::PlannerInfo,
     plan: *mut pg_sys::ModifyTable,
     result_relation: pg_sys::Index,
@@ -247,7 +250,10 @@ pub(super) extern "C-unwind" fn plan_foreign_modify<E: Into<ErrorReport>, W: For
 }
 
 #[pg_guard]
-pub(super) extern "C-unwind" fn begin_foreign_modify<E: Into<ErrorReport>, W: ForeignDataWrapper<E>>(
+pub(super) extern "C-unwind" fn begin_foreign_modify<
+    E: Into<ErrorReport>,
+    W: ForeignDataWrapper<E>,
+>(
     mtstate: *mut pg_sys::ModifyTableState,
     rinfo: *mut pg_sys::ResultRelInfo,
     fdw_private: *mut pg_sys::List,
@@ -280,7 +286,10 @@ pub(super) extern "C-unwind" fn begin_foreign_modify<E: Into<ErrorReport>, W: Fo
 }
 
 #[pg_guard]
-pub(super) extern "C-unwind" fn exec_foreign_insert<E: Into<ErrorReport>, W: ForeignDataWrapper<E>>(
+pub(super) extern "C-unwind" fn exec_foreign_insert<
+    E: Into<ErrorReport>,
+    W: ForeignDataWrapper<E>,
+>(
     _estate: *mut pg_sys::EState,
     rinfo: *mut pg_sys::ResultRelInfo,
     slot: *mut pg_sys::TupleTableSlot,
@@ -309,7 +318,10 @@ unsafe fn get_rowid_cell<E: Into<ErrorReport>, W: ForeignDataWrapper<E>>(
 }
 
 #[pg_guard]
-pub(super) extern "C-unwind" fn exec_foreign_delete<E: Into<ErrorReport>, W: ForeignDataWrapper<E>>(
+pub(super) extern "C-unwind" fn exec_foreign_delete<
+    E: Into<ErrorReport>,
+    W: ForeignDataWrapper<E>,
+>(
     _estate: *mut pg_sys::EState,
     rinfo: *mut pg_sys::ResultRelInfo,
     slot: *mut pg_sys::TupleTableSlot,
@@ -331,7 +343,10 @@ pub(super) extern "C-unwind" fn exec_foreign_delete<E: Into<ErrorReport>, W: For
 }
 
 #[pg_guard]
-pub(super) extern "C-unwind" fn exec_foreign_update<E: Into<ErrorReport>, W: ForeignDataWrapper<E>>(
+pub(super) extern "C-unwind" fn exec_foreign_update<
+    E: Into<ErrorReport>,
+    W: ForeignDataWrapper<E>,
+>(
     _estate: *mut pg_sys::EState,
     rinfo: *mut pg_sys::ResultRelInfo,
     slot: *mut pg_sys::TupleTableSlot,
@@ -375,7 +390,10 @@ pub(super) extern "C-unwind" fn exec_foreign_update<E: Into<ErrorReport>, W: For
 }
 
 #[pg_guard]
-pub(super) extern "C-unwind" fn end_foreign_modify<E: Into<ErrorReport>, W: ForeignDataWrapper<E>>(
+pub(super) extern "C-unwind" fn end_foreign_modify<
+    E: Into<ErrorReport>,
+    W: ForeignDataWrapper<E>,
+>(
     _estate: *mut pg_sys::EState,
     rinfo: *mut pg_sys::ResultRelInfo,
 ) {

--- a/supabase-wrappers/src/scan.rs
+++ b/supabase-wrappers/src/scan.rs
@@ -110,7 +110,7 @@ impl<E: Into<ErrorReport>, W: ForeignDataWrapper<E>> FdwState<E, W> {
 impl<E: Into<ErrorReport>, W: ForeignDataWrapper<E>> utils::SerdeList for FdwState<E, W> {}
 
 #[pg_guard]
-pub(super) extern "C" fn get_foreign_rel_size<E: Into<ErrorReport>, W: ForeignDataWrapper<E>>(
+pub(super) extern "C-unwind" fn get_foreign_rel_size<E: Into<ErrorReport>, W: ForeignDataWrapper<E>>(
     root: *mut pg_sys::PlannerInfo,
     baserel: *mut pg_sys::RelOptInfo,
     foreigntableid: pg_sys::Oid,
@@ -118,7 +118,7 @@ pub(super) extern "C" fn get_foreign_rel_size<E: Into<ErrorReport>, W: ForeignDa
     debug2!("---> get_foreign_rel_size");
     unsafe {
         // refresh leftover memory context
-        let ctx_name = format!("Wrappers_scan_{}", foreigntableid.as_u32());
+        let ctx_name = format!("Wrappers_scan_{}", foreigntableid.to_u32());
         let ctx = memctx::refresh_wrappers_memctx(&ctx_name);
 
         // create scan state
@@ -152,7 +152,7 @@ pub(super) extern "C" fn get_foreign_rel_size<E: Into<ErrorReport>, W: ForeignDa
 }
 
 #[pg_guard]
-pub(super) extern "C" fn get_foreign_paths<E: Into<ErrorReport>, W: ForeignDataWrapper<E>>(
+pub(super) extern "C-unwind" fn get_foreign_paths<E: Into<ErrorReport>, W: ForeignDataWrapper<E>>(
     root: *mut pg_sys::PlannerInfo,
     baserel: *mut pg_sys::RelOptInfo,
     _foreigntableid: pg_sys::Oid,
@@ -194,7 +194,7 @@ pub(super) extern "C" fn get_foreign_paths<E: Into<ErrorReport>, W: ForeignDataW
 }
 
 #[pg_guard]
-pub(super) extern "C" fn get_foreign_plan<E: Into<ErrorReport>, W: ForeignDataWrapper<E>>(
+pub(super) extern "C-unwind" fn get_foreign_plan<E: Into<ErrorReport>, W: ForeignDataWrapper<E>>(
     _root: *mut pg_sys::PlannerInfo,
     baserel: *mut pg_sys::RelOptInfo,
     _foreigntableid: pg_sys::Oid,
@@ -234,7 +234,7 @@ pub(super) extern "C" fn get_foreign_plan<E: Into<ErrorReport>, W: ForeignDataWr
 }
 
 #[pg_guard]
-pub(super) extern "C" fn explain_foreign_scan<E: Into<ErrorReport>, W: ForeignDataWrapper<E>>(
+pub(super) extern "C-unwind" fn explain_foreign_scan<E: Into<ErrorReport>, W: ForeignDataWrapper<E>>(
     node: *mut pg_sys::ForeignScanState,
     es: *mut pg_sys::ExplainState,
 ) {
@@ -292,7 +292,7 @@ unsafe fn assign_paramenter_value<E: Into<ErrorReport>, W: ForeignDataWrapper<E>
 }
 
 #[pg_guard]
-pub(super) extern "C" fn begin_foreign_scan<E: Into<ErrorReport>, W: ForeignDataWrapper<E>>(
+pub(super) extern "C-unwind" fn begin_foreign_scan<E: Into<ErrorReport>, W: ForeignDataWrapper<E>>(
     node: *mut pg_sys::ForeignScanState,
     eflags: c_int,
 ) {
@@ -326,7 +326,7 @@ pub(super) extern "C" fn begin_foreign_scan<E: Into<ErrorReport>, W: ForeignData
 }
 
 #[pg_guard]
-pub(super) extern "C" fn iterate_foreign_scan<E: Into<ErrorReport>, W: ForeignDataWrapper<E>>(
+pub(super) extern "C-unwind" fn iterate_foreign_scan<E: Into<ErrorReport>, W: ForeignDataWrapper<E>>(
     node: *mut pg_sys::ForeignScanState,
 ) -> *mut pg_sys::TupleTableSlot {
     // `debug!` macros are quite expensive at the moment, so avoid logging in the inner loop
@@ -370,7 +370,7 @@ pub(super) extern "C" fn iterate_foreign_scan<E: Into<ErrorReport>, W: ForeignDa
 }
 
 #[pg_guard]
-pub(super) extern "C" fn re_scan_foreign_scan<E: Into<ErrorReport>, W: ForeignDataWrapper<E>>(
+pub(super) extern "C-unwind" fn re_scan_foreign_scan<E: Into<ErrorReport>, W: ForeignDataWrapper<E>>(
     node: *mut pg_sys::ForeignScanState,
 ) {
     debug2!("---> re_scan_foreign_scan");
@@ -384,7 +384,7 @@ pub(super) extern "C" fn re_scan_foreign_scan<E: Into<ErrorReport>, W: ForeignDa
 }
 
 #[pg_guard]
-pub(super) extern "C" fn end_foreign_scan<E: Into<ErrorReport>, W: ForeignDataWrapper<E>>(
+pub(super) extern "C-unwind" fn end_foreign_scan<E: Into<ErrorReport>, W: ForeignDataWrapper<E>>(
     node: *mut pg_sys::ForeignScanState,
 ) {
     debug2!("---> end_foreign_scan");

--- a/supabase-wrappers/src/scan.rs
+++ b/supabase-wrappers/src/scan.rs
@@ -110,7 +110,10 @@ impl<E: Into<ErrorReport>, W: ForeignDataWrapper<E>> FdwState<E, W> {
 impl<E: Into<ErrorReport>, W: ForeignDataWrapper<E>> utils::SerdeList for FdwState<E, W> {}
 
 #[pg_guard]
-pub(super) extern "C-unwind" fn get_foreign_rel_size<E: Into<ErrorReport>, W: ForeignDataWrapper<E>>(
+pub(super) extern "C-unwind" fn get_foreign_rel_size<
+    E: Into<ErrorReport>,
+    W: ForeignDataWrapper<E>,
+>(
     root: *mut pg_sys::PlannerInfo,
     baserel: *mut pg_sys::RelOptInfo,
     foreigntableid: pg_sys::Oid,
@@ -152,7 +155,10 @@ pub(super) extern "C-unwind" fn get_foreign_rel_size<E: Into<ErrorReport>, W: Fo
 }
 
 #[pg_guard]
-pub(super) extern "C-unwind" fn get_foreign_paths<E: Into<ErrorReport>, W: ForeignDataWrapper<E>>(
+pub(super) extern "C-unwind" fn get_foreign_paths<
+    E: Into<ErrorReport>,
+    W: ForeignDataWrapper<E>,
+>(
     root: *mut pg_sys::PlannerInfo,
     baserel: *mut pg_sys::RelOptInfo,
     _foreigntableid: pg_sys::Oid,
@@ -234,7 +240,10 @@ pub(super) extern "C-unwind" fn get_foreign_plan<E: Into<ErrorReport>, W: Foreig
 }
 
 #[pg_guard]
-pub(super) extern "C-unwind" fn explain_foreign_scan<E: Into<ErrorReport>, W: ForeignDataWrapper<E>>(
+pub(super) extern "C-unwind" fn explain_foreign_scan<
+    E: Into<ErrorReport>,
+    W: ForeignDataWrapper<E>,
+>(
     node: *mut pg_sys::ForeignScanState,
     es: *mut pg_sys::ExplainState,
 ) {
@@ -292,7 +301,10 @@ unsafe fn assign_paramenter_value<E: Into<ErrorReport>, W: ForeignDataWrapper<E>
 }
 
 #[pg_guard]
-pub(super) extern "C-unwind" fn begin_foreign_scan<E: Into<ErrorReport>, W: ForeignDataWrapper<E>>(
+pub(super) extern "C-unwind" fn begin_foreign_scan<
+    E: Into<ErrorReport>,
+    W: ForeignDataWrapper<E>,
+>(
     node: *mut pg_sys::ForeignScanState,
     eflags: c_int,
 ) {
@@ -326,7 +338,10 @@ pub(super) extern "C-unwind" fn begin_foreign_scan<E: Into<ErrorReport>, W: Fore
 }
 
 #[pg_guard]
-pub(super) extern "C-unwind" fn iterate_foreign_scan<E: Into<ErrorReport>, W: ForeignDataWrapper<E>>(
+pub(super) extern "C-unwind" fn iterate_foreign_scan<
+    E: Into<ErrorReport>,
+    W: ForeignDataWrapper<E>,
+>(
     node: *mut pg_sys::ForeignScanState,
 ) -> *mut pg_sys::TupleTableSlot {
     // `debug!` macros are quite expensive at the moment, so avoid logging in the inner loop
@@ -370,7 +385,10 @@ pub(super) extern "C-unwind" fn iterate_foreign_scan<E: Into<ErrorReport>, W: Fo
 }
 
 #[pg_guard]
-pub(super) extern "C-unwind" fn re_scan_foreign_scan<E: Into<ErrorReport>, W: ForeignDataWrapper<E>>(
+pub(super) extern "C-unwind" fn re_scan_foreign_scan<
+    E: Into<ErrorReport>,
+    W: ForeignDataWrapper<E>,
+>(
     node: *mut pg_sys::ForeignScanState,
 ) {
     debug2!("---> re_scan_foreign_scan");

--- a/supabase-wrappers/src/utils.rs
+++ b/supabase-wrappers/src/utils.rs
@@ -4,7 +4,6 @@
 use crate::interface::{Cell, Column, Row};
 use pgrx::list::List;
 use pgrx::pg_sys::panic::{ErrorReport, ErrorReportable};
-use pgrx::prelude::PgBuiltInOids;
 use pgrx::spi::Spi;
 use pgrx::IntoDatum;
 use pgrx::*;
@@ -166,10 +165,7 @@ pub fn get_vault_secret(secret_id: &str) -> Option<String> {
             let sid = sid.into_bytes();
             match Spi::get_one_with_args::<String>(
                 "select decrypted_secret from vault.decrypted_secrets where id = $1 or key_id = $1",
-                vec![(
-                    PgBuiltInOids::UUIDOID.oid(),
-                    pgrx::Uuid::from_bytes(sid).into_datum(),
-                )],
+                &[pgrx::Uuid::from_bytes(sid).into()],
             ) {
                 Ok(decrypted) => decrypted,
                 Err(err) => {
@@ -198,7 +194,7 @@ pub fn get_vault_secret(secret_id: &str) -> Option<String> {
 pub fn get_vault_secret_by_name(secret_name: &str) -> Option<String> {
     match Spi::get_one_with_args::<String>(
         "select decrypted_secret from vault.decrypted_secrets where name = $1",
-        vec![(PgBuiltInOids::TEXTOID.oid(), secret_name.into_datum())],
+            &[secret_name.into()]
     ) {
         Ok(decrypted) => decrypted,
         Err(err) => {

--- a/supabase-wrappers/src/utils.rs
+++ b/supabase-wrappers/src/utils.rs
@@ -194,7 +194,7 @@ pub fn get_vault_secret(secret_id: &str) -> Option<String> {
 pub fn get_vault_secret_by_name(secret_name: &str) -> Option<String> {
     match Spi::get_one_with_args::<String>(
         "select decrypted_secret from vault.decrypted_secrets where name = $1",
-            &[secret_name.into()]
+        &[secret_name.into()],
     ) {
         Ok(decrypted) => decrypted,
         Err(err) => {

--- a/wrappers/Cargo.toml
+++ b/wrappers/Cargo.toml
@@ -19,7 +19,6 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(pgrx_embed)'] }
 
 [features]
 default = ["pg15"]
-pg12 = ["pgrx/pg12", "pgrx-tests/pg12", "supabase-wrappers/pg12"]
 pg13 = ["pgrx/pg13", "pgrx-tests/pg13", "supabase-wrappers/pg13"]
 pg14 = ["pgrx/pg14", "pgrx-tests/pg14", "supabase-wrappers/pg14"]
 pg15 = ["pgrx/pg15", "pgrx-tests/pg15", "supabase-wrappers/pg15"]
@@ -190,7 +189,7 @@ all_fdws = [
 ]
 
 [dependencies]
-pgrx = { version = "=0.12.9" }
+pgrx = { version = "=0.14.3" }
 #supabase-wrappers = "0.1"
 supabase-wrappers = { path = "../supabase-wrappers", default-features = false }
 
@@ -289,4 +288,4 @@ iceberg-catalog-rest = { git = "https://github.com/apache/iceberg-rust", rev = "
 rust_decimal = { version = "1.37.1", optional = true }
 
 [dev-dependencies]
-pgrx-tests = "=0.12.9"
+pgrx-tests = "=0.14.3"

--- a/wrappers/src/fdw/airtable_fdw/tests.rs
+++ b/wrappers/src/fdw/airtable_fdw/tests.rs
@@ -5,12 +5,12 @@ mod tests {
 
     #[pg_test]
     fn airtable_smoketest() {
-        Spi::connect(|mut c| {
+        Spi::connect_mut(|c| {
             c.update(
                 r#"CREATE FOREIGN DATA WRAPPER airtable_wrapper
                          HANDLER airtable_fdw_handler VALIDATOR airtable_fdw_validator"#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
             c.update(
@@ -21,7 +21,7 @@ mod tests {
                             api_key 'apiKey'
                          )"#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
             c.update(
@@ -44,7 +44,7 @@ mod tests {
                   )
              "#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
             c.update(
@@ -60,7 +60,7 @@ mod tests {
                   )
              "#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
 
@@ -76,7 +76,7 @@ mod tests {
                 .select(
                     "SELECT bool_field FROM airtable_table WHERE bool_field = False",
                     None,
-                    None,
+                    &[],
                 )
                 .expect("No results for a given query")
                 .filter_map(|r| {
@@ -87,7 +87,7 @@ mod tests {
             assert_eq!(results, vec![false]);
 
             let results = c
-                .select("SELECT string_field FROM airtable_table", None, None)
+                .select("SELECT string_field FROM airtable_table", None, &[])
                 .expect("No results for a given query")
                 .filter_map(|r| {
                     r.get_by_name::<&str, _>("string_field")
@@ -97,7 +97,7 @@ mod tests {
             assert_eq!(results, vec!["two", "three"]);
 
             let results = c
-                .select("SELECT numeric_field FROM airtable_table", None, None)
+                .select("SELECT numeric_field FROM airtable_table", None, &[])
                 .expect("No results for a given query")
                 .filter_map(|r| {
                     r.get_by_name::<pgrx::AnyNumeric, _>("numeric_field")
@@ -110,7 +110,7 @@ mod tests {
             );
 
             let results = c
-                .select("SELECT timestamp_field FROM airtable_table", None, None)
+                .select("SELECT timestamp_field FROM airtable_table", None, &[])
                 .expect("No results for a given query")
                 .filter_map(|r| {
                     r.get_by_name::<pgrx::prelude::Timestamp, _>("timestamp_field")
@@ -121,7 +121,7 @@ mod tests {
             assert_eq!(results, vec!["2023-07-19T06:39:15", "2023-07-20T06:39:15"]);
 
             let results = c
-                .select("SELECT object_field FROM airtable_table", None, None)
+                .select("SELECT object_field FROM airtable_table", None, &[])
                 .expect("No results for a given query")
                 .filter_map(|r| {
                     r.get_by_name::<pgrx::JsonB, _>("object_field")
@@ -133,7 +133,7 @@ mod tests {
             assert_eq!(results, vec!["bar", "baz"]);
 
             let results = c
-                .select("SELECT strings_array_field FROM airtable_table", None, None)
+                .select("SELECT strings_array_field FROM airtable_table", None, &[])
                 .expect("No results for a given query")
                 .filter_map(|r| {
                     r.get_by_name::<pgrx::JsonB, _>("strings_array_field")
@@ -147,7 +147,7 @@ mod tests {
                 .select(
                     "SELECT numerics_array_field FROM airtable_table",
                     None,
-                    None,
+                    &[],
                 )
                 .expect("No results for a given query")
                 .filter_map(|r| {
@@ -159,7 +159,7 @@ mod tests {
             assert_eq!(results, vec![vec![1, 2], vec![3, 4]]);
 
             let results = c
-                .select("SELECT bools_array_field FROM airtable_table", None, None)
+                .select("SELECT bools_array_field FROM airtable_table", None, &[])
                 .expect("No results for a given query")
                 .filter_map(|r| {
                     r.get_by_name::<pgrx::JsonB, _>("bools_array_field")
@@ -170,7 +170,7 @@ mod tests {
             assert_eq!(results, vec![vec![false], vec![true, false, true]]);
 
             let results = c
-                .select("SELECT objects_array_field FROM airtable_table", None, None)
+                .select("SELECT objects_array_field FROM airtable_table", None, &[])
                 .expect("No results for a given query")
                 .filter_map(|r| {
                     r.get_by_name::<pgrx::JsonB, _>("objects_array_field")
@@ -182,7 +182,7 @@ mod tests {
             assert_eq!(results, vec![vec!["bar", "baz"], vec!["qux"]]);
 
             let results = c
-                .select("SELECT string_field FROM airtable_view", None, None)
+                .select("SELECT string_field FROM airtable_view", None, &[])
                 .expect("No results for a given query")
                 .filter_map(|r| {
                     r.get_by_name::<&str, _>("string_field")

--- a/wrappers/src/fdw/airtable_fdw/tests.rs
+++ b/wrappers/src/fdw/airtable_fdw/tests.rs
@@ -144,11 +144,7 @@ mod tests {
             assert_eq!(results, vec![vec!["foo", "bar"], vec!["baz", "qux"]]);
 
             let results = c
-                .select(
-                    "SELECT numerics_array_field FROM airtable_table",
-                    None,
-                    &[],
-                )
+                .select("SELECT numerics_array_field FROM airtable_table", None, &[])
                 .expect("No results for a given query")
                 .filter_map(|r| {
                     r.get_by_name::<pgrx::JsonB, _>("numerics_array_field")

--- a/wrappers/src/fdw/auth0_fdw/tests.rs
+++ b/wrappers/src/fdw/auth0_fdw/tests.rs
@@ -31,12 +31,12 @@ mod tests {
             family_name: Some("Doe".to_string()),
         };
 
-        Spi::connect(|mut c| {
+        Spi::connect_mut(|c| {
             c.update(
                 r#"create foreign data wrapper auth0_wrapper
                          handler auth0_fdw_handler validator auth0_fdw_validator"#,
                 None,
-                None,
+                &[],
             )
             .expect("Failed to create foreign data wrapper");
             c.update(
@@ -47,7 +47,7 @@ mod tests {
                             api_key 'apiKey'
                          )"#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
             c.update(
@@ -81,7 +81,7 @@ mod tests {
                   )
              "#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
             /*
@@ -91,7 +91,7 @@ mod tests {
                 .select(
                     "SELECT * FROM auth0_users WHERE email = 'john@doe.com'",
                     None,
-                    None,
+                    &[],
                 )
                 .expect("Failed to select from auth0_users")
                 .map(|r| Auth0User {

--- a/wrappers/src/fdw/bigquery_fdw/tests.rs
+++ b/wrappers/src/fdw/bigquery_fdw/tests.rs
@@ -78,7 +78,7 @@ mod tests {
             */
 
             let results = c
-                .select("SELECT * FROM test_table", None, &[],)
+                .select("SELECT * FROM test_table", None, &[])
                 .unwrap()
                 .filter_map(|r| r.get_by_name::<&str, _>("name").unwrap())
                 .collect::<Vec<_>>();
@@ -98,7 +98,7 @@ mod tests {
             assert_eq!(results, vec!["bar"]);
 
             let results = c
-                .select("SELECT name FROM test_table_with_subquery", None, &[],)
+                .select("SELECT name FROM test_table_with_subquery", None, &[])
                 .unwrap()
                 .filter_map(|r| r.get_by_name::<&str, _>("name").unwrap())
                 .collect::<Vec<_>>();
@@ -106,7 +106,7 @@ mod tests {
             assert_eq!(results, vec!["FOO", "BAR"]);
 
             let results = c
-                .select("SELECT num::text FROM test_table ORDER BY num", None, &[],)
+                .select("SELECT num::text FROM test_table ORDER BY num", None, &[])
                 .unwrap()
                 .filter_map(|r| r.get_by_name::<&str, _>("num").unwrap())
                 .collect::<Vec<_>>();
@@ -116,15 +116,12 @@ mod tests {
             c.update(
                 "INSERT INTO test_table (id, name) VALUES ($1, $2)",
                 None,
-                &[
-                    42.into(),
-                    "baz".into(),
-                ]
+                &[42.into(), "baz".into()],
             )
             .unwrap();
 
             let results = c
-                .select("SELECT name FROM test_table", None, &[],)
+                .select("SELECT name FROM test_table", None, &[])
                 .unwrap()
                 .filter_map(|r| r.get_by_name::<&str, _>("name").unwrap())
                 .collect::<Vec<_>>();
@@ -133,29 +130,22 @@ mod tests {
             c.update(
                 "UPDATE test_table SET name = $1 WHERE id = $2",
                 None,
-                &[
-                    "qux".into(),
-                    42.into(),
-                ]
+                &["qux".into(), 42.into()],
             )
             .unwrap();
 
             let results = c
-                .select("SELECT name FROM test_table ORDER BY id", None, &[],)
+                .select("SELECT name FROM test_table ORDER BY id", None, &[])
                 .unwrap()
                 .filter_map(|r| r.get_by_name::<&str, _>("name").unwrap())
                 .collect::<Vec<_>>();
             assert_eq!(results, vec!["foo", "bar", "qux"]);
 
-            c.update(
-                "DELETE FROM test_table WHERE id = $1",
-                None,
-                &[42.into()]
-            )
-            .unwrap();
+            c.update("DELETE FROM test_table WHERE id = $1", None, &[42.into()])
+                .unwrap();
 
             let results = c
-                .select("SELECT name FROM test_table ORDER BY id", None, &[],)
+                .select("SELECT name FROM test_table ORDER BY id", None, &[])
                 .unwrap()
                 .filter_map(|r| r.get_by_name::<&str, _>("name").unwrap())
                 .collect::<Vec<_>>();

--- a/wrappers/src/fdw/bigquery_fdw/tests.rs
+++ b/wrappers/src/fdw/bigquery_fdw/tests.rs
@@ -6,12 +6,12 @@ mod tests {
 
     #[pg_test]
     fn bigquery_smoketest() {
-        Spi::connect(|mut c| {
+        Spi::connect_mut(|c| {
             c.update(
                 r#"CREATE FOREIGN DATA WRAPPER bigquery_wrapper
                          HANDLER big_query_fdw_handler VALIDATOR big_query_fdw_validator"#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
             c.update(
@@ -24,7 +24,7 @@ mod tests {
                            mock_auth 'true'
                          )"#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
             c.update(
@@ -50,7 +50,7 @@ mod tests {
                   )
              "#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
             c.update(
@@ -65,7 +65,7 @@ mod tests {
                   )
              "#,
                 None,
-                None,
+                &[],
             ).unwrap();
 
             /*
@@ -78,7 +78,7 @@ mod tests {
             */
 
             let results = c
-                .select("SELECT * FROM test_table", None, None)
+                .select("SELECT * FROM test_table", None, &[],)
                 .unwrap()
                 .filter_map(|r| r.get_by_name::<&str, _>("name").unwrap())
                 .collect::<Vec<_>>();
@@ -89,7 +89,7 @@ mod tests {
                 .select(
                     "SELECT name FROM test_table ORDER BY id DESC, name LIMIT 1",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap()
                 .filter_map(|r| r.get_by_name::<&str, _>("name").unwrap())
@@ -98,7 +98,7 @@ mod tests {
             assert_eq!(results, vec!["bar"]);
 
             let results = c
-                .select("SELECT name FROM test_table_with_subquery", None, None)
+                .select("SELECT name FROM test_table_with_subquery", None, &[],)
                 .unwrap()
                 .filter_map(|r| r.get_by_name::<&str, _>("name").unwrap())
                 .collect::<Vec<_>>();
@@ -106,7 +106,7 @@ mod tests {
             assert_eq!(results, vec!["FOO", "BAR"]);
 
             let results = c
-                .select("SELECT num::text FROM test_table ORDER BY num", None, None)
+                .select("SELECT num::text FROM test_table ORDER BY num", None, &[],)
                 .unwrap()
                 .filter_map(|r| r.get_by_name::<&str, _>("num").unwrap())
                 .collect::<Vec<_>>();
@@ -116,15 +116,15 @@ mod tests {
             c.update(
                 "INSERT INTO test_table (id, name) VALUES ($1, $2)",
                 None,
-                Some(vec![
-                    (PgOid::BuiltIn(PgBuiltInOids::INT8OID), 42.into_datum()),
-                    (PgOid::BuiltIn(PgBuiltInOids::TEXTOID), "baz".into_datum()),
-                ]),
+                &[
+                    42.into(),
+                    "baz".into(),
+                ]
             )
             .unwrap();
 
             let results = c
-                .select("SELECT name FROM test_table", None, None)
+                .select("SELECT name FROM test_table", None, &[],)
                 .unwrap()
                 .filter_map(|r| r.get_by_name::<&str, _>("name").unwrap())
                 .collect::<Vec<_>>();
@@ -133,15 +133,15 @@ mod tests {
             c.update(
                 "UPDATE test_table SET name = $1 WHERE id = $2",
                 None,
-                Some(vec![
-                    (PgOid::BuiltIn(PgBuiltInOids::TEXTOID), "qux".into_datum()),
-                    (PgOid::BuiltIn(PgBuiltInOids::INT8OID), 42.into_datum()),
-                ]),
+                &[
+                    "qux".into(),
+                    42.into(),
+                ]
             )
             .unwrap();
 
             let results = c
-                .select("SELECT name FROM test_table ORDER BY id", None, None)
+                .select("SELECT name FROM test_table ORDER BY id", None, &[],)
                 .unwrap()
                 .filter_map(|r| r.get_by_name::<&str, _>("name").unwrap())
                 .collect::<Vec<_>>();
@@ -150,15 +150,12 @@ mod tests {
             c.update(
                 "DELETE FROM test_table WHERE id = $1",
                 None,
-                Some(vec![(
-                    PgOid::BuiltIn(PgBuiltInOids::INT8OID),
-                    42.into_datum(),
-                )]),
+                &[42.into()]
             )
             .unwrap();
 
             let results = c
-                .select("SELECT name FROM test_table ORDER BY id", None, None)
+                .select("SELECT name FROM test_table ORDER BY id", None, &[],)
                 .unwrap()
                 .filter_map(|r| r.get_by_name::<&str, _>("name").unwrap())
                 .collect::<Vec<_>>();

--- a/wrappers/src/fdw/clickhouse_fdw/tests.rs
+++ b/wrappers/src/fdw/clickhouse_fdw/tests.rs
@@ -211,7 +211,7 @@ mod tests {
                     46i32.into(),
                     47i64.into(),
                     Timestamp::new(2025, 5, 1, 2, 3, 4.0).into(),
-                ]
+                ],
             )
             .unwrap();
             assert_eq!(

--- a/wrappers/src/fdw/cognito_fdw/tests.rs
+++ b/wrappers/src/fdw/cognito_fdw/tests.rs
@@ -6,12 +6,12 @@ mod tests {
 
     #[pg_test]
     fn cognito_smoketest() {
-        Spi::connect(|mut c| {
+        Spi::connect_mut(|c| {
             c.update(
                 r#"create foreign data wrapper cognito_wrapper
                          handler cognito_fdw_handler validator cognito_fdw_validator"#,
                 None,
-                None,
+                &[],
             )
             .expect("Failed to create foreign data wrapper");
             c.update(
@@ -25,15 +25,15 @@ mod tests {
                             region 'ap-southeast-1'
                          )"#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
-            c.update(r#"CREATE SCHEMA IF NOT EXISTS cognito"#, None, None)
+            c.update(r#"CREATE SCHEMA IF NOT EXISTS cognito"#, None, &[])
                 .unwrap();
             c.update(
                 r#"IMPORT FOREIGN SCHEMA cognito FROM SERVER cognito_server INTO cognito"#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
 
@@ -41,7 +41,7 @@ mod tests {
                 .select(
                     "SELECT * FROM cognito.users WHERE email = 'test1'",
                     None,
-                    None,
+                    &[],
                 )
                 .expect("One record for the query")
                 .collect::<Vec<_>>();

--- a/wrappers/src/fdw/firebase_fdw/tests.rs
+++ b/wrappers/src/fdw/firebase_fdw/tests.rs
@@ -6,12 +6,12 @@ mod tests {
 
     #[pg_test]
     fn firebase_smoketest() {
-        Spi::connect(|mut c| {
+        Spi::connect_mut(|c| {
             c.update(
                 r#"CREATE FOREIGN DATA WRAPPER firebase_wrapper
                          HANDLER firebase_fdw_handler VALIDATOR firebase_fdw_validator"#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
             c.update(
@@ -22,7 +22,7 @@ mod tests {
                           access_token 'owner'
                          )"#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
 
@@ -50,7 +50,7 @@ mod tests {
                 )
              "#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
 
@@ -58,7 +58,7 @@ mod tests {
                 .select(
                     "SELECT email FROM firebase_users order by email",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap()
                 .filter_map(|r| r.get_by_name::<&str, _>("email").unwrap())
@@ -81,12 +81,12 @@ mod tests {
                 )
              "#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
 
             let results = c
-                .select("SELECT name,attrs FROM firebase_docs", None, None)
+                .select("SELECT name,attrs FROM firebase_docs", None, &[])
                 .unwrap()
                 .filter_map(|r| {
                     r.get_by_name::<&str, _>("name").unwrap().zip(
@@ -122,12 +122,12 @@ mod tests {
                 )
              "#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
 
             let results = c
-                .select("SELECT name,attrs FROM firebase_docs_nested", None, None)
+                .select("SELECT name,attrs FROM firebase_docs_nested", None, &[])
                 .unwrap()
                 .filter_map(|r| {
                     r.get_by_name::<&str, _>("name").unwrap().zip(

--- a/wrappers/src/fdw/firebase_fdw/tests.rs
+++ b/wrappers/src/fdw/firebase_fdw/tests.rs
@@ -55,11 +55,7 @@ mod tests {
             .unwrap();
 
             let results = c
-                .select(
-                    "SELECT email FROM firebase_users order by email",
-                    None,
-                    &[],
-                )
+                .select("SELECT email FROM firebase_users order by email", None, &[])
                 .unwrap()
                 .filter_map(|r| r.get_by_name::<&str, _>("email").unwrap())
                 .collect::<Vec<_>>();

--- a/wrappers/src/fdw/iceberg_fdw/tests.rs
+++ b/wrappers/src/fdw/iceberg_fdw/tests.rs
@@ -57,11 +57,7 @@ mod tests {
             assert_eq!(results, vec!["APL"]);
 
             let results = c
-                .select(
-                    "SELECT icol FROM iceberg.bids WHERE icol = 1234",
-                    None,
-                    &[],
-                )
+                .select("SELECT icol FROM iceberg.bids WHERE icol = 1234", None, &[])
                 .unwrap()
                 .filter_map(|r| r.get_by_name::<i32, _>("icol").unwrap())
                 .collect::<Vec<_>>();

--- a/wrappers/src/fdw/iceberg_fdw/tests.rs
+++ b/wrappers/src/fdw/iceberg_fdw/tests.rs
@@ -7,12 +7,12 @@ mod tests {
 
     #[pg_test]
     fn iceberg_smoketest() {
-        Spi::connect(|mut c| {
+        Spi::connect_mut(|c| {
             c.update(
                 r#"CREATE FOREIGN DATA WRAPPER iceberg_wrapper
                      HANDLER iceberg_fdw_handler VALIDATOR iceberg_fdw_validator"#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
             c.update(
@@ -26,20 +26,20 @@ mod tests {
                        s3_endpoint_url 'http://localhost:8000'
                      )"#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
-            c.update(r#"CREATE SCHEMA IF NOT EXISTS iceberg"#, None, None)
+            c.update(r#"CREATE SCHEMA IF NOT EXISTS iceberg"#, None, &[])
                 .unwrap();
             c.update(
                 r#"IMPORT FOREIGN SCHEMA "docs_example" FROM SERVER iceberg_server INTO iceberg"#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
 
             let results = c
-                .select("SELECT * FROM iceberg.bids order by symbol", None, None)
+                .select("SELECT * FROM iceberg.bids order by symbol", None, &[])
                 .unwrap()
                 .filter_map(|r| r.get_by_name::<&str, _>("symbol").unwrap())
                 .collect::<Vec<_>>();
@@ -49,7 +49,7 @@ mod tests {
                 .select(
                     "SELECT * FROM iceberg.bids WHERE symbol in ('APL', 'XXX')",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap()
                 .filter_map(|r| r.get_by_name::<&str, _>("symbol").unwrap())
@@ -60,7 +60,7 @@ mod tests {
                 .select(
                     "SELECT icol FROM iceberg.bids WHERE icol = 1234",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap()
                 .filter_map(|r| r.get_by_name::<i32, _>("icol").unwrap())
@@ -71,7 +71,7 @@ mod tests {
                 .select(
                     "SELECT lcol FROM iceberg.bids WHERE lcol >= 5678",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap()
                 .filter_map(|r| r.get_by_name::<i64, _>("lcol").unwrap())
@@ -79,7 +79,7 @@ mod tests {
             assert_eq!(results, vec![5678]);
 
             let results = c
-                .select("SELECT symbol FROM iceberg.bids WHERE bcol", None, None)
+                .select("SELECT symbol FROM iceberg.bids WHERE bcol", None, &[])
                 .unwrap()
                 .filter_map(|r| r.get_by_name::<&str, _>("symbol").unwrap())
                 .collect::<Vec<_>>();
@@ -89,7 +89,7 @@ mod tests {
                 .select(
                     "SELECT symbol FROM iceberg.bids WHERE bcol is true",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap()
                 .filter_map(|r| r.get_by_name::<&str, _>("symbol").unwrap())
@@ -100,7 +100,7 @@ mod tests {
                 .select(
                     "SELECT symbol FROM iceberg.bids WHERE amt is null and ask = 11.22",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap()
                 .filter_map(|r| r.get_by_name::<&str, _>("symbol").unwrap())
@@ -111,7 +111,7 @@ mod tests {
                 .select(
                     "SELECT dt FROM iceberg.bids WHERE dt = date '2025-05-16'",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap()
                 .filter_map(|r| r.get_by_name::<pgrx::datum::Date, _>("dt").unwrap())
@@ -122,7 +122,7 @@ mod tests {
                 .select(
                     "SELECT tstz FROM iceberg.bids WHERE symbol = 'APL'",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap()
                 .filter_map(|r| {
@@ -144,7 +144,7 @@ mod tests {
                 .select(
                     "SELECT bin FROM iceberg.bids WHERE symbol = 'MCS'",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap()
                 .filter_map(|r| r.get_by_name::<&[u8], _>("bin").unwrap())
@@ -155,7 +155,7 @@ mod tests {
                 .select(
                     "SELECT uid FROM iceberg.bids WHERE symbol = 'MCS'",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap()
                 .filter_map(|r| r.get_by_name::<pgrx::datum::Uuid, _>("uid").unwrap())
@@ -166,7 +166,7 @@ mod tests {
                 .select(
                     "SELECT details FROM iceberg.bids WHERE symbol = 'APL'",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap()
                 .filter_map(|r| r.get_by_name::<pgrx::datum::JsonB, _>("details").unwrap())
@@ -178,7 +178,7 @@ mod tests {
                 .select(
                     "SELECT list FROM iceberg.bids WHERE symbol = 'MCS'",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap()
                 .filter_map(|r| r.get_by_name::<pgrx::datum::JsonB, _>("list").unwrap())
@@ -190,7 +190,7 @@ mod tests {
                 .select(
                     "SELECT map FROM iceberg.bids WHERE symbol = 'APL'",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap()
                 .filter_map(|r| r.get_by_name::<pgrx::datum::JsonB, _>("map").unwrap())

--- a/wrappers/src/fdw/logflare_fdw/tests.rs
+++ b/wrappers/src/fdw/logflare_fdw/tests.rs
@@ -5,12 +5,12 @@ mod tests {
 
     #[pg_test]
     fn logflare_smoketest() {
-        Spi::connect(|mut c| {
+        Spi::connect_mut(|c| {
             c.update(
                 r#"CREATE FOREIGN DATA WRAPPER logflare_wrapper
                          HANDLER logflare_fdw_handler VALIDATOR logflare_fdw_validator"#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
             c.update(
@@ -21,7 +21,7 @@ mod tests {
                             api_key 'apiKey'
                          )"#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
             c.update(
@@ -38,12 +38,12 @@ mod tests {
                   )
              "#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
 
             let results = c
-                .select("SELECT * FROM logflare_table", None, None)
+                .select("SELECT * FROM logflare_table", None, &[])
                 .unwrap()
                 .filter_map(|r| r.get_by_name::<&str, _>("id").unwrap())
                 .collect::<Vec<_>>();

--- a/wrappers/src/fdw/mssql_fdw/tests.rs
+++ b/wrappers/src/fdw/mssql_fdw/tests.rs
@@ -58,12 +58,12 @@ mod tests {
         })
         .expect("insert test data");
 
-        Spi::connect(|mut c| {
+        Spi::connect_mut(|c| {
             c.update(
                 r#"CREATE FOREIGN DATA WRAPPER mssql_wrapper
                          HANDLER mssql_fdw_handler VALIDATOR mssql_fdw_validator"#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
             c.update(
@@ -73,7 +73,7 @@ mod tests {
                            conn_string 'Server=localhost,1433;User=sa;Password=Password1234_56;Database=master;IntegratedSecurity=false;TrustServerCertificate=true;encrypt=DANGER_PLAINTEXT;ApplicationName=wrappers'
                          )"#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
             c.update(
@@ -91,7 +91,7 @@ mod tests {
                   )
              "#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
             c.update(
@@ -106,7 +106,7 @@ mod tests {
                   )
              "#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
 
@@ -114,7 +114,7 @@ mod tests {
                 .select(
                     "SELECT name, amount FROM mssql_users WHERE id = 42",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap()
                 .filter_map(|r| {
@@ -129,7 +129,7 @@ mod tests {
             );
 
             let results = c
-                .select("SELECT name FROM mssql_users ORDER BY id DESC", None, None)
+                .select("SELECT name FROM mssql_users ORDER BY id DESC", None, &[])
                 .unwrap()
                 .filter_map(|r| r.get_by_name::<&str, _>("name").unwrap())
                 .collect::<Vec<_>>();
@@ -139,7 +139,7 @@ mod tests {
                 .select(
                     "SELECT name FROM mssql_users ORDER BY id LIMIT 2 OFFSET 1",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap()
                 .filter_map(|r| r.get_by_name::<&str, _>("name").unwrap())
@@ -150,7 +150,7 @@ mod tests {
                 .select(
                     "SELECT name FROM mssql_users WHERE name like 'ba%' ORDER BY id",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap()
                 .filter_map(|r| r.get_by_name::<&str, _>("name").unwrap())
@@ -161,7 +161,7 @@ mod tests {
                 .select(
                     "SELECT name FROM mssql_users WHERE name not like 'ba%'",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap()
                 .filter_map(|r| r.get_by_name::<&str, _>("name").unwrap())
@@ -172,7 +172,7 @@ mod tests {
                 .select(
                     "SELECT name FROM mssql_users_cust_sql ORDER BY id",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap()
                 .filter_map(|r| r.get_by_name::<&str, _>("name").unwrap())
@@ -183,7 +183,7 @@ mod tests {
                 .select(
                     "SELECT name FROM mssql_users WHERE is_admin is true",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap()
                 .filter_map(|r| r.get_by_name::<&str, _>("name").unwrap())
@@ -193,7 +193,7 @@ mod tests {
 
         let result = std::panic::catch_unwind(|| {
             Spi::connect(|c| {
-                c.select("SELECT name FROM mssql_users LIMIT 2 OFFSET 1", None, None)
+                c.select("SELECT name FROM mssql_users LIMIT 2 OFFSET 1", None, &[])
                     .is_err()
             })
         });

--- a/wrappers/src/fdw/redis_fdw/tests.rs
+++ b/wrappers/src/fdw/redis_fdw/tests.rs
@@ -106,12 +106,12 @@ mod tests {
 
         // perform test
 
-        Spi::connect(|mut c| {
+        Spi::connect_mut(|c| {
             c.update(
                 r#"CREATE FOREIGN DATA WRAPPER redis_wrapper
                          HANDLER redis_fdw_handler VALIDATOR redis_fdw_validator"#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
             c.update(
@@ -121,7 +121,7 @@ mod tests {
                            conn_url 'redis://127.0.0.1'
                          )"#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
             c.update(
@@ -136,7 +136,7 @@ mod tests {
                     );
              "#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
             c.update(
@@ -151,7 +151,7 @@ mod tests {
                     );
              "#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
             c.update(
@@ -167,7 +167,7 @@ mod tests {
                     );
              "#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
             c.update(
@@ -182,7 +182,7 @@ mod tests {
                     );
              "#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
             c.update(
@@ -198,7 +198,7 @@ mod tests {
                     );
              "#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
             c.update(
@@ -214,7 +214,7 @@ mod tests {
                     );
              "#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
             c.update(
@@ -230,7 +230,7 @@ mod tests {
                     );
              "#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
             c.update(
@@ -246,7 +246,7 @@ mod tests {
                     );
              "#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
             c.update(
@@ -262,19 +262,19 @@ mod tests {
                     );
              "#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
 
             let results = c
-                .select("SELECT * FROM redis_list", None, None)
+                .select("SELECT * FROM redis_list", None, &[])
                 .unwrap()
                 .filter_map(|r| r.get_by_name::<&str, _>("element").unwrap())
                 .collect::<Vec<_>>();
             assert_eq!(results, vec!["foo", "bar", "42"]);
 
             let results = c
-                .select("SELECT * FROM redis_set ORDER BY 1", None, None)
+                .select("SELECT * FROM redis_set ORDER BY 1", None, &[])
                 .unwrap()
                 .filter_map(|r| r.get_by_name::<&str, _>("element").unwrap())
                 .collect::<Vec<_>>();
@@ -284,7 +284,7 @@ mod tests {
                 .select(
                     "SELECT key, value FROM redis_hash WHERE key = 'foo'",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap()
                 .filter_map(|r| {
@@ -296,7 +296,7 @@ mod tests {
             assert_eq!(results, vec![("foo", "bar")]);
 
             let results = c
-                .select("SELECT * FROM redis_zset", None, None)
+                .select("SELECT * FROM redis_zset", None, &[])
                 .unwrap()
                 .filter_map(|r| r.get_by_name::<&str, _>("element").unwrap())
                 .collect::<Vec<_>>();
@@ -306,7 +306,7 @@ mod tests {
                 .select(
                     "SELECT items::text FROM redis_stream ORDER BY id DESC",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap()
                 .filter_map(|r| r.get_by_name::<&str, _>("items").unwrap())
@@ -320,7 +320,7 @@ mod tests {
                 .select(
                     "SELECT key, items::text FROM redis_multi_lists ORDER BY key",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap()
                 .filter_map(|r| {
@@ -341,7 +341,7 @@ mod tests {
                 .select(
                     "SELECT key, items::text FROM redis_multi_sets ORDER BY key",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap()
                 .filter_map(|r| {
@@ -359,7 +359,7 @@ mod tests {
                 .select(
                     "SELECT key, items::text FROM redis_multi_hashes ORDER BY key",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap()
                 .filter_map(|r| {
@@ -380,7 +380,7 @@ mod tests {
                 .select(
                     "SELECT key, items::text FROM redis_multi_zsets ORDER BY key",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap()
                 .filter_map(|r| {

--- a/wrappers/src/fdw/s3_fdw/tests.rs
+++ b/wrappers/src/fdw/s3_fdw/tests.rs
@@ -5,12 +5,12 @@ mod tests {
 
     #[pg_test]
     fn s3_smoketest() {
-        Spi::connect(|mut c| {
+        Spi::connect_mut(|c| {
             c.update(
                 r#"CREATE FOREIGN DATA WRAPPER s3_wrapper
                      HANDLER s3_fdw_handler VALIDATOR s3_fdw_validator"#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
             c.update(
@@ -24,7 +24,7 @@ mod tests {
                        path_style_url 'true'
                      )"#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
 
@@ -45,7 +45,7 @@ mod tests {
                   )
              "#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
 
@@ -67,7 +67,7 @@ mod tests {
                   )
              "#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
 
@@ -87,7 +87,7 @@ mod tests {
                   )
              "#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
 
@@ -108,7 +108,7 @@ mod tests {
                   )
              "#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
 
@@ -129,7 +129,7 @@ mod tests {
                   )
              "#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
 
@@ -151,14 +151,14 @@ mod tests {
                   )
              "#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
 
             let check_test_table = |table| {
                 let sql = format!("SELECT * FROM {} ORDER BY name LIMIT 1", table);
                 let results = c
-                    .select(&sql, None, None)
+                    .select(&sql, None, &[])
                     .unwrap()
                     .filter_map(|r| {
                         r.get_by_name::<&str, _>("name")
@@ -178,7 +178,7 @@ mod tests {
             let check_parquet_table = |table| {
                 let sql = format!("SELECT * FROM {} ORDER BY id LIMIT 1", table);
                 let results = c
-                    .select(&sql, None, None)
+                    .select(&sql, None, &[])
                     .unwrap()
                     .filter_map(|r| {
                         r.get_by_name::<i32, _>("id")

--- a/wrappers/src/fdw/stripe_fdw/tests.rs
+++ b/wrappers/src/fdw/stripe_fdw/tests.rs
@@ -5,12 +5,12 @@ mod tests {
 
     #[pg_test]
     fn stripe_smoketest() {
-        Spi::connect(|mut c| {
+        Spi::connect_mut(|c| {
             c.update(
                 r#"CREATE FOREIGN DATA WRAPPER stripe_wrapper
                          HANDLER stripe_fdw_handler VALIDATOR stripe_fdw_validator"#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
             c.update(
@@ -21,20 +21,20 @@ mod tests {
                            api_key 'sk_test_51LUmojFkiV6mfx3cpEzG9VaxhA86SA4DIj3b62RKHnRC0nhPp2JBbAmQ1izsX9RKD8rlzvw2xpY54AwZtXmWciif00Qi8J0w3O'  -- Stripe API Key, required
                          )"#,
                 None,
-                None,
+                &[],
             ).unwrap();
-            c.update(r#"CREATE SCHEMA IF NOT EXISTS stripe"#, None, None)
+            c.update(r#"CREATE SCHEMA IF NOT EXISTS stripe"#, None, &[])
                 .unwrap();
             c.update(
                 r#"IMPORT FOREIGN SCHEMA stripe FROM SERVER my_stripe_server INTO stripe"#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
             c.update(
                 r#"IMPORT FOREIGN SCHEMA stripe FROM SERVER my_stripe_server INTO stripe"#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
             c.update(
@@ -42,7 +42,7 @@ mod tests {
                   LIMIT TO ("checkout_sessions", "customers", "balance", "non-exists")
                   FROM SERVER my_stripe_server INTO stripe"#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
             c.update(
@@ -50,12 +50,12 @@ mod tests {
                   EXCEPT ("checkout_sessions", "customers", "balance", "non-exists")
                   FROM SERVER my_stripe_server INTO stripe"#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
 
             let results = c
-                .select("SELECT * FROM stripe.accounts", None, None)
+                .select("SELECT * FROM stripe.accounts", None, &[])
                 .unwrap()
                 .filter_map(|r| {
                     r.get_by_name::<&str, _>("email")
@@ -70,7 +70,7 @@ mod tests {
                 .select(
                     "SELECT * FROM stripe.balance WHERE balance_type IS NOT NULL",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap()
                 .filter_map(|r| {
@@ -86,7 +86,7 @@ mod tests {
             );
 
             let results = c
-                .select("SELECT * FROM stripe.balance_transactions", None, None)
+                .select("SELECT * FROM stripe.balance_transactions", None, &[])
                 .unwrap()
                 .filter_map(|r| {
                     r.get_by_name::<i64, _>("amount")
@@ -100,7 +100,7 @@ mod tests {
             assert_eq!(results, vec![((((100, "usd"), 0), "available"), "charge")]);
 
             let results = c
-                .select("SELECT * FROM stripe.charges", None, None)
+                .select("SELECT * FROM stripe.charges", None, &[])
                 .unwrap()
                 .filter_map(|r| {
                     r.get_by_name::<i64, _>("amount")
@@ -112,7 +112,7 @@ mod tests {
             assert_eq!(results, vec![((100, "usd"), "succeeded")]);
 
             let results = c
-                .select("SELECT * FROM stripe.customers", None, None)
+                .select("SELECT * FROM stripe.customers", None, &[])
                 .unwrap()
                 .filter_map(|r| {
                     r.get_by_name::<&str, _>("id")
@@ -132,7 +132,7 @@ mod tests {
                 .select(
                     "SELECT attrs->>'id' as id FROM stripe.customers",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap()
                 .filter_map(|r| r.get_by_name::<&str, _>("id").unwrap())
@@ -143,7 +143,7 @@ mod tests {
                 .select(
                     "SELECT id, display_name FROM stripe.billing_meters",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap()
                 .filter_map(|r| r.get_by_name::<&str, _>("id").unwrap())
@@ -154,7 +154,7 @@ mod tests {
                 .select(
                     "SELECT attrs->>'id' as id FROM stripe.checkout_sessions",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap()
                 .filter_map(|r| r.get_by_name::<&str, _>("id").unwrap())
@@ -178,7 +178,7 @@ mod tests {
             // assert!(results.is_empty());
 
             let results = c
-                .select("SELECT * FROM stripe.disputes", None, None)
+                .select("SELECT * FROM stripe.disputes", None, &[])
                 .unwrap()
                 .filter_map(|r| {
                     r.get_by_name::<&str, _>("id")
@@ -193,7 +193,7 @@ mod tests {
             );
 
             let results = c
-                .select("SELECT * FROM stripe.events", None, None)
+                .select("SELECT * FROM stripe.events", None, &[])
                 .unwrap()
                 .filter_map(|r| {
                     r.get_by_name::<&str, _>("id")
@@ -207,7 +207,7 @@ mod tests {
             );
 
             let results = c
-                .select("SELECT * FROM stripe.files", None, None)
+                .select("SELECT * FROM stripe.files", None, &[])
                 .unwrap()
                 .filter_map(|r| {
                     r.get_by_name::<&str, _>("id")
@@ -232,7 +232,7 @@ mod tests {
             );
 
             let results = c
-                .select("SELECT * FROM stripe.file_links", None, None)
+                .select("SELECT * FROM stripe.file_links", None, &[])
                 .unwrap()
                 .filter_map(|r| {
                     r.get_by_name::<&str, _>("id")
@@ -253,7 +253,7 @@ mod tests {
             );
 
             let results = c
-                .select("SELECT * FROM stripe.invoices", None, None)
+                .select("SELECT * FROM stripe.invoices", None, &[])
                 .unwrap()
                 .filter_map(|r| {
                     r.get_by_name::<&str, _>("customer")
@@ -269,7 +269,7 @@ mod tests {
             );
 
             let results = c
-                .select("SELECT * FROM stripe.payment_intents", None, None)
+                .select("SELECT * FROM stripe.payment_intents", None, &[])
                 .unwrap()
                 .filter_map(|r| {
                     r.get_by_name::<i64, _>("amount")
@@ -280,7 +280,7 @@ mod tests {
             assert_eq!(results, vec![(1099, "usd")]);
 
             let results = c
-                .select("SELECT * FROM stripe.payouts", None, None)
+                .select("SELECT * FROM stripe.payouts", None, &[])
                 .unwrap()
                 .filter_map(|r| {
                     r.get_by_name::<&str, _>("id")
@@ -296,7 +296,7 @@ mod tests {
             );
 
             let results = c
-                .select("SELECT * FROM stripe.prices", None, None)
+                .select("SELECT * FROM stripe.prices", None, &[])
                 .unwrap()
                 .filter_map(|r| {
                     r.get_by_name::<&str, _>("id")
@@ -319,7 +319,7 @@ mod tests {
             );
 
             let results = c
-                .select("SELECT * FROM stripe.products", None, None)
+                .select("SELECT * FROM stripe.products", None, &[])
                 .unwrap()
                 .filter_map(|r| {
                     r.get_by_name::<&str, _>("name")
@@ -334,7 +334,7 @@ mod tests {
             );
 
             let results = c
-                .select("SELECT * FROM stripe.refunds", None, None)
+                .select("SELECT * FROM stripe.refunds", None, &[])
                 .unwrap()
                 .filter_map(|r| {
                     r.get_by_name::<&str, _>("id")
@@ -350,7 +350,7 @@ mod tests {
             );
 
             let results = c
-                .select("SELECT * FROM stripe.setup_attempts where setup_intent='seti_1Pgag7B7WZ01zgkWSgwGdb8Z'", None, None).unwrap()
+                .select("SELECT * FROM stripe.setup_attempts where setup_intent='seti_1Pgag7B7WZ01zgkWSgwGdb8Z'", None, &[]).unwrap()
                 .filter_map(|r| {
                     r.get_by_name::<&str, _>("id")
                         .unwrap()
@@ -367,7 +367,7 @@ mod tests {
             );
 
             let results = c
-                .select("SELECT * FROM stripe.setup_intents", None, None)
+                .select("SELECT * FROM stripe.setup_intents", None, &[])
                 .unwrap()
                 .filter_map(|r| {
                     r.get_by_name::<&str, _>("id")
@@ -385,7 +385,7 @@ mod tests {
             );
 
             let results = c
-                .select("SELECT * FROM stripe.subscriptions", None, None)
+                .select("SELECT * FROM stripe.subscriptions", None, &[])
                 .unwrap()
                 .filter_map(|r| {
                     r.get_by_name::<&str, _>("customer")
@@ -410,7 +410,7 @@ mod tests {
             );
 
             let results = c
-                .select("SELECT * FROM stripe.topups", None, None)
+                .select("SELECT * FROM stripe.topups", None, &[])
                 .unwrap()
                 .filter_map(|r| {
                     r.get_by_name::<&str, _>("id")
@@ -426,7 +426,7 @@ mod tests {
             );
 
             let results = c
-                .select("SELECT * FROM stripe.transfers", None, None)
+                .select("SELECT * FROM stripe.transfers", None, &[])
                 .unwrap()
                 .filter_map(|r| {
                     r.get_by_name::<&str, _>("id")
@@ -457,14 +457,14 @@ mod tests {
                 VALUES ('test@test.com', 'test name', null)
                 "#,
                 None,
-                None,
+                &[],
             );
 
             let results = c
                 .select(
                     "SELECT * FROM stripe.customers WHERE email = 'test@test.com'",
                     None,
-                    None,
+                    &[],
                 ).unwrap()
                 .filter_map(|r| {
                     r.get_by_name::<&str, _>("email")
@@ -484,14 +484,14 @@ mod tests {
                 WHERE email = 'test@test.com'
                 "#,
                 None,
-                None,
+                &[],
             );
 
             let results = c
                 .select(
                     "SELECT * FROM stripe.customers WHERE email = 'test@test.com'",
                     None,
-                    None,
+                    &[],
                 ).unwrap()
                 .filter_map(|r| {
                     r.get_by_name::<&str, _>("email").unwrap().and_then(|v| v.value::<&str>()).zip(
@@ -510,14 +510,14 @@ mod tests {
                 DELETE FROM stripe.customers WHERE email = 'test@test.com'
                 "#,
                 None,
-                None,
+                &[],
             );
 
             let results = c
                 .select(
                     "SELECT * FROM stripe.customers WHERE email = 'test@test.com'",
                     None,
-                    None,
+                    &[],
                 ).unwrap()
                 .filter_map(|r| {
                     r.get_by_name::<&str, _>("email").unwrap().and_then(|v| v.value::<&str>()).zip(

--- a/wrappers/src/fdw/stripe_fdw/tests.rs
+++ b/wrappers/src/fdw/stripe_fdw/tests.rs
@@ -129,11 +129,7 @@ mod tests {
             );
 
             let results = c
-                .select(
-                    "SELECT attrs->>'id' as id FROM stripe.customers",
-                    None,
-                    &[],
-                )
+                .select("SELECT attrs->>'id' as id FROM stripe.customers", None, &[])
                 .unwrap()
                 .filter_map(|r| r.get_by_name::<&str, _>("id").unwrap())
                 .collect::<Vec<_>>();

--- a/wrappers/src/fdw/wasm_fdw/bindings/v1.rs
+++ b/wrappers/src/fdw/wasm_fdw/bindings/v1.rs
@@ -100,7 +100,7 @@ impl From<HostParam> for GuestParam {
     fn from(value: HostParam) -> Self {
         Self {
             id: value.id as u32,
-            type_oid: value.type_oid.as_u32(),
+            type_oid: value.type_oid.to_u32(),
         }
     }
 }

--- a/wrappers/src/fdw/wasm_fdw/bindings/v2.rs
+++ b/wrappers/src/fdw/wasm_fdw/bindings/v2.rs
@@ -112,7 +112,7 @@ impl From<HostParam> for GuestParam {
     fn from(value: HostParam) -> Self {
         Self {
             id: value.id as u32,
-            type_oid: value.type_oid.as_u32(),
+            type_oid: value.type_oid.to_u32(),
         }
     }
 }

--- a/wrappers/src/fdw/wasm_fdw/tests.rs
+++ b/wrappers/src/fdw/wasm_fdw/tests.rs
@@ -5,12 +5,12 @@ mod tests {
 
     #[pg_test]
     fn wasm_smoketest() {
-        Spi::connect(|mut c| {
+        Spi::connect_mut(|c| {
             c.update(
                 r#"CREATE FOREIGN DATA WRAPPER wasm_wrapper
                      HANDLER wasm_fdw_handler VALIDATOR wasm_fdw_validator"#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
 
@@ -29,7 +29,7 @@ mod tests {
                        private_key E'-----BEGIN PRIVATE KEY-----\nMIIEvwIBADANBgkqhkiG9w0BAQEFAASCBKkwggSlAgEAAoIBAQCOQv0mMe1yElR8\nhiQgduWu7OrMR3iW8xbu+i04LkMDKB/JtdMl1Mq3Gs/XWUB07BOIytcK4L7k1Z/3\nnkTGvib85S5+VLsngBzWltltvCOfnM2uCLWHmVpfMR1WVFrCU1r7NP92U2APpwvN\ncJps39VNyQWTm+TvQN25enqAC2uR6xdvItb86dn4Tab3KcAXj0f0qHompa8SSwBO\nGZFpgAjt7QFPWTniNQyBU7wXTntwV+a2WC/bf1i9MRAf8bqSr+yqijLHVGrmBPSb\njmvo/8bj69DzeY2//gZXAMe1m6cEjXPm2MY/POd66Xg1YZDzYsv95GZ54kJ+EgEF\n9rjsi/J5AgMBAAECggEAAsG9kh3pkgpU5Mzcqlxjew5QRoEkDxjK2vqyIaKT3d3L\nL+d8HgGPpBi66ltqalmgz0fO/wD38gtJvEyu3IMW0lPGoOAXeF59MJNfx0acEh3B\nxpuYmPYZ0DptbRzZXWasHq4aPTrEY8lC60pBU9bKlWVN3FxrBU/mfA+pjA2smflC\n54brJTsSb1/1xAExxsvB2Leb6VcNWKRCaN6Z4gdWd1Qofi080LVWxE3MXhxHpTMj\nVf3KHhKI5DHJXlZPU/w4KXOlp99UH0vnx3EJzD07kI+nR2k7tfh8PxwFzn8g6hEC\nK9Q+HmzUUTxFh1M8eXi7IMRjLRJThVSl/Kbqr6cpeQKBgQC+410aRuHUteQIgJBQ\nbceAOjEh5MetByIEFdXLEgYspl1rSjN/JoIMUguyJ8KZGj5G3NaRaJklNOofYekI\nhIL3SBWZ9U58MJVMnSUVeBdazCu0k9HnOfOFrFJIDoRPBfjnP0UJmC+9ggoVayOX\nVW5psrxGiQXWiG7mho1bshSlNwKBgQC+yX1wFSF8gGsAb41iw60K9W+O5PLVWxAu\nYst8CQTY64RVctvAypWtNTb4nmIBe9aX9k5loe+uv8Zse/t1hgCVGR7n70EyT9Y+\nGNrGqYtVjtZQ+L+dAivrlUKsTDGqzWldUTg7gpOqkFaQbV0O11ytyKJKYXCpTrL2\nwib6V4X9zwKBgQCllTJAxfXFfxZUbblBm0iwKUpPXVX7+LEAHDS9F2B1wMZOeCod\nhLjQmSb+HlFGX6Zf79bMgZA+3xyrplHviorUmBns2AaB4d7Qe4wciHSx1WOgG427\n5uAgNy+Uw8rvhX24koB/Zx0aZT/7/lj8QCYr19hL0zZWNzkEDPl37gzMlwKBgQC3\noOsww8XVNSzH4JZupvOYhp53JHltTRaH7uL3YR7fQd++9qv4JYRmj793D8o4r17e\nKF1QiMpOoZpzs+lVNkK9Ps52YduYdys33WhEqc7H7JDuolya3Ao11xWzDCsJwGdX\nP+MltAo4sm/+1qQosrQrN96sRJjQ/ERYKIqnjTIUFQKBgQC6xaC5SB1UMepFbTVa\n2tuRuYwcrU/NxjeW85SAyeyv2dMg7S+Ot8mnA1Js2O0NHlczUZgRZalYkCuSUE78\nb6rIbezIW2azrw3tqAAPLsB+rhXvaUpICoybu+j6aCiqtZYsDx7zIj/FTD27Tpwx\nYfLx1Erqd3vM/LzOIaIOqlfETw==\n-----END PRIVATE KEY-----'
                        )"#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
             c.update(
@@ -48,12 +48,12 @@ mod tests {
                   )
              "#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
 
             let results = c
-                .select("SELECT * FROM snowflake_mytable WHERE id = 42", None, None)
+                .select("SELECT * FROM snowflake_mytable WHERE id = 42", None, &[])
                 .unwrap()
                 .filter_map(|r| r.get_by_name::<&str, _>("name").unwrap())
                 .collect::<Vec<_>>();
@@ -71,15 +71,15 @@ mod tests {
                        api_key '1234567890'
                      )"#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
-            c.update(r#"CREATE SCHEMA IF NOT EXISTS paddle"#, None, None)
+            c.update(r#"CREATE SCHEMA IF NOT EXISTS paddle"#, None, &[])
                 .unwrap();
             c.update(
                 r#"IMPORT FOREIGN SCHEMA paddle FROM SERVER paddle_server INTO paddle"#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
 
@@ -87,7 +87,7 @@ mod tests {
                 .select(
                     "SELECT * FROM paddle.customers WHERE id = 'ctm_01hymwgpkx639a6mkvg99563sp'",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap()
                 .filter_map(|r| r.get_by_name::<&str, _>("email").unwrap())
@@ -106,7 +106,7 @@ mod tests {
                        api_key '1234567890'
                      )"#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
             c.update(
@@ -125,7 +125,7 @@ mod tests {
                   )
              "#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
 
@@ -133,7 +133,7 @@ mod tests {
                 .select(
                     "SELECT * FROM notion_pages WHERE id = '5a67c86f-d0da-4d0a-9dd7-f4cf164e6247'",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap()
                 .filter_map(|r| r.get_by_name::<&str, _>("url").unwrap())
@@ -156,7 +156,7 @@ mod tests {
                        api_key '1234567890'
                      )"#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
             c.update(
@@ -173,12 +173,12 @@ mod tests {
                   )
              "#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
 
             let results = c
-                .select("SELECT * FROM calendly_event_types", None, None)
+                .select("SELECT * FROM calendly_event_types", None, &[])
                 .unwrap()
                 .filter_map(|r| r.get_by_name::<&str, _>("uri").unwrap())
                 .collect::<Vec<_>>();
@@ -199,7 +199,7 @@ mod tests {
                        api_key '1234567890'
                      )"#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
             c.update(
@@ -216,12 +216,12 @@ mod tests {
                   )
              "#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
 
             let results = c
-                .select("SELECT * FROM cal_my_profile", None, None)
+                .select("SELECT * FROM cal_my_profile", None, &[])
                 .unwrap()
                 .filter_map(|r| r.get_by_name::<i64, _>("id").unwrap())
                 .collect::<Vec<_>>();
@@ -241,7 +241,7 @@ mod tests {
                        api_token 'ccc'
                      )"#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
             c.update(
@@ -257,12 +257,12 @@ mod tests {
                   )
              "#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
 
             let results = c
-                .select("SELECT * FROM cfd1_table order by id", None, None)
+                .select("SELECT * FROM cfd1_table order by id", None, &[])
                 .unwrap()
                 .filter_map(|r| r.get_by_name::<i64, _>("id").unwrap())
                 .collect::<Vec<_>>();
@@ -280,7 +280,7 @@ mod tests {
                        api_key 'ccc'
                      )"#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
             c.update(
@@ -301,12 +301,12 @@ mod tests {
                   )
              "#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
 
             let results = c
-                .select("SELECT * FROM clerk_table", None, None)
+                .select("SELECT * FROM clerk_table", None, &[])
                 .unwrap()
                 .filter_map(|r| r.get_by_name::<&str, _>("id").unwrap())
                 .collect::<Vec<_>>();
@@ -324,7 +324,7 @@ mod tests {
                        api_key 'ccc'
                      )"#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
             c.update(
@@ -343,12 +343,12 @@ mod tests {
                   )
              "#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
 
             let results = c
-                .select("SELECT * FROM orb_table", None, None)
+                .select("SELECT * FROM orb_table", None, &[])
                 .unwrap()
                 .filter_map(|r| r.get_by_name::<&str, _>("id").unwrap())
                 .collect::<Vec<_>>();
@@ -366,7 +366,7 @@ mod tests {
                        api_key 'ccc'
                      )"#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
             c.update(
@@ -387,12 +387,12 @@ mod tests {
                   )
              "#,
                 None,
-                None,
+                &[],
             )
             .unwrap();
 
             let results = c
-                .select("SELECT id, user_id FROM hubspot_table", None, None)
+                .select("SELECT id, user_id FROM hubspot_table", None, &[])
                 .unwrap()
                 .filter_map(|r| r.get_by_name::<&str, _>("user_id").unwrap())
                 .collect::<Vec<_>>();

--- a/wrappers/src/fdw/wasm_fdw/wasm_fdw.rs
+++ b/wrappers/src/fdw/wasm_fdw/wasm_fdw.rs
@@ -157,7 +157,7 @@ fn download_from_url(
 fn get_cache_path(url: &str, name: &str, version: &str) -> WasmFdwResult<PathBuf> {
     let hash = Sha256::digest(format!(
         "{}:{}:{}@{}",
-        unsafe { pg_sys::GetUserId().as_u32() },
+        unsafe { pg_sys::GetUserId().to_u32() },
         url,
         name,
         version

--- a/wrappers/src/stats.rs
+++ b/wrappers/src/stats.rs
@@ -90,10 +90,9 @@ pub(crate) fn inc_stats(fdw_name: &str, metric: Metric, inc: i64) {
 
     if let Err(e) = Spi::run_with_args(
         &sql,
-        Some(vec![
-            (PgBuiltInOids::TEXTOID.oid(), fdw_name.into_datum()),
-            (PgBuiltInOids::INT8OID.oid(), inc.into_datum()),
-        ]),
+        &[
+            fdw_name.into(), inc.into(),
+        ],
     ) {
         report_warning(&format!("Failed to increment stats: {}", e));
     }
@@ -120,7 +119,7 @@ pub(crate) fn get_metadata(fdw_name: &str) -> Option<JsonB> {
 
     match Spi::get_one_with_args(
         &sql,
-        vec![(PgBuiltInOids::TEXTOID.oid(), fdw_name.into_datum())],
+        &[fdw_name.into()],
     ) {
         Ok(metadata) => metadata,
         Err(e) => {
@@ -163,10 +162,9 @@ pub(crate) fn set_metadata(fdw_name: &str, metadata: Option<JsonB>) {
 
     if let Err(err) = Spi::run_with_args(
         &sql,
-        Some(vec![
-            (PgBuiltInOids::TEXTOID.oid(), fdw_name.into_datum()),
-            (PgBuiltInOids::JSONBOID.oid(), metadata.into_datum()),
-        ]),
+        &[
+            fdw_name.into(), metadata.into(),
+        ],
     ) {
         report_warning(&format!("Failed to set metadata: {}", err));
     }

--- a/wrappers/src/stats.rs
+++ b/wrappers/src/stats.rs
@@ -88,12 +88,7 @@ pub(crate) fn inc_stats(fdw_name: &str, metric: Metric, inc: i64) {
         stats_table, metric, metric, metric, metric
     );
 
-    if let Err(e) = Spi::run_with_args(
-        &sql,
-        &[
-            fdw_name.into(), inc.into(),
-        ],
-    ) {
+    if let Err(e) = Spi::run_with_args(&sql, &[fdw_name.into(), inc.into()]) {
         report_warning(&format!("Failed to increment stats: {}", e));
     }
 }
@@ -117,10 +112,7 @@ pub(crate) fn get_metadata(fdw_name: &str) -> Option<JsonB> {
 
     let sql = format!("select metadata from {} where fdw_name = $1", stats_table);
 
-    match Spi::get_one_with_args(
-        &sql,
-        &[fdw_name.into()],
-    ) {
+    match Spi::get_one_with_args(&sql, &[fdw_name.into()]) {
         Ok(metadata) => metadata,
         Err(e) => {
             report_warning(&format!("Failed to get metadata: {}", e));
@@ -160,12 +152,7 @@ pub(crate) fn set_metadata(fdw_name: &str, metadata: Option<JsonB>) {
         stats_table
     );
 
-    if let Err(err) = Spi::run_with_args(
-        &sql,
-        &[
-            fdw_name.into(), metadata.into(),
-        ],
-    ) {
+    if let Err(err) = Spi::run_with_args(&sql, &[fdw_name.into(), metadata.into()]) {
         report_warning(&format!("Failed to set metadata: {}", err));
     }
 }


### PR DESCRIPTION
PostgreSQL 12 has been unsupported for over half a year, and pgrx v0.14.0 officially dropped support for it.

The other reason I propose this version bumping is that pgrx v0.12.9 failed to install pg 12 on my mac.

This patch removes PG12 support from the wrappers by upgrading pgrx to v0.14.3. Some code adjustments were required due to changes introduced in the newer pgrx versions.

For reference, see the following updates in pgrx:

- [force using extern "C-unwind" for functions marked with `#[pg_guard]`][1]
- [Made SPI query arguments type safe][2]
- [Added connect_mut for data changing SPI operations][3]
- [Renamed Oid::as_u32 to to_u32][4]

[1]: https://github.com/pgcentralfoundation/pgrx/pull/2014
[2]: https://github.com/pgcentralfoundation/pgrx/pull/1858
[3]: https://github.com/pgcentralfoundation/pgrx/pull/1913
[4]: https://github.com/pgcentralfoundation/pgrx/pull/2011

