### PR TITLE
ci: fix wasm file path when creating release

### DIFF
--- a/.github/workflows/release_wasm_fdw.yml
+++ b/.github/workflows/release_wasm_fdw.yml
@@ -115,5 +115,5 @@ jobs:
           files: |
             ./wasm-wrappers/fdw/${{ steps.extract_info.outputs.PROJECT }}/README.txt
             ./wasm-wrappers/fdw/${{ steps.extract_info.outputs.PROJECT }}/checksum.txt
-            ./wasm-wrappers/fdw/${{ steps.extract_info.outputs.PROJECT }}/target/wasm32-unknown-unknown/release/*.wasm
+            ./wasm-wrappers/fdw/target/wasm32-unknown-unknown/release/${{ steps.extract_info.outputs.PROJECT }}.wasm
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to fix the incorrect wasm file path when creating a Wasm FDW release.

## What is the current behavior?

The wasm file target path uses each individual wasm fdw target folder, which is incorrect as all the wasm fdws are now under a workspace. The target folder is now under the workspace.

## What is the new behavior?

Use the workspace target folder as wasm file path.

## Additional context

N/A
