### PR TITLE
ci: change release runner to `blacksmith-4vcpu-ubuntu-2404`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,8 +42,8 @@ jobs:
         features:
           - "all_fdws"
         box:
-          - { runner: blacksmith-8vcpu-ubuntu-2404, arch: amd64 }
-          - { runner: blacksmith-8vcpu-ubuntu-2404-arm, arch: arm64 }
+          - { runner: blacksmith-4vcpu-ubuntu-2404, arch: amd64 }
+          - { runner: blacksmith-4vcpu-ubuntu-2404-arm, arch: arm64 }
     runs-on: ${{ matrix.box.runner }}
     timeout-minutes: 90
     steps:

--- a/.github/workflows/release_wasm_fdw.yml
+++ b/.github/workflows/release_wasm_fdw.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   release:
     name: Create Wasm FDW Release
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to change release workflow runner to `blacksmith-4vcpu-ubuntu-2404`.

## What is the current behavior?

The release runner is `blacksmith-8vcpu-ubuntu-2404`, but it is currently not usable.

## What is the new behavior?

Change the release workflow runner to `blacksmith-4vcpu-ubuntu-2404`.

## Additional context

N/A
