### PR TITLE
fix(snowflake): change wit version to 0.2.1

### DIFF
--- a/wasm-wrappers/fdw/snowflake_fdw/wit/world.wit
+++ b/wasm-wrappers/fdw/snowflake_fdw/wit/world.wit
@@ -1,4 +1,4 @@
-package supabase:snowflake-fdw@0.2.0;
+package supabase:snowflake-fdw@0.2.1;
 
 world snowflake {
     import supabase:wrappers/http@0.2.0;


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to change Snowflake FDW wit version from `0.2.0` to `0.2.1`, which should be consistent with the version in the `Cargo.toml` file.

## What is the current behavior?

The current wit version for Snowflake FDW is `0.2.0`, but the Snowflake FDW project version in `Cargo.toml` is `0.2.1`.

## What is the new behavior?

Change wit version for Snowflake FDW to `0.2.1`.

## Additional context

N/A
