### PR TITLE
ci: fix checksum file generation in Wasm FDW release workflow

### DIFF
--- a/.github/workflows/release_wasm_fdw.yml
+++ b/.github/workflows/release_wasm_fdw.yml
@@ -57,7 +57,7 @@ jobs:
           method: sha256
           output: wasm-wrappers/fdw/${{ steps.extract_info.outputs.PROJECT }}/checksum.txt
           patterns: |
-            ./wasm-wrappers/fdw/${{ steps.extract_info.outputs.PROJECT }}/target/wasm32-unknown-unknown/release/*.wasm
+            ./wasm-wrappers/fdw/target/wasm32-unknown-unknown/release/${{ steps.extract_info.outputs.PROJECT }}.wasm
 
       - name: Get project metadata JSON
         id: metadata


### PR DESCRIPTION
## What kind of change does this PR introduce?

The PR is to fix another similar issue as #498 , the input of checksum file generation should be the workplace folder.

## What is the current behavior?

N/A

## What is the new behavior?

N/A

## Additional context

N/A
