### PR TITLE
chore: add support for pg18

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -41,7 +41,7 @@ jobs:
           sudo apt -y autoremove && sudo apt -y clean
           sudo chmod a+rwx `/usr/lib/postgresql/15/bin/pg_config --pkglibdir` `/usr/lib/postgresql/15/bin/pg_config --sharedir`/extension /var/run/postgresql/
 
-      - run: cargo install cargo-pgrx --version 0.14.3
+      - run: cargo install cargo-pgrx --version 0.16.0
       - run: cargo pgrx init --pg15 /usr/lib/postgresql/15/bin/pg_config
 
       - name: Build docker images

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,8 +37,8 @@ jobs:
         extension_name:
           - wrappers
         pgrx_version:
-          - 0.14.3
-        postgres: [14, 15, 16, 17]
+          - 0.16.0
+        postgres: [14, 15, 16, 17, 18]
         features:
           - "all_fdws"
         box:

--- a/.github/workflows/test_supabase_wrappers.yml
+++ b/.github/workflows/test_supabase_wrappers.yml
@@ -36,7 +36,7 @@ jobs:
         sudo apt -y autoremove && sudo apt -y clean
         sudo chmod a+rwx `/usr/lib/postgresql/15/bin/pg_config --pkglibdir` `/usr/lib/postgresql/15/bin/pg_config --sharedir`/extension /var/run/postgresql/
 
-    - run: cargo install cargo-pgrx --version 0.14.3
+    - run: cargo install cargo-pgrx --version 0.16.0
     - run: cargo pgrx init --pg15 /usr/lib/postgresql/15/bin/pg_config
 
     - name: Format code

--- a/.github/workflows/test_wrappers.yml
+++ b/.github/workflows/test_wrappers.yml
@@ -44,7 +44,7 @@ jobs:
         sudo apt -y autoremove && sudo apt -y clean
         sudo chmod a+rwx `/usr/lib/postgresql/15/bin/pg_config --pkglibdir` `/usr/lib/postgresql/15/bin/pg_config --sharedir`/extension /var/run/postgresql/
 
-    - run: cargo install cargo-pgrx --version 0.14.3
+    - run: cargo install cargo-pgrx --version 0.16.0
     - run: cargo pgrx init --pg15 /usr/lib/postgresql/15/bin/pg_config
 
     - name: Format code
@@ -93,7 +93,7 @@ jobs:
         sudo apt -y autoremove && sudo apt -y clean
         sudo chmod a+rwx `/usr/lib/postgresql/15/bin/pg_config --pkglibdir` `/usr/lib/postgresql/15/bin/pg_config --sharedir`/extension /var/run/postgresql/
 
-    - run: cargo install cargo-pgrx --version 0.14.3
+    - run: cargo install cargo-pgrx --version 0.16.0
     - run: cargo pgrx init --pg15 /usr/lib/postgresql/15/bin/pg_config
     - run: cargo install cargo-component --version 0.21.1
     - run: rustup target add wasm32-unknown-unknown

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -708,16 +708,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomic-traits"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707f750b93bd1b739cf9ddf85f8fe7c97a4a62c60ccf8b6f232514bd9103bedc"
-dependencies = [
- "cfg-if",
- "rustc_version",
-]
-
-[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1889,6 +1879,15 @@ name = "cobs"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
+
+[[package]]
+name = "codepage"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48f68d061bc2828ae826206326e61251aca94c1e4a5305cf52d9138639c918b4"
+dependencies = [
+ "encoding_rs",
+]
 
 [[package]]
 name = "colorchoice"
@@ -3288,15 +3287,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hash32"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3334,16 +3324,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
  "hashbrown 0.15.3",
-]
-
-[[package]]
-name = "heapless"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
-dependencies = [
- "hash32",
- "stable_deref_trait",
 ]
 
 [[package]]
@@ -5274,15 +5254,13 @@ dependencies = [
 
 [[package]]
 name = "pgrx"
-version = "0.14.3"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dffb5a99b514090574a668078a28394317d30bbb33a8b6d651342ebd945e81b"
+checksum = "2c898b37587b29f8fa7ca20bfaaf57103e10fa81e6caed2cc7b742f96088d851"
 dependencies = [
- "atomic-traits",
  "bitflags 2.9.1",
  "bitvec",
  "enum-map",
- "heapless",
  "libc",
  "once_cell",
  "pgrx-macros",
@@ -5298,9 +5276,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-bindgen"
-version = "0.14.3"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9e43f241932f230af1ed713fac06133a074efb12a80705db7f679627551b5a8"
+checksum = "35439a65a6c0cc17e9758005da0557cff583a3e4da0f92a4a744494ac21c190e"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
@@ -5317,9 +5295,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-macros"
-version = "0.14.3"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c97650c7bb75290fc0b7e1a80bc5cea74e541015369a6558f72fb3da0c0e95e"
+checksum = "3586274c7d7237e68bebb871cf9244444f1ad78bb395679ad4ef1015db302454"
 dependencies = [
  "pgrx-sql-entity-graph",
  "proc-macro2",
@@ -5329,11 +5307,13 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-config"
-version = "0.14.3"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a370f7f6127487e50be58aaf6544439352ff667e9ab6e5e6b24fb77f794315b"
+checksum = "0cc24f6663377dca8797ff3561d9ecdaef47e518ca2e2438fd85ef3c20f421ea"
 dependencies = [
  "cargo_toml",
+ "codepage",
+ "encoding_rs",
  "eyre",
  "home",
  "owo-colors",
@@ -5343,13 +5323,14 @@ dependencies = [
  "thiserror 2.0.12",
  "toml 0.8.22",
  "url",
+ "winapi",
 ]
 
 [[package]]
 name = "pgrx-pg-sys"
-version = "0.14.3"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa062f644530005641b5cdc4b5d1303c70ffa38bd1089699035ea46adac41b6d"
+checksum = "b44a35477c0752c00cab38c2d8b7ea2d2d3554e3385870d7ad43e3ae5ade66a9"
 dependencies = [
  "cee-scape",
  "libc",
@@ -5362,9 +5343,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-sql-entity-graph"
-version = "0.14.3"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc58ca1db80bc9b38e38be7d65e3dd6ba2813083410e7a81ed9db70147c40f86"
+checksum = "59036a5849c5b0bca0f33df1fdd72206ceb74712959756b3fecba56a8e19d52a"
 dependencies = [
  "convert_case",
  "eyre",
@@ -5378,9 +5359,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-tests"
-version = "0.14.3"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9ec4957e116035f87c2fb475b7c95554b44400d66e25842d6edb2491ed6c883"
+checksum = "1455045c6345fcb1f1f441205735719290cb1cd71975e0a37693adb807b1b8a3"
 dependencies = [
  "clap-cargo",
  "eyre",

--- a/supabase-wrappers/Cargo.toml
+++ b/supabase-wrappers/Cargo.toml
@@ -21,17 +21,18 @@ pg14 = ["pgrx/pg14", "pgrx-tests/pg14"]
 pg15 = ["pgrx/pg15", "pgrx-tests/pg15"]
 pg16 = ["pgrx/pg16", "pgrx-tests/pg16"]
 pg17 = ["pgrx/pg17", "pgrx-tests/pg17"]
+pg18 = ["pgrx/pg18", "pgrx-tests/pg18"]
 pg_test = []
 
 [dependencies]
-pgrx = { version = "=0.14.3", default-features = false }
+pgrx = { version = "=0.16.0", default-features = false }
 thiserror = "1.0.63"
 tokio = { version = "1.43", features = ["rt", "net"] }
 uuid = { version = "1.10.0" }
 supabase-wrappers-macros = { version = "0.1", path = "../supabase-wrappers-macros" }
 
 [dev-dependencies]
-pgrx-tests = "=0.14.3"
+pgrx-tests = "=0.16.0"
 
 [package.metadata.docs.rs]
 features = ["pg15"]

--- a/supabase-wrappers/src/scan.rs
+++ b/supabase-wrappers/src/scan.rs
@@ -190,12 +190,14 @@ pub(super) extern "C-unwind" fn get_foreign_paths<
             baserel,
             ptr::null_mut(), // default pathtarget
             (*baserel).rows,
+            #[cfg(feature = "pg18")]
+            0, // disabled_nodes
             startup_cost,
             total_cost,
             ptr::null_mut(), // no pathkeys
             ptr::null_mut(), // no outer rel either
             ptr::null_mut(), // no extra plan
-            #[cfg(feature = "pg17")]
+            #[cfg(any(feature = "pg17", feature = "pg18"))]
             ptr::null_mut(), // no restrict info
             ptr::null_mut(), // no fdw_private data
         );

--- a/supabase-wrappers/src/sort.rs
+++ b/supabase-wrappers/src/sort.rs
@@ -15,6 +15,9 @@ pub(crate) unsafe fn create_sort(
         let sort = Sort {
             field: CStr::from_ptr(attname).to_str().unwrap().to_owned(),
             field_no: attno as usize,
+            #[cfg(feature = "pg18")]
+            reversed: (*pathkey).pk_cmptype == pg_sys::BTGreaterStrategyNumber,
+            #[cfg(not(feature = "pg18"))]
             reversed: (*pathkey).pk_strategy as u32 == pg_sys::BTGreaterStrategyNumber,
             nulls_first: (*pathkey).pk_nulls_first,
             ..Default::default()

--- a/wrappers/Cargo.toml
+++ b/wrappers/Cargo.toml
@@ -24,6 +24,7 @@ pg14 = ["pgrx/pg14", "pgrx-tests/pg14", "supabase-wrappers/pg14"]
 pg15 = ["pgrx/pg15", "pgrx-tests/pg15", "supabase-wrappers/pg15"]
 pg16 = ["pgrx/pg16", "pgrx-tests/pg16", "supabase-wrappers/pg16"]
 pg17 = ["pgrx/pg17", "pgrx-tests/pg17", "supabase-wrappers/pg17"]
+pg18 = ["pgrx/pg18", "pgrx-tests/pg18", "supabase-wrappers/pg18"]
 pg_test = []
 
 helloworld_fdw = []
@@ -211,7 +212,7 @@ all_fdws = [
 ]
 
 [dependencies]
-pgrx = { version = "=0.14.3" }
+pgrx = { version = "=0.16.0" }
 #supabase-wrappers = "0.1"
 supabase-wrappers = { path = "../supabase-wrappers", default-features = false }
 
@@ -320,4 +321,4 @@ rust_decimal = { version = "1.37.1", optional = true }
 duckdb = { version = "1.3.2", features = ["bundled"], optional = true }
 
 [dev-dependencies]
-pgrx-tests = "=0.14.3"
+pgrx-tests = "=0.16.0"


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to add support for Postgres v18, and also upgraded `pgrx` to `0.16.0`.

## What is the current behavior?

Currently no pg18 support.

## What is the new behavior?

Pg18 is supported.

## Additional context

N/A
