### PR TITLE
fix(clickhouse): exclude array type qual pushdown

### DIFF
--- a/supabase-wrappers/src/interface.rs
+++ b/supabase-wrappers/src/interface.rs
@@ -61,6 +61,22 @@ pub enum Cell {
     StringArray(Vec<Option<String>>),
 }
 
+impl Cell {
+    /// Check if cell is an array type
+    pub fn is_array(&self) -> bool {
+        matches!(
+            self,
+            Cell::BoolArray(_)
+                | Cell::I16Array(_)
+                | Cell::I32Array(_)
+                | Cell::I64Array(_)
+                | Cell::F32Array(_)
+                | Cell::F64Array(_)
+                | Cell::StringArray(_)
+        )
+    }
+}
+
 unsafe impl Send for Cell {}
 
 impl Clone for Cell {

--- a/wrappers/src/fdw/clickhouse_fdw/clickhouse_fdw.rs
+++ b/wrappers/src/fdw/clickhouse_fdw/clickhouse_fdw.rs
@@ -394,7 +394,14 @@ impl ClickHouseFdw {
         if !quals.is_empty() {
             let cond = quals
                 .iter()
-                .filter(|q| !self.params.iter().any(|p| p.field == q.field))
+                .filter(|q| {
+                    let is_param = self.params.iter().any(|p| p.field == q.field);
+                    let is_array = match &q.value {
+                        Value::Cell(c) => c.is_array(),
+                        _ => false,
+                    };
+                    !is_param && !is_array
+                })
                 .map(|q| q.deparse())
                 .collect::<Vec<String>>()
                 .join(" and ");

--- a/wrappers/src/fdw/clickhouse_fdw/tests.rs
+++ b/wrappers/src/fdw/clickhouse_fdw/tests.rs
@@ -257,7 +257,7 @@ mod tests {
             );
             assert_eq!(
                 c.select(
-                    "SELECT arr_i64, arr_str FROM test_table WHERE id = 42",
+                    "SELECT arr_i64, arr_str FROM test_table WHERE id = 42 and array['abc','def'] @> arr_str",
                     None,
                     &[]
                 )


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to prevent array type qual to be pushed down for ClickHouse FDW. Fix #491.

## What is the current behavior?

Array type operators, such like `@>`, are not supported by ClickHouse, but they are included in the deparsed sql and pushed down to ClickHouse.

## What is the new behavior?

Wrappers won't do array operator translation, so all array type column quals are excluded from pushdown.

## Additional context

N/A
