### PR TITLE
docs(iceberg): add documentation for `batch_size` server option

### DIFF
--- a/docs/catalog/iceberg.md
+++ b/docs/catalog/iceberg.md
@@ -160,7 +160,7 @@ For any server options need to be stored in Vault, you can add a prefix `vault_`
 
     For other optional S3 options, please refer to [PyIceberg S3 Configuration](https://py.iceberg.apache.org/configuration/#s3).
 
-Additional server options include:
+#### Additional Server Options
 
 - `batch_size` - Controls the batch size of records read from Iceberg (default: 4096)
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to add documentation for `batch_size` server option for Iceberg wrapper. The `batch_size` foreign server option was implemented in the Iceberg FDW but not documented. This option controls the batch size of records read from Iceberg with a default value of 4096.

## What is the current behavior?

N/A

## What is the new behavior?

N/A

## Additional context

N/A
