### PR TITLE
fix(airtable): make column name case insensitive

### DIFF
--- a/wrappers/dockerfiles/airtable/server.py
+++ b/wrappers/dockerfiles/airtable/server.py
@@ -41,7 +41,7 @@ if __name__ == "__main__":
     client.create(
         test_table,
         {
-            "bool_field": True,
+            "BOOL_field": True,
             "numeric_field": 1,
             "string_field": "two",
             "timestamp_field": "2023-07-19T06:39:15.000Z",
@@ -55,7 +55,7 @@ if __name__ == "__main__":
     client.create(
         test_table,
         {
-            "bool_field": False,
+            "BOOL_field": False,
             "numeric_field": 2,
             "string_field": "three",
             "timestamp_field": "2023-07-20T06:39:15.000Z",

--- a/wrappers/src/fdw/airtable_fdw/README.md
+++ b/wrappers/src/fdw/airtable_fdw/README.md
@@ -11,6 +11,7 @@ This is a foreign data wrapper for [Airtable](https://www.airtable.com). It is d
 
 | Version | Date       | Notes                                                |
 | ------- | ---------- | ---------------------------------------------------- |
+| 0.1.5   | 2025-08-14 | Make column name case insensitive                    |
 | 0.1.4   | 2024-09-30 | Support for pgrx 0.12.6                              |
 | 0.1.3   | 2023-10-20 | Added jsonb data types support                       |
 | 0.1.2   | 2023-07-19 | Added more data types support                        |

--- a/wrappers/src/fdw/airtable_fdw/airtable_fdw.rs
+++ b/wrappers/src/fdw/airtable_fdw/airtable_fdw.rs
@@ -28,7 +28,7 @@ fn create_client(api_key: &str) -> Result<ClientWithMiddleware, AirtableFdwError
 }
 
 #[wrappers_fdw(
-    version = "0.1.4",
+    version = "0.1.5",
     author = "Ankur Goyal",
     website = "https://github.com/supabase/wrappers/tree/main/wrappers/src/fdw/airtable_fdw",
     error_type = "AirtableFdwError"

--- a/wrappers/src/fdw/airtable_fdw/result.rs
+++ b/wrappers/src/fdw/airtable_fdw/result.rs
@@ -95,8 +95,9 @@ impl AirtableRecord {
                 continue;
             }
 
+            let col_name_lowercase = col.name.to_lowercase();
             let cell = match col.type_oid {
-                pg_sys::BOOLOID => self.fields.0.get(&col.name).map_or_else(
+                pg_sys::BOOLOID => self.fields.0.get(&col_name_lowercase).map_or_else(
                     || Ok(None),
                     |val| {
                         if let Value::Bool(v) = val {
@@ -106,7 +107,7 @@ impl AirtableRecord {
                         }
                     },
                 ),
-                pg_sys::CHAROID => self.fields.0.get(&col.name).map_or_else(
+                pg_sys::CHAROID => self.fields.0.get(&col_name_lowercase).map_or_else(
                     || Ok(None),
                     |val| {
                         if let Value::Number(v) = val {
@@ -116,7 +117,7 @@ impl AirtableRecord {
                         }
                     },
                 ),
-                pg_sys::INT2OID => self.fields.0.get(&col.name).map_or_else(
+                pg_sys::INT2OID => self.fields.0.get(&col_name_lowercase).map_or_else(
                     || Ok(None),
                     |val| {
                         if let Value::Number(v) = val {
@@ -126,7 +127,7 @@ impl AirtableRecord {
                         }
                     },
                 ),
-                pg_sys::FLOAT4OID => self.fields.0.get(&col.name).map_or_else(
+                pg_sys::FLOAT4OID => self.fields.0.get(&col_name_lowercase).map_or_else(
                     || Ok(None),
                     |val| {
                         if let Value::Number(v) = val {
@@ -136,7 +137,7 @@ impl AirtableRecord {
                         }
                     },
                 ),
-                pg_sys::INT4OID => self.fields.0.get(&col.name).map_or_else(
+                pg_sys::INT4OID => self.fields.0.get(&col_name_lowercase).map_or_else(
                     || Ok(None),
                     |val| {
                         if let Value::Number(v) = val {
@@ -146,7 +147,7 @@ impl AirtableRecord {
                         }
                     },
                 ),
-                pg_sys::FLOAT8OID => self.fields.0.get(&col.name).map_or_else(
+                pg_sys::FLOAT8OID => self.fields.0.get(&col_name_lowercase).map_or_else(
                     || Ok(None),
                     |val| {
                         if let Value::Number(v) = val {
@@ -156,7 +157,7 @@ impl AirtableRecord {
                         }
                     },
                 ),
-                pg_sys::INT8OID => self.fields.0.get(&col.name).map_or_else(
+                pg_sys::INT8OID => self.fields.0.get(&col_name_lowercase).map_or_else(
                     || Ok(None),
                     |val| {
                         if let Value::Number(v) = val {
@@ -166,7 +167,7 @@ impl AirtableRecord {
                         }
                     },
                 ),
-                pg_sys::NUMERICOID => match self.fields.0.get(&col.name) {
+                pg_sys::NUMERICOID => match self.fields.0.get(&col_name_lowercase) {
                     Some(val) => {
                         if let Value::Number(v) = val {
                             let n = match v.as_f64() {
@@ -180,7 +181,7 @@ impl AirtableRecord {
                     }
                     None => Ok(None),
                 },
-                pg_sys::TEXTOID => self.fields.0.get(&col.name).map_or_else(
+                pg_sys::TEXTOID => self.fields.0.get(&col_name_lowercase).map_or_else(
                     || Ok(None),
                     |val| {
                         if let Value::String(v) = val {
@@ -190,7 +191,7 @@ impl AirtableRecord {
                         }
                     },
                 ),
-                pg_sys::DATEOID => self.fields.0.get(&col.name).map_or_else(
+                pg_sys::DATEOID => self.fields.0.get(&col_name_lowercase).map_or_else(
                     || Ok(None),
                     |val| {
                         if let Value::String(v) = val {
@@ -202,7 +203,7 @@ impl AirtableRecord {
                         }
                     },
                 ),
-                pg_sys::TIMESTAMPOID => self.fields.0.get(&col.name).map_or_else(
+                pg_sys::TIMESTAMPOID => self.fields.0.get(&col_name_lowercase).map_or_else(
                     || Ok(None),
                     |val| {
                         if let Value::String(v) = val {
@@ -215,7 +216,7 @@ impl AirtableRecord {
                         }
                     },
                 ),
-                pg_sys::TIMESTAMPTZOID => self.fields.0.get(&col.name).map_or_else(
+                pg_sys::TIMESTAMPTZOID => self.fields.0.get(&col_name_lowercase).map_or_else(
                     || Ok(None),
                     |val| {
                         if let Value::String(v) = val {
@@ -229,7 +230,7 @@ impl AirtableRecord {
                     },
                 ),
                 // TODO: Think about adding support for BOOLARRAYOID, NUMERICARRAYOID, TEXTARRAYOID and rest of array types.
-                pg_sys::JSONBOID => self.fields.0.get(&col.name).map_or_else(
+                pg_sys::JSONBOID => self.fields.0.get(&col_name_lowercase).map_or_else(
                     || Ok(None),
                     |val| Ok(Some(Cell::Json(pgrx::JsonB(val.clone())))),
                 ),

--- a/wrappers/src/fdw/airtable_fdw/tests.rs
+++ b/wrappers/src/fdw/airtable_fdw/tests.rs
@@ -27,7 +27,7 @@ mod tests {
             c.update(
                 r#"
                   CREATE FOREIGN TABLE airtable_table (
-                    bool_field bool,
+                    "BOOL_FIELD" bool,
                     numeric_field numeric,
                     string_field text,
                     timestamp_field timestamp,
@@ -74,14 +74,14 @@ mod tests {
             */
             let results = c
                 .select(
-                    "SELECT bool_field FROM airtable_table WHERE bool_field = False",
+                    r#"SELECT "BOOL_FIELD" FROM airtable_table WHERE "BOOL_FIELD" = False"#,
                     None,
                     &[],
                 )
                 .expect("No results for a given query")
                 .filter_map(|r| {
-                    r.get_by_name::<bool, _>("bool_field")
-                        .expect("bool_field is missing")
+                    r.get_by_name::<bool, _>("BOOL_FIELD")
+                        .expect("BOOL_FIELD is missing")
                 })
                 .collect::<Vec<_>>();
             assert_eq!(results, vec![false]);


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to make column name case insensitive in Airtable wrapper which is same as Airtable. Fix #171.

## What is the current behavior?

The column name in foreign table must be lowercase, otherwise it won't be populated if the column name is uppercase in Airtable.

## What is the new behavior?

The column name in foreign table is now case insensitive, this is done by converting column name to lowercase from both sides and then match them together.

## Additional context

N/A
