### PR TITLE
fix(duckdb): replace `execute_batch()` with `execute()`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2548,9 +2548,9 @@ dependencies = [
 
 [[package]]
 name = "duckdb"
-version = "1.3.0"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "379464d1fbb69d1bbda7c11d96fafde6f2bdb78c67e630e6339b048e6e45107e"
+checksum = "07ab83a22530667ffc8cc0e31c0549bb07bea5dba3b957a8e315effc38923701"
 dependencies = [
  "arrow",
  "cast",
@@ -2561,7 +2561,7 @@ dependencies = [
  "num-integer",
  "rust_decimal",
  "smallvec",
- "strum 0.25.0",
+ "strum 0.27.2",
 ]
 
 [[package]]
@@ -3305,11 +3305,11 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
- "hashbrown 0.14.5",
+ "hashbrown 0.15.3",
 ]
 
 [[package]]
@@ -4233,11 +4233,10 @@ checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libduckdb-sys"
-version = "1.3.0"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25d3f1defe457d1ac0fbaef0fe6926953cb33419dd3c8dbac53882d020bee697"
+checksum = "4e02f6069513efb67a0743aff3b846090de14763802b0e95c352ebc6e1bdc1da"
 dependencies = [
- "autocfg",
  "cc",
  "flate2",
  "pkg-config",
@@ -7310,30 +7309,17 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
-dependencies = [
- "strum_macros 0.25.3",
-]
-
-[[package]]
-name = "strum"
 version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 
 [[package]]
-name = "strum_macros"
-version = "0.25.3"
+name = "strum"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
- "heck 0.4.1",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 2.0.101",
+ "strum_macros 0.27.2",
 ]
 
 [[package]]
@@ -7346,6 +7332,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
  "syn 2.0.101",
 ]
 

--- a/docs/catalog/duckdb.md
+++ b/docs/catalog/duckdb.md
@@ -267,7 +267,7 @@ A `create server` statement example:
         warehouse 'my_warehouse',
 
         -- R2 Data Catalog URI
-        catalog_uri 'https://catalog.cloudflarestorage.com/1a4d06e707l56a1a724719292be42e3a/r2-data-catalog'
+        catalog_uri 'catalog.cloudflarestorage.com/1a4d06e707l56a1a724719292be42e3a/r2-data-catalog'
       );
     ```
 
@@ -286,7 +286,7 @@ A `create server` statement example:
         warehouse 'my_warehouse',
 
         -- R2 Data Catalog URI
-        catalog_uri 'https://catalog.cloudflarestorage.com/1a4d06e707l56a1a724719292be42e3a/r2-data-catalog'
+        catalog_uri 'catalog.cloudflarestorage.com/1a4d06e707l56a1a724719292be42e3a/r2-data-catalog'
       );
     ```
 
@@ -385,8 +385,10 @@ A `create server` statement example:
         -- Warehouse name
         warehouse 'warehouse',
 
+        use_ssl 'false',
+
         -- Lakekeeper REST Catalog URI
-        catalog_uri 'http://lakekeeper:8181/catalog'
+        catalog_uri 'lakekeeper:8181/catalog'
       );
     ```
 
@@ -411,8 +413,10 @@ A `create server` statement example:
         -- Warehouse name
         warehouse 'warehouse',
 
+        use_ssl 'false',
+
         -- Lakekeeper REST Catalog URI
-        catalog_uri 'http://lakekeeper:8181/catalog'
+        catalog_uri 'lakekeeper:8181/catalog'
       );
     ```
 
@@ -763,7 +767,7 @@ create server duckdb_server
     type 'r2_catalog',
     token '<R2 API token>',
     warehouse '2b303ef0293bc91a0217a0381af14a3e_r2-data-catalog-tutorial',
-    catalog_uri 'https://catalog.cloudflarestorage.com/2b303ef0293bc91a0217a0381af14a3e/r2-data-catalog-tutorial'
+    catalog_uri 'catalog.cloudflarestorage.com/2b303ef0293bc91a0217a0381af14a3e/r2-data-catalog-tutorial'
   );
 ```
 

--- a/wrappers/Cargo.toml
+++ b/wrappers/Cargo.toml
@@ -300,7 +300,7 @@ iceberg-catalog-rest = { version = "0.5.1", optional = true }
 rust_decimal = { version = "1.37.1", optional = true }
 
 # for duckdb_fdw
-duckdb = { version = "1.3.0", features = ["bundled"], optional = true }
+duckdb = { version = "1.3.2", features = ["bundled"], optional = true }
 
 [dev-dependencies]
 pgrx-tests = "=0.14.3"

--- a/wrappers/src/fdw/duckdb_fdw/README.md
+++ b/wrappers/src/fdw/duckdb_fdw/README.md
@@ -10,5 +10,6 @@ This is a foreign data wrapper for [DuckDB](https://duckdb.org/). It is develope
 
 | Version | Date       | Notes                                                |
 | ------- | ---------- | ---------------------------------------------------- |
+| 0.1.1   | 2025-08-15 | Replace execute_batch() with execute()               |
 | 0.1.0   | 2024-10-31 | Initial version                                      |
 

--- a/wrappers/src/fdw/duckdb_fdw/duckdb_fdw.rs
+++ b/wrappers/src/fdw/duckdb_fdw/duckdb_fdw.rs
@@ -9,7 +9,7 @@ use supabase_wrappers::prelude::*;
 use super::{mapper, server_type::ServerType, DuckdbFdwError, DuckdbFdwResult};
 
 #[wrappers_fdw(
-    version = "0.1.0",
+    version = "0.1.1",
     author = "Supabase",
     website = "https://github.com/supabase/wrappers/tree/main/wrappers/src/fdw/duckdb_fdw",
     error_type = "DuckdbFdwError"


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to replace `execute_batch()` with `execute()` used in DuckDB wrapper. 

## What is the current behavior?

The `execute_batch()` can run multiple sql in one batch, but it won't report error if one of it failed. This might be a bug in upstream.

## What is the new behavior?

To mitigate this issue we run each sql separately using `execute()` so the error will be reported correctly.

## Additional context

Some other minor changes in this PR:

- upgrade upstream DuckDB crate version to `1.3.2`
- some doc errors are fixed as well
