### PR TITLE
chore(s3vectors): [WRA-10] change custom type `embd` name to `s3vec`

### DIFF
--- a/wrappers/src/fdw/s3vectors_fdw/README.md
+++ b/wrappers/src/fdw/s3vectors_fdw/README.md
@@ -10,4 +10,5 @@ This is a foreign data wrapper for [AWS S3 Vectors](https://aws.amazon.com/s3/fe
 
 | Version | Date       | Notes                                                |
 | ------- | ---------- | ---------------------------------------------------- |
+| 0.1.1   | 2025-11-17 | Changed 'embd' type name to 's3vec'                  |
 | 0.1.0   | 2025-09-14 | Initial version                                      |

--- a/wrappers/src/fdw/s3vectors_fdw/mod.rs
+++ b/wrappers/src/fdw/s3vectors_fdw/mod.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::module_inception)]
 mod conv;
-mod embd;
+mod s3vec;
 mod s3vectors_fdw;
 mod tests;
 
@@ -22,6 +22,9 @@ use supabase_wrappers::prelude::{CreateRuntimeError, OptionsError};
 enum S3VectorsFdwError {
     #[error("query filter is not supported, check S3 Vectors wrapper documents for more details")]
     QueryNotSupported,
+
+    #[error("invalid s3vec value: {0}")]
+    InvalidS3Vec(String),
 
     #[error("invalid insert value {0}")]
     InvalidInsertValue(String),

--- a/wrappers/src/fdw/s3vectors_fdw/tests.rs
+++ b/wrappers/src/fdw/s3vectors_fdw/tests.rs
@@ -51,7 +51,7 @@ mod tests {
 
             let results = c
                 .select(
-                    r#"SELECT embd_distance(data) as distance, *
+                    r#"SELECT s3vec_distance(data) as distance, *
                     FROM s3_vectors.my_vector_index
                     WHERE data <==> '[1.2, -0.8, 2.9]'
                       AND metadata <==> '{"model": {"$eq": "test"}}'


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to change custom type `embd` name to `s3vec`. We'd prefer to use s3 as a prefix so we can standardise on anything else that the s3 team adds in the future.

## What is the current behavior?

N/A

## What is the new behavior?

N/A

## Additional context

This PR also replaced `s3vec::from` with `s3vec::try_from` to guard null pointer.
