### PR TITLE
chore: bump Wrappers version to 0.5.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7438,7 +7438,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "supabase-wrappers"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "pgrx",
  "pgrx-tests",
@@ -9543,7 +9543,7 @@ dependencies = [
 
 [[package]]
 name = "wrappers"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "anyhow",
  "arrow-array",

--- a/supabase-wrappers/Cargo.toml
+++ b/supabase-wrappers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "supabase-wrappers"
-version = "0.1.25"
+version = "0.1.26"
 authors = ["Supabase Inc. https://supabase.com/"]
 license = "Apache-2.0"
 description = "Postgres Foreign Data Wrapper development framework in Rust."

--- a/wrappers/Cargo.toml
+++ b/wrappers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wrappers"
-version = "0.5.6"
+version = "0.5.7"
 publish = false
 homepage = "https://github.com/supabase/wrappers/tree/main/wrappers"
 repository = "https://github.com/supabase/wrappers/tree/main/wrappers"


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to bump wrappers version to 0.5.7.

## What is the current behavior?

N/A

## What is the new behavior?

N/A

## Additional context

N/A
