### PR TITLE
chore: bump wrappers version to 0.5.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7355,7 +7355,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "supabase-wrappers"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "pgrx",
  "pgrx-tests",
@@ -9566,7 +9566,7 @@ dependencies = [
 
 [[package]]
 name = "wrappers"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "arrow-array",

--- a/supabase-wrappers/Cargo.toml
+++ b/supabase-wrappers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "supabase-wrappers"
-version = "0.1.22"
+version = "0.1.23"
 authors = ["Supabase Inc. https://supabase.com/"]
 license = "Apache-2.0"
 description = "Postgres Foreign Data Wrapper development framework in Rust."

--- a/wrappers/Cargo.toml
+++ b/wrappers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wrappers"
-version = "0.5.3"
+version = "0.5.4"
 publish = false
 homepage = "https://github.com/supabase/wrappers/tree/main/wrappers"
 repository = "https://github.com/supabase/wrappers/tree/main/wrappers"


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to bump wrappers version to 0.5.4.

## What is the current behavior?

N/A

## What is the new behavior?

N/A

## Additional context

supabase-wrappers framework version is also upgraded to 0.1.23.
