### PR TITLE
fix: extension upgrade issue with `s3vectors_fdw`

### DIFF
--- a/wrappers/sql/bootstrap.sql
+++ b/wrappers/sql/bootstrap.sql
@@ -22,3 +22,7 @@ COMMENT ON COLUMN wrappers_fdw_stats.bytes_in IS 'Total bytes input from origin'
 COMMENT ON COLUMN wrappers_fdw_stats.bytes_out IS 'Total bytes output to Postgres';
 COMMENT ON COLUMN wrappers_fdw_stats.metadata IS 'Metadata specific for the FDW';
 
+-- The operator '<==>' is defined in s3vectors_fdw since v0.5.6, drop it here
+-- to avoid conflict when upgrading wrappers extension.
+DROP OPERATOR IF EXISTS <==> (jsonb, jsonb);
+

--- a/wrappers/src/fdw/s3vectors_fdw/s3vec.rs
+++ b/wrappers/src/fdw/s3vectors_fdw/s3vec.rs
@@ -107,21 +107,21 @@ impl TryFrom<*mut bytea> for S3Vec {
     }
 }
 
-#[pg_operator(immutable, parallel_safe)]
+#[pg_operator(create_or_replace, immutable, parallel_safe)]
 #[opname(<==>)]
 fn s3vec_knn(_left: S3Vec, _right: S3Vec) -> bool {
     // always return true here, actual calculation will be done in the wrapper
     true
 }
 
-#[pg_operator(immutable, parallel_safe)]
+#[pg_operator(create_or_replace, immutable, parallel_safe)]
 #[opname(<==>)]
 fn metadata_filter(_left: JsonB, _right: JsonB) -> bool {
     // always return true here, actual calculation will be done in the wrapper
     true
 }
 
-#[pg_extern]
+#[pg_extern(create_or_replace)]
 fn s3vec_distance(s3vec: S3Vec) -> f32 {
     s3vec.distance
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to fix issue when upgrade wrappers extension from 0.5.6 onwards. 

## What is the current behavior?

In version 0.5.6, s3vectors_fdw defined a custom type `embd`, some custom functions and a custom operator `<==>` around that type. The `embd` type name needs to be changed to `s3vec` from 0.5.7, but current upgrade sql script cannot handle the upgrade properly.

## What is the new behavior?

Drop the custom operator `<==>` beforehand in the bootstrap sql and added `create or replace` for the custom functions.

## Additional context

N/A
