### PR TITLE
chore: bump Wrappers version to 0.5.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7388,7 +7388,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "supabase-wrappers"
-version = "0.1.24"
+version = "0.1.25"
 dependencies = [
  "pgrx",
  "pgrx-tests",
@@ -9601,7 +9601,7 @@ dependencies = [
 
 [[package]]
 name = "wrappers"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "anyhow",
  "arrow-array",

--- a/supabase-wrappers/Cargo.toml
+++ b/supabase-wrappers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "supabase-wrappers"
-version = "0.1.24"
+version = "0.1.25"
 authors = ["Supabase Inc. https://supabase.com/"]
 license = "Apache-2.0"
 description = "Postgres Foreign Data Wrapper development framework in Rust."

--- a/wrappers/Cargo.toml
+++ b/wrappers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wrappers"
-version = "0.5.5"
+version = "0.5.6"
 publish = false
 homepage = "https://github.com/supabase/wrappers/tree/main/wrappers"
 repository = "https://github.com/supabase/wrappers/tree/main/wrappers"


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to bump wrappers version to 0.5.6.

## What is the current behavior?

N/A

## What is the new behavior?

Major changes in this version:

- [Added MotherDuck support for DuckDB wrapper](https://github.com/supabase/wrappers/pull/511)
- [Included the missing S3 vectors wrapper in the native fdw list](https://github.com/supabase/wrappers/pull/514)
- [Refactored ClickHouse wrapper to use stream based data read](https://github.com/supabase/wrappers/pull/515)
- [Fix FDW state resource release issue in the framework](https://github.com/supabase/wrappers/pull/516)

## Additional context

N/A
