### PR TITLE
chore(s3vectors): remove `bucket_name` option from import foreign schema statement

### DIFF
--- a/docs/catalog/s3vectors.md
+++ b/docs/catalog/s3vectors.md
@@ -122,11 +122,8 @@ For example, using below SQL can automatically create foreign tables in the `s3_
 
 ```sql
 -- create foreign table for each index from S3 Vector bucket
-import foreign schema s3_vectors
-  from server s3_vectors_server into s3_vectors
-  options (
-    bucket_name 'my-vector-bucket'
-  );
+import foreign schema "my-vector-bucket"
+  from server s3_vectors_server into s3_vectors;
 ```
 
 ### S3 Vector Tables
@@ -371,11 +368,8 @@ Import the foreign table:
 
 ```sql
 -- Import all indexes from a vector bucket
-import foreign schema s3_vectors
-  from server s3_vectors_server into s3_vectors
-  options (
-    bucket_name 'my-vector-bucket'
-  );
+import foreign schema "my-vector-bucket"
+  from server s3_vectors_server into s3_vectors;
 
 -- or, create the foreign table manually
 create foreign table if not exists s3_vectors.embeddings (

--- a/wrappers/src/fdw/s3vectors_fdw/README.md
+++ b/wrappers/src/fdw/s3vectors_fdw/README.md
@@ -8,7 +8,8 @@ This is a foreign data wrapper for [AWS S3 Vectors](https://aws.amazon.com/s3/fe
 
 ## Changelog
 
-| Version | Date       | Notes                                                |
-| ------- | ---------- | ---------------------------------------------------- |
-| 0.1.1   | 2025-11-17 | Changed 'embd' type name to 's3vec'                  |
-| 0.1.0   | 2025-09-14 | Initial version                                      |
+| Version | Date       | Notes                                                      |
+| ------- | ---------- | ---------------------------------------------------------- |
+| 0.1.2   | 2025-11-19 | Removed 'bucket_name' option from 'import foreign schema'  |
+| 0.1.1   | 2025-11-17 | Changed 'embd' type name to 's3vec'                        |
+| 0.1.0   | 2025-09-14 | Initial version                                            |

--- a/wrappers/src/fdw/s3vectors_fdw/s3vectors_fdw.rs
+++ b/wrappers/src/fdw/s3vectors_fdw/s3vectors_fdw.rs
@@ -19,7 +19,7 @@ use super::s3vec::S3Vec;
 use super::{S3VectorsFdwError, S3VectorsFdwResult};
 
 #[wrappers_fdw(
-    version = "0.1.1",
+    version = "0.1.2",
     author = "Supabase",
     website = "https://github.com/supabase/wrappers/tree/main/wrappers/src/fdw/s3vectors_fdw",
     error_type = "S3VectorsFdwError"
@@ -437,7 +437,7 @@ impl ForeignDataWrapper<S3VectorsFdwError> for S3VectorsFdw {
         &mut self,
         import_stmt: ImportForeignSchemaStmt,
     ) -> S3VectorsFdwResult<Vec<String>> {
-        let bucket_name = require_option("bucket_name", &import_stmt.options)?;
+        let bucket_name = &import_stmt.remote_schema;
         let mut next_token: Option<String> = None;
         let mut ret: Vec<String> = Vec::new();
 

--- a/wrappers/src/fdw/s3vectors_fdw/tests.rs
+++ b/wrappers/src/fdw/s3vectors_fdw/tests.rs
@@ -28,11 +28,7 @@ mod tests {
             c.update(r#"CREATE SCHEMA IF NOT EXISTS s3_vectors"#, None, &[])
                 .unwrap();
             c.update(
-                r#"IMPORT FOREIGN SCHEMA "s3_vectors" FROM SERVER s3_vectors_server INTO s3_vectors
-                   OPTIONS (
-                     bucket_name 'my-vector-bucket'
-                   )
-                "#,
+                r#"IMPORT FOREIGN SCHEMA "my-vector-bucket" FROM SERVER s3_vectors_server INTO s3_vectors"#,
                 None,
                 &[],
             )


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to remove `bucket_name` option from `import foreign schema` statement.

## What is the current behavior?

When importing foreign schema from remote, the bucket name is specified by `bucket_name` option.

## What is the new behavior?

The `bucket_name` option has been replaced by the remote schema in `import foreign schema` statement, e.g.

```
import foreign schema "my-vector-bucket-name"
from server s3_vectors_server into s3_vectors;
```

## Additional context

N/A
