### PR TITLE
ci: remove duplicate `locked` argument for pgrx installation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,7 +102,7 @@ jobs:
           # Ensure cargo/rust on path
           source "$HOME/.cargo/env"
 
-          cargo install --locked cargo-pgrx --version ${{ matrix.pgrx_version }} --locked
+          cargo install --locked cargo-pgrx --version ${{ matrix.pgrx_version }}
           cargo pgrx init --pg${{ matrix.postgres }}=/usr/lib/postgresql/${{ matrix.postgres }}/bin/pg_config
 
           # selects the pgVer from pg_config on path


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to remove duplicate '--locked' argument for pgrx installation in release workflow.

## What is the current behavior?

N/A

## What is the new behavior?

N/A

## Additional context

N/A
