### PR TITLE
chore: bump wrappers version to `0.5.3`

### DIFF
--- a/.github/workflows/test_wrappers.yml
+++ b/.github/workflows/test_wrappers.yml
@@ -14,7 +14,8 @@ jobs:
   # =============================================================
   test_native:
     name: Run native wrappers tests
-    runs-on: ubuntu-24.04
+    runs-on:
+      group: Default Larger Runners
 
     steps:
     - name: Checkout code
@@ -62,7 +63,8 @@ jobs:
   # =============================================================
   test_wasm:
     name: Run Wasm wrappers tests
-    runs-on: ubuntu-24.04
+    runs-on:
+      group: Default Larger Runners
 
     steps:
     - name: Checkout code

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9568,7 +9568,7 @@ dependencies = [
 
 [[package]]
 name = "wrappers"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "arrow-array",

--- a/wrappers/Cargo.toml
+++ b/wrappers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wrappers"
-version = "0.5.2"
+version = "0.5.3"
 publish = false
 homepage = "https://github.com/supabase/wrappers/tree/main/wrappers"
 repository = "https://github.com/supabase/wrappers/tree/main/wrappers"
@@ -193,6 +193,7 @@ native_fdws = [
     "redis_fdw",
     "cognito_fdw",
     "iceberg_fdw",
+    "duckdb_fdw",
 ]
 all_fdws = [
     "native_fdws",


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to bump Wrappers version to 0.5.3. This a fix version which is to include the missing DuckDB FDW.

## What is the current behavior?

N/A

## What is the new behavior?

N/A

## Additional context

Upgrade CI runner spec as the original one is too small.
