### PR TITLE
fix: [DATAENG-979] memory context layout refactoring

### DIFF
--- a/supabase-wrappers/src/utils.rs
+++ b/supabase-wrappers/src/utils.rs
@@ -2,11 +2,12 @@
 //!
 
 use crate::interface::{Cell, Column, Row};
-use pgrx::list::List;
-use pgrx::pg_sys::panic::{ErrorReport, ErrorReportable};
-use pgrx::spi::Spi;
-use pgrx::IntoDatum;
-use pgrx::*;
+use pgrx::{
+    list::List,
+    pg_sys::panic::{ErrorReport, ErrorReportable},
+    spi::Spi,
+    IntoDatum, *,
+};
 use std::ffi::c_void;
 use std::ffi::CStr;
 use std::num::NonZeroUsize;
@@ -296,12 +297,10 @@ pub(super) unsafe fn extract_target_columns(
 // trait for "serialize" and "deserialize" state from specified memory context,
 // so that it is safe to be carried between the planning and the execution
 pub(super) trait SerdeList {
-    unsafe fn serialize_to_list(state: PgBox<Self>, mut ctx: PgMemoryContexts) -> *mut pg_sys::List
+    unsafe fn serialize_to_list(state: PgBox<Self>) -> *mut pg_sys::List
     where
         Self: Sized,
     {
-        let mut old_ctx = ctx.set_as_current();
-
         let ret = memcx::current_context(|mcx| {
             let mut ret = List::<*mut c_void>::Nil;
             let val = state.into_pg() as i64;
@@ -317,8 +316,6 @@ pub(super) trait SerdeList {
             ret.unstable_push_in_context(cst as _, mcx);
             ret.into_ptr()
         });
-
-        old_ctx.set_as_current();
 
         ret
     }


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to do some memory context layout refactoring in the Wrappers framework.

## What is the current behavior?

The current memory context layout in the framework is like below:

- CacheMemoryContext
  - WrappersRootMemCtx (long-live)
    - Wrappers_scan_xxx (long-live)
    - Wrappers_scan_yyy (long-live)
    - Wrappers_modify_xxx (long-live)
    - ...

Each foreign table has exactly one scan and modify memory context with its oid as name suffix. Those memory context are created under the single root `WrappersRootMemCtx` which is under `CacheMemoryContext`.

The memory context will never be deleted after creation, but it will be reset at the beginning of the query, in `GetForeignRelSize` (scan) and `PlanForeignModify` (modify) callbacks respectively.

This caused problem when a query has multiple foreign scans planned and those callbacks sequence are overlapped. For example, the below query is to get estimated row count in the foreign table `stripe.products`:

```sql
CREATE OR REPLACE FUNCTION pg_temp.count_estimate(
    query text
) RETURNS integer LANGUAGE plpgsql AS $$
DECLARE
    plan jsonb;
BEGIN
    EXECUTE 'EXPLAIN (FORMAT JSON)' || query INTO plan;
    RETURN plan->0->'Plan'->'Plan Rows';
END;
$$;

with approximation as (
    select reltuples as estimate
    from pg_class
    where oid = 173709  -- the foreign table oid
)
select 
  case 
    when estimate = -1 then (select pg_temp.count_estimate('select * from stripe.products;'))
    when estimate > 50000 then estimate
    else (select count(*) from stripe.products)
  end as count,
  estimate = -1 or estimate > 50000 as is_estimate
from approximation;
```

Its callback sequence is like below:

1. get_foreign_rel_size
2. get_foreign_paths
3. get_foreign_plan
4. begin_foreign_scan
5. get_foreign_rel_size
6. get_foreign_paths
7. get_foreign_plan
8. begin_foreign_scan
9. explain_foreign_scan
10. end_foreign_scan
11. end_foreign_scan

For the same foreign table `stripe.products`, there are 2 foreign scans planned and executed in overlapped sequence.

1. 1,2,3,4,10
2. 5,6,7,8,9,10

But there is only one memory context associated with that foreign table, so the 2nd `get_foreign_rel_size` reset that memory context before the 1st foreign scan finished. This caused the 1st scan's `end_foreign_scan` called on a freed instance.

## What is the new behavior?

Change the memory context layout to below:

- CacheMemoryContext
  - WrappersRootMemCtx (long-live)
    - Wrappers_scan_xxx (ephemeral)
    - Wrappers_scan_xxx (ephemeral)
    - Wrappers_scan_yyy (ephemeral)
    - Wrappers_modify_xxx (ephemeral)
    - ...

Each foreign scan will have its own memory context created (even name is still same), those memory context are short-lived and will be created in `GetForeignRelSize` (scan) and `PlanForeignModify` (modify) , and deleted in  `EndForeignScan` and `EndForeignModify` respectively.

So for the above example, there will 2 memory context (same name) created for the 2 scans respectively, so their callback sequence won't affect each other.

## Additional context

N/A
