### PR TITLE
fix(redis): add TLS crypto provider initialisation

### DIFF
--- a/wrappers/src/fdw/redis_fdw/redis_fdw.rs
+++ b/wrappers/src/fdw/redis_fdw/redis_fdw.rs
@@ -5,6 +5,7 @@ use serde_json::json;
 use serde_json::value::Value as JsonValue;
 use std::collections::HashMap;
 
+use crate::setup_rustls_default_crypto_provider;
 use supabase_wrappers::prelude::*;
 
 use super::{RedisFdwError, RedisFdwResult};
@@ -241,6 +242,8 @@ impl RedisFdw {
 
 impl ForeignDataWrapper<RedisFdwError> for RedisFdw {
     fn new(server: ForeignServer) -> RedisFdwResult<Self> {
+        setup_rustls_default_crypto_provider();
+
         let conn_url = match server.options.get("conn_url") {
             Some(url) => url.to_owned(),
             None => {


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to add TLS crypto provider initialisation for Redis FDW.

## What is the current behavior?

After Rustls was upgraded >0.22, it is required to set up its crypto provider when initialisation. Redis FDW didn't done it so the connection through TLS will fail.

## What is the new behavior?

Call `setup_rustls_default_crypto_provider` to provide crypto provider for Rustls when the FDW instance is created.

## Additional context

N/A
