### PR TITLE
fix: deal with NULL in FromDatum implementation for `bytea` type in Cell

### DIFF
--- a/supabase-wrappers/src/interface.rs
+++ b/supabase-wrappers/src/interface.rs
@@ -330,7 +330,11 @@ impl FromDatum for Cell {
                 JsonB::from_datum(datum, is_null).map(Cell::Json)
             }
             PgOid::BuiltIn(PgBuiltInOids::BYTEAOID) => {
-                Some(Cell::Bytea(datum.cast_mut_ptr::<bytea>()))
+                if is_null {
+                    None
+                } else {
+                    Some(Cell::Bytea(datum.cast_mut_ptr::<bytea>()))
+                }
             }
             PgOid::BuiltIn(PgBuiltInOids::UUIDOID) => {
                 Uuid::from_datum(datum, is_null).map(Cell::Uuid)


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to fix incorrect NULL processing in FromDatum implementation for `bytea` type in Cell.

## What is the current behavior?

It didn't deal with NULL case properly and always return NOT NULL.

## What is the new behavior?

Deal with NULL case correctly just like other data types.

## Additional context

N/A
