### PR TITLE
fix(iceberg): refactor sever options passdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3583,8 +3583,9 @@ dependencies = [
 
 [[package]]
 name = "iceberg"
-version = "0.5.0"
-source = "git+https://github.com/apache/iceberg-rust?rev=12485be4a30848213faea62740ad7cb5a41bd6f2#12485be4a30848213faea62740ad7cb5a41bd6f2"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ad4b76a13ef469b09493330c4360630499949f4984478b77d6a70d252caf8b4"
 dependencies = [
  "anyhow",
  "apache-avro",
@@ -3633,8 +3634,9 @@ dependencies = [
 
 [[package]]
 name = "iceberg-catalog-rest"
-version = "0.5.0"
-source = "git+https://github.com/apache/iceberg-rust?rev=12485be4a30848213faea62740ad7cb5a41bd6f2#12485be4a30848213faea62740ad7cb5a41bd6f2"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d744269adcd9a89cea578b6e8443186cb9d5e7d41a47679f3b1d5b71842820e"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3653,8 +3655,8 @@ dependencies = [
 
 [[package]]
 name = "iceberg-catalog-s3tables"
-version = "0.5.0"
-source = "git+https://github.com/apache/iceberg-rust?rev=12485be4a30848213faea62740ad7cb5a41bd6f2#12485be4a30848213faea62740ad7cb5a41bd6f2"
+version = "0.5.1"
+source = "git+https://github.com/burmecia/iceberg-rust?rev=e565bc43c1b9fa6b25a601f68bcec1423a984cc1#e565bc43c1b9fa6b25a601f68bcec1423a984cc1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/docs/catalog/iceberg.md
+++ b/docs/catalog/iceberg.md
@@ -345,9 +345,9 @@ create server iceberg_server
   options (
     aws_access_key_id '<R2_access_key_ID>',
     aws_secret_access_key '<R2_secret_access_key>',
-	token '<R2 API token>',
-	warehouse 'xxx_r2-data-catalog-tutorial',
-	"s3.endpoint" 'https://xxx.r2.cloudflarestorage.com',
+    token '<R2 API token>',
+    warehouse 'xxx_r2-data-catalog-tutorial',
+    "s3.endpoint" 'https://xxx.r2.cloudflarestorage.com',
     catalog_uri 'https://catalog.cloudflarestorage.com/xxx/r2-data-catalog-tutorial'
   );
 ```

--- a/docs/catalog/iceberg.md
+++ b/docs/catalog/iceberg.md
@@ -43,9 +43,9 @@ By default, Postgres stores FDW credentials inside `pg_catalog.pg_foreign_server
 -- Save your AWS credentials in Vault and retrieve the created
 -- `aws_access_key_id` and `aws_secret_access_key`
 select vault.create_secret(
-  '<access key id>',
-  'aws_access_key_id',
-  'AWS access key for Wrappers'
+  '<access key id>',  -- secret to be encrypted
+  'aws_access_key_id',  -- secret name
+  'AWS access key for Wrappers'  -- secret description
 );
 select vault.create_secret(
   '<secret access key>'
@@ -56,24 +56,26 @@ select vault.create_secret(
 
 ### Connecting to Icerberg
 
-We need to provide Postgres with the credentials to connect to Iceberg. We can do this using the `create server` command:
+We need to provide Postgres with the credentials to connect to Iceberg. We can do this using the `create server` command.
+
+For any server options need to be stored in Vault, you can add a prefix `vault_` to its name and use the secret ID returned from the `select vault.create_secret()` statement as the option value.
 
 #### Connecting to AWS S3 Tables
 
 === "With Vault"
 
     ```sql
-    create server iceberg_fdw
+    create server iceberg_server
       foreign data wrapper iceberg_wrapper
       options (
         -- The key id saved in Vault from above
-        vault_access_key_id '<key_ID>',
+        vault_aws_access_key_id '<key_ID>',
 
         -- The secret id saved in Vault from above
-        vault_secret_access_key '<secret_key>',
+        vault_aws_secret_access_key '<secret_key>',
 
         -- AWS region
-        aws_region 'us-east-1',
+        region_name 'us-east-1',
 
         -- AWS S3 table bucket ARN
         aws_s3table_bucket_arn 'arn:aws:s3tables:us-east-1:204203087419:bucket/my-table-bucket'
@@ -83,7 +85,7 @@ We need to provide Postgres with the credentials to connect to Iceberg. We can d
 === "Without Vault"
 
     ```sql
-    create server iceberg_fdw
+    create server iceberg_server
       foreign data wrapper iceberg_wrapper
       options (
         -- The AWS access key ID
@@ -93,42 +95,45 @@ We need to provide Postgres with the credentials to connect to Iceberg. We can d
         aws_secret_access_key '<secret_key>',
 
         -- AWS region
-        aws_region 'us-east-1',
+        region_name 'us-east-1',
 
         -- AWS S3 table bucket ARN
         aws_s3table_bucket_arn 'arn:aws:s3tables:us-east-1:204203087419:bucket/my-table-bucket'
       );
     ```
 
-#### Connecting to Iceberg REST Catalog + AWS S3
+#### Connecting to Iceberg REST Catalog + AWS S3 (or compatible) storage
 
 === "With Vault"
 
     ```sql
-    create server iceberg_fdw
+    create server iceberg_server
       foreign data wrapper iceberg_wrapper
       options (
         -- The key id saved in Vault from above
-        vault_access_key_id '<key_ID>',
+        vault_aws_access_key_id '<key_ID>',
 
         -- The secret id saved in Vault from above
-        vault_secret_access_key '<secret_key>',
+        vault_aws_secret_access_key '<secret_key>',
 
         -- AWS region
-        aws_region 'us-east-1',
+        region_name 'us-east-1',
 
         -- Iceberg REST Catalog URI
         catalog_uri 'https://rest-catalog/ws',
 
+        -- Warehouse name
+        warehouse 'warehouse',
+
         -- AWS S3 endpoint URL, optional
-        s3_endpoint_url 'https://alternative-s3-storage:8000'
+        "s3.endpoint" 'https://alternative-s3-storage:8000'
       );
     ```
 
 === "Without Vault"
 
     ```sql
-    create server iceberg_fdw
+    create server iceberg_server
       foreign data wrapper iceberg_wrapper
       options (
         -- The key id saved in Vault from above
@@ -138,15 +143,22 @@ We need to provide Postgres with the credentials to connect to Iceberg. We can d
         aws_secret_access_key '<secret_key>',
 
         -- AWS region
-        aws_region 'us-east-1',
+        region_name 'us-east-1',
 
         -- Iceberg REST Catalog URI
         catalog_uri 'https://rest-catalog/ws',
 
+        -- Warehouse name
+        warehouse 'warehouse',
+
         -- AWS S3 endpoint URL, optional
-        s3_endpoint_url 'https://alternative-s3-storage:8000'
+        "s3.endpoint" 'https://alternative-s3-storage:8000'
       );
     ```
+
+!!! info
+
+    For other optional S3 options, please refer to [PyIceberg S3 Configuration](https://py.iceberg.apache.org/configuration/#s3).
 
 ### Create a schema
 
@@ -170,17 +182,18 @@ For example, using below SQL can automatically create foreign tables in the `ice
 
 ```sql
 -- create all the foreign tables from Iceberg "docs_example" namespace
-import foreign schema "docs_example" from server iceberg_server into iceberg;
+import foreign schema "docs_example"
+  from server iceberg_server into iceberg;
 
 -- or, only create "readme" and "guides" foreign tables
 import foreign schema "docs_example"
-   limit to ("readme", "guides")
-   from server iceberg_server into iceberg;
+  limit to ("readme", "guides")
+  from server iceberg_server into iceberg;
 
 -- or, create all foreign tables except "readme"
 import foreign schema "docs_example"
-   except ("readme")
-   from server iceberg_server into iceberg;
+  except ("readme")
+  from server iceberg_server into iceberg;
 ```
 
 !!! note
@@ -219,7 +232,7 @@ create foreign table iceberg.guides (
   content text,
   created_at timestamp
 )
-  server iceberg_fdw
+  server iceberg_server
   options (
     table 'docs_example.guides'
   );
@@ -276,18 +289,32 @@ This section describes important limitations and considerations when using this 
 - Only supports specific data type mappings between Postgres and Iceberg
 - Only supports read operations (no INSERT, UPDATE, DELETE, or TRUNCATE)
 - [Apache Iceberg schema evolution](https://iceberg.apache.org/spec/#schema-evolution) is not supported
-- When using Iceberg REST catalog, only supports AWS S3 as the storage
+- When using Iceberg REST catalog, only supports AWS S3 (or compatible) as the storage
 - Materialized views using these foreign tables may fail during logical backups
 
 ## Examples
 
 ### Basic Example
 
-First, import foreign tables from Iceberg namespace `docs_example`:
+First, create a server for AWS S3 Tables:
+
+```sql
+create server iceberg_server
+  foreign data wrapper iceberg_wrapper
+  options (
+    aws_access_key_id '<AWS_access_key_ID>',
+    aws_secret_access_key '<AWS_secret_access_key>',
+    region_name 'us-east-1',
+    aws_s3table_bucket_arn 'arn:aws:s3tables:us-east-1:204203087419:bucket/my-table-bucket'
+  );
+```
+
+Import the foreign table:
 
 ```sql
 -- Run below SQL to import all tables under namespace 'docs_example'
-import foreign schema "docs_example" from server iceberg_server into iceberg;
+import foreign schema "docs_example"
+  from server iceberg_server into iceberg;
 
 -- or, create the foreign table manually
 create foreign table if not exists iceberg.guides (
@@ -296,7 +323,7 @@ create foreign table if not exists iceberg.guides (
   content text,
   created_at timestamp
 )
-  server iceberg_fdw
+  server iceberg_server
   options (
     table 'docs_example.guides'
   );
@@ -306,6 +333,31 @@ Then query the foreign table:
 
 ```sql
 select * from iceberg.guides;
+```
+
+### Read Cloudflare R2 Data Catalog
+
+First, follow the steps in [Getting Started Guide](https://developers.cloudflare.com/r2/data-catalog/get-started/) to create a R2 Catalog on Cloudflare. Once it is completed, create a server like below:
+
+```sql
+create server iceberg_server
+  foreign data wrapper iceberg_wrapper
+  options (
+    aws_access_key_id '<R2_access_key_ID>',
+    aws_secret_access_key '<R2_secret_access_key>',
+	token '<R2 API token>',
+	warehouse 'xxx_r2-data-catalog-tutorial',
+	"s3.endpoint" 'https://xxx.r2.cloudflarestorage.com',
+    catalog_uri 'https://catalog.cloudflarestorage.com/xxx/r2-data-catalog-tutorial'
+  );
+```
+
+Then, import all the tables in `default` namespace and query it:
+
+```sql
+import foreign schema "default" from server iceberg_server into iceberg;
+
+select * from iceberg.people;
 ```
 
 ### Query Pushdown Examples

--- a/wrappers/Cargo.toml
+++ b/wrappers/Cargo.toml
@@ -282,9 +282,9 @@ anyhow  = { version = "1.0.81", optional = true }
 uuid = { version = "1.16.0", optional = true }
 
 # for iceberg_fdw
-iceberg = { git = "https://github.com/apache/iceberg-rust", rev = "12485be4a30848213faea62740ad7cb5a41bd6f2", package = "iceberg", optional = true }
-iceberg-catalog-s3tables = { git = "https://github.com/apache/iceberg-rust", rev = "12485be4a30848213faea62740ad7cb5a41bd6f2", package="iceberg-catalog-s3tables", optional = true }
-iceberg-catalog-rest = { git = "https://github.com/apache/iceberg-rust", rev = "12485be4a30848213faea62740ad7cb5a41bd6f2", package="iceberg-catalog-rest", optional = true }
+iceberg = { version = "0.5.1", optional = true }
+iceberg-catalog-s3tables = { git = "https://github.com/burmecia/iceberg-rust", rev = "e565bc43c1b9fa6b25a601f68bcec1423a984cc1", package="iceberg-catalog-s3tables", optional = true }
+iceberg-catalog-rest = { version = "0.5.1", optional = true }
 rust_decimal = { version = "1.37.1", optional = true }
 
 [dev-dependencies]

--- a/wrappers/src/fdw/iceberg_fdw/README.md
+++ b/wrappers/src/fdw/iceberg_fdw/README.md
@@ -10,5 +10,6 @@ This is a foreign data wrapper for [Apache Iceberg](https://iceberg.apache.org/)
 
 | Version | Date       | Notes                                                |
 | ------- | ---------- | ---------------------------------------------------- |
+| 0.1.1   | 2025-05-15 | Refactor server options passdown                     |
 | 0.1.0   | 2025-05-07 | Initial version                                      |
 

--- a/wrappers/src/fdw/iceberg_fdw/iceberg_fdw.rs
+++ b/wrappers/src/fdw/iceberg_fdw/iceberg_fdw.rs
@@ -27,7 +27,7 @@ fn copy_option(map: &mut HashMap<String, String>, from_key: &str, to_key: &str) 
 }
 
 #[wrappers_fdw(
-    version = "0.1.0",
+    version = "0.1.1",
     author = "Supabase",
     website = "https://github.com/supabase/wrappers/tree/main/wrappers/src/fdw/iceberg_fdw",
     error_type = "IcebergFdwError"

--- a/wrappers/src/fdw/iceberg_fdw/tests.rs
+++ b/wrappers/src/fdw/iceberg_fdw/tests.rs
@@ -21,9 +21,9 @@ mod tests {
                      OPTIONS (
                        aws_access_key_id 'admin',
                        aws_secret_access_key 'password',
-                       aws_region 'us-east-1',
                        catalog_uri 'http://localhost:8181',
-                       s3_endpoint_url 'http://localhost:8000'
+                       warehouse 'warehouse',
+                       "s3.endpoint" 'http://localhost:8000'
                      )"#,
                 None,
                 &[],


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is mainly to refactor how the server options passed down to iceberg crate.

## What is the current behavior?

Currently, only a few hand-picked options in `create server` are passed down to iceberg crate. Those options are not comprehensive and have unnecessary name translation.

## What is the new behavior?

All the options in `create server` are passed down to iceberg crate without modification, except the option has `vault_` prefix, which will be replaced by decrypted text from Vault and the name striped that prefix. With this change, we can support any the iceberg services as upstream supported.

Other changes in this PR:

- As upstream iceberg crate just released version `0.5.1`, we switched to use it
- Upstream S3 tables catalog crate hasn't released yet, so we used a fork of it
- Updated docs and added one more example `Read Cloudflare R2 Data Catalog`

## Additional context

N/A
