### PR TITLE
fix extern "C" issue, because pgrx 0.14.3 need to use extern "C-unwind"

### DIFF
--- a/supabase-wrappers/src/modify.rs
+++ b/supabase-wrappers/src/modify.rs
@@ -107,7 +107,7 @@ unsafe fn find_rowid_column(
 
 #[cfg(feature = "pg13")]
 #[pg_guard]
-pub(super) extern "C" fn add_foreign_update_targets(
+pub(super) extern "C-unwind" fn add_foreign_update_targets(
     parsetree: *mut pg_sys::Query,
     _target_rte: *mut pg_sys::RangeTblEntry,
     target_relation: pg_sys::Relation,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior

When we build pg version 13 will throw exception as below.

```
error: custom attribute panicked
   --> supabase-wrappers/src/modify.rs:109:1
    |
109 | #[pg_guard]
    | ^^^^^^^^^^^
    |
    = help: message: #[pg_guard] must be combined with extern "C-unwind"

error[E0425]: cannot find value `add_foreign_update_targets` in module `modify`
   --> supabase-wrappers/src/interface.rs:825:64
    |
825 |             fdw_routine.AddForeignUpdateTargets = Some(modify::add_foreign_update_targets);
    |                                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ not found in `modify`
    |
note: found an item that was configured out
   --> supabase-wrappers/src/modify.rs:144:33
    |
144 | pub(super) extern "C-unwind" fn add_foreign_update_targets(
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
note: the item is gated here
   --> supabase-wrappers/src/modify.rs:142:1
    |
142 | #[cfg(not(feature = "pg13"))]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

For more information about this error, try `rustc --explain E0425`.
error: could not compile `supabase-wrappers` (lib) due to 2 previous errors
```

Please link any relevant issues here.

## What is the new behavior?

fix extern "C" issue, because pgrx 0.14.3 need to use extern "C-unwind"

https://github.com/pgcentralfoundation/pgrx/tree/v0.14.3?tab=readme-ov-file#key-features

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
