### PR TITLE
chore: bump Wrappers version to `0.5.2`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9568,7 +9568,7 @@ dependencies = [
 
 [[package]]
 name = "wrappers"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "arrow-array",

--- a/wrappers/Cargo.toml
+++ b/wrappers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wrappers"
-version = "0.5.1"
+version = "0.5.2"
 publish = false
 homepage = "https://github.com/supabase/wrappers/tree/main/wrappers"
 repository = "https://github.com/supabase/wrappers/tree/main/wrappers"


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to bump Wrappers version to `0.5.2`.

## What is the current behavior?

N/A

## What is the new behavior?

N/A

## Additional context

N/A
