### PR TITLE
ci: upgrade arm runner to `u22-arm-runner`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
           - "all_fdws"
         box:
           - { runner: ubuntu-24.04, arch: amd64 }
-          - { runner: arm-runner, arch: arm64 }
+          - { runner: u22-arm-runner, arch: arm64 }
     runs-on: ${{ matrix.box.runner }}
     timeout-minutes: 90
     steps:


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to upgrade Ubuntu 20 based arm runner to Ubuntu 24 based `u22-arm-runner`.

## What is the current behavior?

N/A

## What is the new behavior?

N/A

## Additional context

N/A
