### PR TITLE
fix(clickhouse): add quotes for deparsed UUID

### DIFF
--- a/supabase-wrappers/src/interface.rs
+++ b/supabase-wrappers/src/interface.rs
@@ -188,7 +188,7 @@ impl fmt::Display for Cell {
                     write!(f, r#"'\x{}'"#, hex)
                 }
             }
-            Cell::Uuid(v) => write!(f, "{}", v),
+            Cell::Uuid(v) => write!(f, "'{}'", v),
             Cell::BoolArray(v) => write_array(v, f),
             Cell::I16Array(v) => write_array(v, f),
             Cell::I32Array(v) => write_array(v, f),

--- a/wrappers/src/fdw/clickhouse_fdw/clickhouse_fdw.rs
+++ b/wrappers/src/fdw/clickhouse_fdw/clickhouse_fdw.rs
@@ -778,10 +778,7 @@ impl ForeignDataWrapper<ClickHouseFdwError> for ClickHouseFdw {
                     continue;
                 }
                 if let Some(cell) = cell {
-                    match cell {
-                        Cell::Uuid(_) => sets.push(format!("{} = '{}'", col, cell)),
-                        _ => sets.push(format!("{} = {}", col, cell)),
-                    }
+                    sets.push(format!("{} = {}", col, cell));
                 } else {
                     sets.push(format!("{} = null", col));
                 }

--- a/wrappers/src/fdw/clickhouse_fdw/tests.rs
+++ b/wrappers/src/fdw/clickhouse_fdw/tests.rs
@@ -429,6 +429,18 @@ mod tests {
                     Some(vec![444i64, 222i64]),
                 )
             );
+            assert_eq!(
+                c.select(
+                    "SELECT uid FROM test_table WHERE uid = $1",
+                    None,
+                    &[pgrx::Uuid::from_bytes([43u8; 16]).into(),],
+                )
+                .unwrap()
+                .first()
+                .get_one::<Uuid>()
+                .unwrap(),
+                Some(Uuid::from_bytes([43u8; 16])),
+            );
 
             // test delete data in foreign table
             c.update("DELETE FROM test_table WHERE id = 42", None, &[])


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to fix UUID deparse for ClickHouse FDW. Fix #489 

## What is the current behavior?

Currently, the UUID is deparsed without quotes which caused incorrect deparsed SQL. For example,

```sql
select uid from clickhouse.mytable where uid = '2f4b4278-8896-4bce-b601-aaf45baee7eb'
```

will be deparsed to:

```sql
select uid from mytable where uid = 2f4b4278-8896-4bce-b601-aaf45baee7eb
```

## What is the new behavior?

Add single quotes for UUID deparse.

## Additional context

N/A
