### PR TITLE
fix(clickhouse): implement re_scan for nested loop joins

### DIFF
--- a/wrappers/src/fdw/clickhouse_fdw/README.md
+++ b/wrappers/src/fdw/clickhouse_fdw/README.md
@@ -11,6 +11,7 @@ This is a foreign data wrapper for [ClickHouse](https://clickhouse.com/). It is 
 
 | Version | Date       | Notes                                                |
 | ------- | ---------- | ---------------------------------------------------- |
+| 0.1.10  | 2026-02-04 | Implement re_scan() for nested loop joins            |
 | 0.1.9   | 2025-11-08 | Added stream_buffer_size foreign table option        |
 | 0.1.8   | 2025-10-27 | Refactor to read rows with async streaming           |
 | 0.1.7   | 2025-05-22 | Added more data types support                        |

--- a/wrappers/src/fdw/clickhouse_fdw/tests.rs
+++ b/wrappers/src/fdw/clickhouse_fdw/tests.rs
@@ -575,8 +575,7 @@ mod tests {
                 .unwrap();
             assert_eq!(
                 inner_join_count, 3,
-                "Inner join should return 3 rows, got {}",
-                inner_join_count
+                "Inner join should return 3 rows, got {inner_join_count}",
             );
 
             // Verify inner join values are correct
@@ -614,8 +613,7 @@ mod tests {
                 .unwrap();
             assert_eq!(
                 left_join_count, 3,
-                "Left join should return 3 rows, got {}",
-                left_join_count
+                "Left join should return 3 rows, got {left_join_count}",
             );
 
             // Test right join - should return 3 rows with correct values
@@ -632,8 +630,7 @@ mod tests {
                 .unwrap();
             assert_eq!(
                 right_join_count, 3,
-                "Right join should return 3 rows, got {}",
-                right_join_count
+                "Right join should return 3 rows, got {right_join_count}",
             );
 
             // Cleanup


### PR DESCRIPTION
## Summary

- Fixes #532

PostgreSQL uses Nested Loop joins when joining foreign tables. During a Nested Loop join, the inner (right) table is scanned multiple times - once for each row of the outer table. The FDW framework calls `re_scan()` to restart the inner scan for each outer row.

The ClickHouse FDW was using the default no-op `re_scan()` implementation, which caused joins to return incomplete results because after the first scan:
- `is_scan_complete` was still `true`
- `row_receiver` channel was exhausted
- No new streaming task was spawned

This fix implements `re_scan()` to restart the async streaming by:
- Aborting existing streaming task if running
- Resetting scan state flags
- Reinitializing the bounded channel
- Spawning new streaming task with the same SQL query
- Fetching the first row to initialize the rescan

## Test plan

- [x] Added integration test `clickhouse_join_test` that verifies inner, left, and right joins return correct results
- [x] All existing tests pass (`cargo pgrx test pg16`)
- [x] `cargo clippy` passes with no warnings
- [x] `cargo fmt` passes

The test creates two foreign tables with values (1, 2, 3) each and verifies:
- Inner join returns 3 rows with values (1,1), (2,2), (3,3)
- Left join returns 3 rows
- Right join returns 3 rows