### PR TITLE
fix(iceberg): remove server option validator

### DIFF
--- a/wrappers/src/fdw/iceberg_fdw/iceberg_fdw.rs
+++ b/wrappers/src/fdw/iceberg_fdw/iceberg_fdw.rs
@@ -367,16 +367,7 @@ impl ForeignDataWrapper<IcebergFdwError> for IcebergFdw {
         catalog: Option<pg_sys::Oid>,
     ) -> IcebergFdwResult<()> {
         if let Some(oid) = catalog {
-            if oid == FOREIGN_SERVER_RELATION_ID {
-                // AWS credential pair must be specified together
-                let a = check_options_contain(&options, "aws_access_key_id");
-                let b = check_options_contain(&options, "aws_secret_access_key");
-                match (a, b) {
-                    (a @ Err(_), Ok(_)) => a.map(|_| ())?,
-                    (Ok(_), b @ Err(_)) => b.map(|_| ())?,
-                    _ => (),
-                }
-            } else if oid == FOREIGN_TABLE_RELATION_ID {
+            if oid == FOREIGN_TABLE_RELATION_ID {
                 // check required option
                 check_options_contain(&options, "table")?;
             }


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to remove server option validator for Iceberg FDW.

## What is the current behavior?

The current server option validator requires both `aws_access_key_id` and `aws_secret_access_key` to be presented, but those options are not mandatory anymore because this FDW can connect to Iceberg services other than AWS.

## What is the new behavior?

Removed those 2 server options requirement.

## Additional context

N/A
