### PR TITLE
chore: bump Wrappers version to 0.5.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7388,7 +7388,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "supabase-wrappers"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "pgrx",
  "pgrx-tests",
@@ -9601,7 +9601,7 @@ dependencies = [
 
 [[package]]
 name = "wrappers"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "anyhow",
  "arrow-array",

--- a/supabase-wrappers/Cargo.toml
+++ b/supabase-wrappers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "supabase-wrappers"
-version = "0.1.23"
+version = "0.1.24"
 authors = ["Supabase Inc. https://supabase.com/"]
 license = "Apache-2.0"
 description = "Postgres Foreign Data Wrapper development framework in Rust."

--- a/wrappers/Cargo.toml
+++ b/wrappers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wrappers"
-version = "0.5.4"
+version = "0.5.5"
 publish = false
 homepage = "https://github.com/supabase/wrappers/tree/main/wrappers"
 repository = "https://github.com/supabase/wrappers/tree/main/wrappers"


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to bump wrappers version to 0.5.5. 

## What is the current behavior?

N/A

## What is the new behavior?

Major changes in this version:

- [Added AWS S3 Vectors wrapper](https://github.com/supabase/wrappers/pull/503)
- [Added INSERT support for Iceberg wrapper](https://github.com/supabase/wrappers/pull/506)
- [Added pg18 support](https://github.com/supabase/wrappers/pull/505)
- [Added Shopify Wasm wrapper](https://github.com/supabase/wrappers/pull/497)

## Additional context

N/A
