### PR TITLE
feat: add aggregate pushdown support (COUNT/SUM/AVG/MIN/MAX)

### DIFF
--- a/docs/catalog/bigquery.md
+++ b/docs/catalog/bigquery.md
@@ -144,13 +144,45 @@ create foreign table bigquery.my_bigquery_table (
 
 #### Notes
 
-- Supports `where`, `order by` and `limit` clause pushdown
+- Supports `where`, `order by`, `limit` and aggregate clause pushdown
 - When using `rowid_column`, it must be specified for data modification operations
 - Data in the streaming buffer cannot be updated or deleted until the buffer is flushed (up to 90 minutes)
 
 ## Query Pushdown Support
 
 This FDW supports `where`, `order by` and `limit` clause pushdown.
+
+### Aggregate Pushdown
+
+The FDW pushes common aggregate queries down to BigQuery so the aggregation
+runs remotely and only the final result rows are transferred to Postgres. This
+is much faster than fetching every row and aggregating locally, especially
+over large tables — and on BigQuery it also reduces the bytes scanned billed
+to your project.
+
+**Supported aggregates** — `count(*)`, `count(col)`, `count(distinct col)`,
+`sum(col)`, `avg(col)`, `min(col)`, `max(col)`.
+
+**Supported shapes** — scalar aggregates, `group by` over plain columns, with
+or without a `where` clause. Pushdown also works when the foreign `table`
+option is a sub-query.
+
+```sql
+-- All of these run as a single aggregate query on BigQuery:
+select count(*) from bigquery.my_table;
+select id, sum(amount) from bigquery.my_table group by id;
+select count(distinct name) from bigquery.my_table where id = 1;
+```
+
+**Cases that are not pushed down** — the query still returns the correct
+result, but the aggregation happens in Postgres after fetching the rows:
+
+- The query has a `having` clause
+- The aggregate has a `filter (where …)` clause
+- A `distinct` modifier is used on anything other than `count`
+- The aggregate's argument is not a plain column (for example `sum(a + 1)`)
+- A `group by` item is not a plain column (for example `group by id + 1`)
+- The aggregate function is not in the list above (for example `stddev`, `string_agg`)
 
 ## Inserting Rows & the Streaming Buffer
 
@@ -255,4 +287,68 @@ where id = 1;
 -- delete data
 delete from bigquery.people
 where id = 2;
+```
+
+### Aggregate Query Examples
+
+These examples assume an `orders` table on BigQuery and a matching foreign
+table on Postgres:
+
+```sql
+-- Run on BigQuery
+create table your_project_id.your_dataset_id.orders (
+  id       int64,
+  user_id  int64,
+  amount   numeric,
+  status   string
+);
+
+insert into your_project_id.your_dataset_id.orders values
+  (1, 1, 100.0, 'paid'),
+  (2, 1,  50.0, 'paid'),
+  (3, 2, 200.0, 'pending'),
+  (4, 2,  75.0, 'paid'),
+  (5, 3, 300.0, 'paid');
+```
+
+```sql
+-- Foreign table on Postgres
+create foreign table bigquery.orders (
+  id      bigint,
+  user_id bigint,
+  amount  numeric,
+  status  text
+)
+  server bigquery_server
+  options (
+    table 'orders'
+  );
+```
+
+Each query below runs a single aggregate query against BigQuery and returns
+just the result rows:
+
+```sql
+-- Total order count
+select count(*) from bigquery.orders;
+
+-- Total revenue from paid orders
+select sum(amount) from bigquery.orders where status = 'paid';
+
+-- Per-user order count and revenue
+select user_id, count(*) as orders, sum(amount) as revenue
+from bigquery.orders
+group by user_id
+order by user_id;
+
+-- Smallest and largest order
+select min(amount), max(amount) from bigquery.orders;
+
+-- Number of distinct users who placed an order
+select count(distinct user_id) from bigquery.orders;
+
+-- Average order value per status
+select status, avg(amount) as avg_amount
+from bigquery.orders
+group by status;
 ```

--- a/docs/catalog/clickhouse.md
+++ b/docs/catalog/clickhouse.md
@@ -153,13 +153,44 @@ create foreign table clickhouse.my_table (
 
 #### Notes
 
-- Supports `where`, `order by` and `limit` clause pushdown
+- Supports `where`, `order by`, `limit` and aggregate clause pushdown
 - Supports parametrized views in subqueries
 - When using `rowid_column`, it must be specified for data modification operations
 
 ## Query Pushdown Support
 
 This FDW supports `where`, `order by` and `limit` clause pushdown, as well as parametrized view (see above).
+
+### Aggregate Pushdown
+
+The FDW pushes common aggregate queries down to ClickHouse so the aggregation
+runs remotely and only the final result rows are transferred to Postgres. This
+is much faster than fetching every row and aggregating locally, especially
+over large tables.
+
+**Supported aggregates** — `count(*)`, `count(col)`, `count(distinct col)`,
+`sum(col)`, `avg(col)`, `min(col)`, `max(col)`.
+
+**Supported shapes** — scalar aggregates, `group by` over plain columns, with
+or without a `where` clause. Pushdown also works when the foreign `table`
+option is a sub-query or a parametrized view.
+
+```sql
+-- All of these run as a single aggregate query on ClickHouse:
+select count(*) from clickhouse.my_table;
+select id, sum(amount) from clickhouse.my_table group by id;
+select count(distinct name) from clickhouse.my_table where id = 1;
+```
+
+**Cases that are not pushed down** — the query still returns the correct
+result, but the aggregation happens in Postgres after fetching the rows:
+
+- The query has a `having` clause
+- The aggregate has a `filter (where …)` clause
+- A `distinct` modifier is used on anything other than `count`
+- The aggregate's argument is not a plain column (for example `sum(a + 1)`)
+- A `group by` item is not a plain column (for example `group by id + 1`)
+- The aggregate function is not in the list above (for example `stddev`, `string_agg`)
 
 ## Supported Data Types
 
@@ -243,4 +274,70 @@ select * from clickhouse.people;
 insert into clickhouse.people values (4, 'Yoda');
 update clickhouse.people set name = 'Princess Leia' where id = 2;
 delete from clickhouse.people where id = 3;
+```
+
+### Aggregate Query Examples
+
+These examples assume the `clickhouse.people` foreign table from the previous
+section, plus an `orders` table with a row per order:
+
+```sql
+-- Run on ClickHouse
+create table orders (
+  id        Int64,
+  person_id Int64,
+  amount    Float64,
+  status    String
+)
+engine=MergeTree()
+order by id;
+
+insert into orders values
+  (1, 1, 100.0, 'paid'),
+  (2, 1,  50.0, 'paid'),
+  (3, 2, 200.0, 'pending'),
+  (4, 2,  75.0, 'paid'),
+  (5, 3, 300.0, 'paid');
+```
+
+```sql
+-- Foreign table on Postgres
+create foreign table clickhouse.orders (
+  id        bigint,
+  person_id bigint,
+  amount    double precision,
+  status    text
+)
+  server clickhouse_server
+  options (
+    table 'orders'
+  );
+```
+
+Each query below runs a single aggregate query against ClickHouse and returns
+just the result rows:
+
+```sql
+-- Total order count
+select count(*) from clickhouse.orders;
+
+-- Total revenue from paid orders
+select sum(amount) from clickhouse.orders where status = 'paid';
+
+-- Per-person order count and revenue
+select person_id, count(*) as orders, sum(amount) as revenue
+from clickhouse.orders
+group by person_id
+order by person_id;
+
+-- Smallest and largest order
+select min(amount), max(amount) from clickhouse.orders;
+
+-- Number of distinct customers who placed an order
+select count(distinct person_id) from clickhouse.orders;
+
+-- Average order value per status
+select status, avg(amount) as avg_amount
+from clickhouse.orders
+group by status;
 ```

--- a/docs/catalog/mssql.md
+++ b/docs/catalog/mssql.md
@@ -145,11 +145,49 @@ create foreign table mssql.users (
       - `where` clauses
       - `order by` clauses
       - `limit` clauses
+      - aggregate clauses
 - See Data Types section for type mappings between PostgreSQL and SQL Server
 
 ## Query Pushdown Support
 
 This FDW supports `where`, `order by` and `limit` clause pushdown.
+
+### Aggregate Pushdown
+
+The FDW pushes common aggregate queries down to SQL Server so the aggregation
+runs remotely and only the final result rows are transferred to Postgres. This
+is much faster than fetching every row and aggregating locally, especially
+over large tables.
+
+**Supported aggregates** — `count(*)`, `count(col)`, `count(distinct col)`,
+`sum(col)`, `avg(col)`, `min(col)`, `max(col)`.
+
+**Supported shapes** — scalar aggregates, `group by` over plain columns, with
+or without a `where` clause. Pushdown also works when the foreign `table`
+option is a sub-query.
+
+```sql
+-- All of these run as a single aggregate query on SQL Server:
+select count(*) from mssql.users;
+select id, sum(amount) from mssql.users group by id;
+select count(distinct name) from mssql.users where id = 42;
+```
+
+`count(*)` and `count(col)` are translated to SQL Server's `count_big` so the
+result fits Postgres' `bigint` without overflow. Each aggregate is also wrapped
+in a `cast(... as <sql_server_type>)` so values come back in the exact type
+Postgres expects (for example, `sum` over a `bigint` column is cast to
+`numeric`, matching Postgres' `sum(bigint) → numeric` rule).
+
+**Cases that are not pushed down** — the query still returns the correct
+result, but the aggregation happens in Postgres after fetching the rows:
+
+- The query has a `having` clause
+- The aggregate has a `filter (where …)` clause
+- A `distinct` modifier is used on anything other than `count`
+- The aggregate's argument is not a plain column (for example `sum(a + 1)`)
+- A `group by` item is not a plain column (for example `group by id + 1`)
+- The aggregate function is not in the list above (for example `stddev`, `string_agg`)
 
 ## Supported Data Types
 
@@ -230,4 +268,68 @@ create foreign table mssql.users_subquery (
   );
 
 select * from mssql.users_subquery;
+```
+
+### Aggregate Query Examples
+
+These examples assume an `orders` table on SQL Server and a matching foreign
+table on Postgres:
+
+```sql
+-- Run on SQL Server
+create table orders (
+  id        bigint,
+  user_id   bigint,
+  amount    numeric(18,2),
+  status    varchar(20)
+);
+
+insert into orders (id, user_id, amount, status) values
+  (1, 42, 100.00, 'paid'),
+  (2, 42,  50.00, 'paid'),
+  (3, 43, 200.00, 'pending'),
+  (4, 43,  75.00, 'paid'),
+  (5, 44, 300.00, 'paid');
+```
+
+```sql
+-- Foreign table on Postgres
+create foreign table mssql.orders (
+  id      bigint,
+  user_id bigint,
+  amount  numeric(18,2),
+  status  text
+)
+  server mssql_server
+  options (
+    table 'orders'
+  );
+```
+
+Each query below runs a single aggregate query against SQL Server and returns
+just the result rows:
+
+```sql
+-- Total order count
+select count(*) from mssql.orders;
+
+-- Total revenue from paid orders
+select sum(amount) from mssql.orders where status = 'paid';
+
+-- Per-user order count and revenue
+select user_id, count(*) as orders, sum(amount) as revenue
+from mssql.orders
+group by user_id
+order by user_id;
+
+-- Smallest and largest order
+select min(amount), max(amount) from mssql.orders;
+
+-- Number of distinct users who placed an order
+select count(distinct user_id) from mssql.orders;
+
+-- Average order value per status
+select status, avg(amount) as avg_amount
+from mssql.orders
+group by status;
 ```

--- a/docs/contributing/native.md
+++ b/docs/contributing/native.md
@@ -25,6 +25,12 @@ pub trait ForeignDataWrapper {
     fn delete(...);
     fn end_modify(...);
 
+    // functions for aggregate pushdown (optional)
+    fn supported_aggregates(...) -> Vec<AggregateKind>;
+    fn supports_group_by(...) -> bool;
+    fn get_aggregate_rel_size(...) -> (i64, i32);
+    fn begin_aggregate_scan(...);
+
     // other optional functions
     ...
 }

--- a/docs/guides/query-pushdown.md
+++ b/docs/guides/query-pushdown.md
@@ -10,7 +10,7 @@ Query pushdown is a technique that enhances query performance by executing parts
 
 ### Using Query Pushdown
 
-In Wrappers, the pushdown logic is integrated into each FDW. You don’t need to modify your queries to benefit from this feature. For example, the [Stripe FDW](https://supabase.com/docs/guides/database/extensions/wrappers/stripe) automatically applies query pushdown for `id` within the `customer` object:
+In Wrappers, the pushdown logic is integrated into each FDW. You don't need to modify your queries to benefit from this feature. For example, the [Stripe FDW](https://supabase.com/docs/guides/database/extensions/wrappers/stripe) automatically applies query pushdown for `id` within the `customer` object:
 
 ```sql
 select *
@@ -34,3 +34,68 @@ limit 20;
 ```
 
 This query executes `order by name limit 20` on ClickHouse before transferring the result to Postgres.
+
+### Aggregate Pushdown
+
+Aggregate pushdown allows aggregate functions like `COUNT`, `SUM`, `AVG`, `MIN`, and `MAX` to be executed directly on the foreign data source. This is especially valuable for analytics queries where you only need summary statistics rather than raw data.
+
+```sql
+select count(*), sum(amount), avg(amount)
+from foreign_table
+where status = 'active';
+```
+
+Instead of fetching all matching rows and computing aggregates locally, the FDW can push the entire aggregation to the remote source. This dramatically reduces data transfer - returning just a single row with the computed values.
+
+#### GROUP BY Support
+
+FDWs that support aggregate pushdown can also support `GROUP BY` pushdown:
+
+```sql
+select department, count(*), avg(salary)
+from employees
+group by department;
+```
+
+This executes the grouping and aggregation on the remote server, returning only the grouped results.
+
+#### Supported Aggregate Functions
+
+The Wrappers framework supports pushing down these aggregate functions:
+
+| Function | Description |
+|----------|-------------|
+| `COUNT(*)` | Count all rows |
+| `COUNT(column)` | Count non-null values |
+| `COUNT(DISTINCT column)` | Count unique non-null values |
+| `SUM(column)` | Sum of values |
+| `AVG(column)` | Average of values |
+| `MIN(column)` | Minimum value |
+| `MAX(column)` | Maximum value |
+
+#### Implementing Aggregate Pushdown
+
+FDW developers can enable aggregate pushdown by implementing these trait methods:
+
+```rust
+fn supported_aggregates(&self) -> Vec<AggregateKind> {
+    vec![AggregateKind::Count, AggregateKind::Sum, AggregateKind::Avg]
+}
+
+fn supports_group_by(&self) -> bool {
+    true
+}
+
+fn begin_aggregate_scan(
+    &mut self,
+    aggregates: &[Aggregate],
+    group_by: &[Column],
+    quals: &[Qual],
+    options: &HashMap<String, String>,
+) -> Result<(), Error> {
+    // Build and execute remote aggregate query
+    Ok(())
+}
+```
+
+See the [API documentation](https://docs.rs/supabase-wrappers/latest/supabase_wrappers/) for detailed information on implementing aggregate pushdown.

--- a/supabase-wrappers/src/interface.rs
+++ b/supabase-wrappers/src/interface.rs
@@ -682,6 +682,167 @@ impl Limit {
     }
 }
 
+/// Represents the type of aggregate function for pushdown
+///
+/// This enum is used to declare which aggregate functions an FDW supports
+/// for remote execution via [`ForeignDataWrapper::supported_aggregates`].
+///
+/// ## Examples
+///
+/// ```rust,no_run
+/// use supabase_wrappers::prelude::*;
+///
+/// fn get_supported() -> Vec<AggregateKind> {
+///     vec![
+///         AggregateKind::Count,
+///         AggregateKind::Sum,
+///         AggregateKind::Avg,
+///     ]
+/// }
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AggregateKind {
+    /// COUNT(*) - count all rows
+    Count,
+    /// COUNT(column) - count non-null values in a column
+    CountColumn,
+    /// SUM(column) - sum of values
+    Sum,
+    /// AVG(column) - average of values
+    Avg,
+    /// MIN(column) - minimum value
+    Min,
+    /// MAX(column) - maximum value
+    Max,
+}
+
+impl AggregateKind {
+    /// Returns the SQL function name for this aggregate kind
+    ///
+    /// ## Examples
+    ///
+    /// ```rust,no_run
+    /// use supabase_wrappers::prelude::*;
+    ///
+    /// assert_eq!(AggregateKind::Count.sql_name(), "COUNT");
+    /// assert_eq!(AggregateKind::Sum.sql_name(), "SUM");
+    /// ```
+    pub fn sql_name(&self) -> &'static str {
+        match self {
+            AggregateKind::Count => "COUNT",
+            AggregateKind::CountColumn => "COUNT",
+            AggregateKind::Sum => "SUM",
+            AggregateKind::Avg => "AVG",
+            AggregateKind::Min => "MIN",
+            AggregateKind::Max => "MAX",
+        }
+    }
+}
+
+/// Represents a single aggregate operation in a pushed-down query
+///
+/// This struct contains all information needed for an FDW to execute an
+/// aggregate function remotely.
+///
+/// ## Examples
+///
+/// ```rust,no_run
+/// use supabase_wrappers::prelude::*;
+///
+/// // COUNT(*) aggregate
+/// let count_all = Aggregate {
+///     kind: AggregateKind::Count,
+///     column: None,
+///     distinct: false,
+///     alias: "count".to_string(),
+/// };
+///
+/// // SUM(amount) aggregate
+/// let sum_amount = Aggregate {
+///     kind: AggregateKind::Sum,
+///     column: Some(Column {
+///         name: "amount".to_string(),
+///         num: 1,
+///         type_oid: pgrx::pg_sys::FLOAT8OID,
+///     }),
+///     distinct: false,
+///     alias: "total_amount".to_string(),
+/// };
+/// ```
+#[derive(Debug, Clone)]
+pub struct Aggregate {
+    /// Type of aggregate function
+    pub kind: AggregateKind,
+
+    /// Column being aggregated (None for COUNT(*))
+    pub column: Option<Column>,
+
+    /// Whether DISTINCT modifier is applied (e.g., COUNT(DISTINCT col))
+    pub distinct: bool,
+
+    /// Output column name/alias for the aggregate result
+    pub alias: String,
+}
+
+impl Aggregate {
+    /// Deparses the aggregate into SQL syntax
+    ///
+    /// ## Examples
+    ///
+    /// ```rust,no_run
+    /// use supabase_wrappers::prelude::*;
+    ///
+    /// let count_all = Aggregate {
+    ///     kind: AggregateKind::Count,
+    ///     column: None,
+    ///     distinct: false,
+    ///     alias: "cnt".to_string(),
+    /// };
+    /// assert_eq!(count_all.deparse(), "COUNT(*)");
+    ///
+    /// let sum_col = Aggregate {
+    ///     kind: AggregateKind::Sum,
+    ///     column: Some(Column { name: "price".to_string(), num: 1, type_oid: pgrx::pg_sys::Oid::INVALID }),
+    ///     distinct: false,
+    ///     alias: "total".to_string(),
+    /// };
+    /// assert_eq!(sum_col.deparse(), "SUM(price)");
+    /// ```
+    pub fn deparse(&self) -> String {
+        let func_name = self.kind.sql_name();
+        match self.kind {
+            AggregateKind::Count => format!("{func_name}(*)"),
+            _ => {
+                let col_name = self.column.as_ref().map(|c| c.name.as_str()).unwrap_or("*");
+                if self.distinct {
+                    format!("{func_name}(DISTINCT {col_name})")
+                } else {
+                    format!("{func_name}({col_name})")
+                }
+            }
+        }
+    }
+
+    /// Deparses the aggregate with its alias for use in SELECT
+    ///
+    /// ## Examples
+    ///
+    /// ```rust,no_run
+    /// use supabase_wrappers::prelude::*;
+    ///
+    /// let count_all = Aggregate {
+    ///     kind: AggregateKind::Count,
+    ///     column: None,
+    ///     distinct: false,
+    ///     alias: "cnt".to_string(),
+    /// };
+    /// assert_eq!(count_all.deparse_with_alias(), "COUNT(*) AS cnt");
+    /// ```
+    pub fn deparse_with_alias(&self) -> String {
+        format!("{} AS {}", self.deparse(), self.alias)
+    }
+}
+
 /// The Foreign Data Wrapper trait
 ///
 /// This is the main interface for your foreign data wrapper. Required functions
@@ -831,6 +992,173 @@ pub trait ForeignDataWrapper<E: Into<ErrorReport>> {
         Ok(())
     }
 
+    // =========================================================================
+    // Aggregate Pushdown Methods
+    // =========================================================================
+
+    /// Returns the list of aggregate functions this FDW can push down to the
+    /// remote data source.
+    ///
+    /// Default implementation returns an empty vector (no aggregate pushdown).
+    /// Override this method to enable aggregate pushdown for your FDW.
+    ///
+    /// When this method returns a non-empty vector, the framework will:
+    /// 1. Check if the query's aggregates are all supported
+    /// 2. Call [`get_aggregate_rel_size`](Self::get_aggregate_rel_size) for cost estimation
+    /// 3. Create an aggregate path in the query planner
+    /// 4. Call [`begin_aggregate_scan`](Self::begin_aggregate_scan) if the aggregate path is chosen
+    ///
+    /// ## Examples
+    ///
+    /// ```rust,ignore
+    /// use supabase_wrappers::prelude::*;
+    ///
+    /// fn supported_aggregates(&self) -> Vec<AggregateKind> {
+    ///     vec![
+    ///         AggregateKind::Count,
+    ///         AggregateKind::CountColumn,
+    ///         AggregateKind::Sum,
+    ///         AggregateKind::Avg,
+    ///         AggregateKind::Min,
+    ///         AggregateKind::Max,
+    ///     ]
+    /// }
+    /// ```
+    fn supported_aggregates(&self) -> Vec<AggregateKind> {
+        vec![]
+    }
+
+    /// Returns whether this FDW supports GROUP BY pushdown alongside aggregates.
+    ///
+    /// Only relevant if [`supported_aggregates`](Self::supported_aggregates) returns a non-empty vector.
+    /// Default implementation returns `false`.
+    ///
+    /// When `true`, GROUP BY columns will be passed to [`begin_aggregate_scan`](Self::begin_aggregate_scan).
+    ///
+    /// ## Examples
+    ///
+    /// ```rust,ignore
+    /// fn supports_group_by(&self) -> bool {
+    ///     true
+    /// }
+    /// ```
+    fn supports_group_by(&self) -> bool {
+        false
+    }
+
+    /// Estimate the size of aggregate query results for query planning.
+    ///
+    /// Called during query planning when aggregate pushdown is being considered.
+    /// Returns `(estimated_rows, mean_row_width_bytes)`.
+    ///
+    /// Default implementation estimates:
+    /// - 1 row for ungrouped aggregates (e.g., `SELECT COUNT(*) FROM t`)
+    /// - 100 rows for grouped aggregates (e.g., `SELECT dept, COUNT(*) FROM t GROUP BY dept`)
+    ///
+    /// Override this method if you can provide better estimates based on your
+    /// knowledge of the remote data source.
+    ///
+    /// ## Parameters
+    ///
+    /// - `aggregates`: List of aggregate operations to be computed
+    /// - `group_by`: Columns in GROUP BY clause (empty if none)
+    /// - `quals`: WHERE clause conditions
+    /// - `options`: Foreign table options
+    ///
+    /// ## Examples
+    ///
+    /// ```rust,ignore
+    /// fn get_aggregate_rel_size(
+    ///     &mut self,
+    ///     aggregates: &[Aggregate],
+    ///     group_by: &[Column],
+    ///     quals: &[Qual],
+    ///     options: &HashMap<String, String>,
+    /// ) -> Result<(i64, i32), MyFdwError> {
+    ///     let rows = if group_by.is_empty() { 1 } else { 50 };
+    ///     let width = 8 * aggregates.len() as i32;
+    ///     Ok((rows, width))
+    /// }
+    /// ```
+    fn get_aggregate_rel_size(
+        &mut self,
+        aggregates: &[Aggregate],
+        group_by: &[Column],
+        _quals: &[Qual],
+        _options: &HashMap<String, String>,
+    ) -> Result<(i64, i32), E> {
+        // Default: 1 row if no GROUP BY, otherwise estimate 100 rows
+        let rows = if group_by.is_empty() { 1 } else { 100 };
+        let width = 8 * aggregates.len() as i32;
+        Ok((rows, width))
+    }
+
+    /// Called when beginning execution of a pushed-down aggregate query.
+    ///
+    /// This method is called instead of [`begin_scan`](Self::begin_scan) when
+    /// the query planner chooses the aggregate pushdown path. The FDW should
+    /// prepare to return aggregate results based on the provided parameters.
+    ///
+    /// After this method returns successfully, [`iter_scan`](Self::iter_scan)
+    /// will be called to retrieve the aggregate results.
+    ///
+    /// ## Parameters
+    ///
+    /// - `aggregates`: List of aggregate operations to compute
+    /// - `group_by`: Columns to group by (empty for ungrouped aggregates)
+    /// - `quals`: WHERE clause conditions to apply before aggregation
+    /// - `options`: Foreign table options
+    ///
+    /// ## Result Row Format
+    ///
+    /// The rows returned by [`iter_scan`](Self::iter_scan) should contain:
+    /// 1. GROUP BY column values (in order specified)
+    /// 2. Aggregate results (in order specified, using `alias` as column name)
+    ///
+    /// ## Examples
+    ///
+    /// ```rust,ignore
+    /// fn begin_aggregate_scan(
+    ///     &mut self,
+    ///     aggregates: &[Aggregate],
+    ///     group_by: &[Column],
+    ///     quals: &[Qual],
+    ///     options: &HashMap<String, String>,
+    /// ) -> Result<(), MyFdwError> {
+    ///     // Build remote query with aggregates
+    ///     let mut select_items = Vec::new();
+    ///
+    ///     // Add GROUP BY columns
+    ///     for col in group_by {
+    ///         select_items.push(col.name.clone());
+    ///     }
+    ///
+    ///     // Add aggregate expressions
+    ///     for agg in aggregates {
+    ///         select_items.push(agg.deparse_with_alias());
+    ///     }
+    ///
+    ///     let query = format!("SELECT {} FROM ...", select_items.join(", "));
+    ///
+    ///     // Execute and store results for iter_scan
+    ///     self.results = self.execute_query(&query)?;
+    ///     Ok(())
+    /// }
+    /// ```
+    fn begin_aggregate_scan(
+        &mut self,
+        _aggregates: &[Aggregate],
+        _group_by: &[Column],
+        _quals: &[Qual],
+        _options: &HashMap<String, String>,
+    ) -> Result<(), E> {
+        // Default: This should not be called if supported_aggregates() returns empty.
+        // If called, it means the FDW declared aggregate support but didn't implement
+        // this method - which is a programming error. We'll just proceed with an
+        // empty result set by returning Ok.
+        Ok(())
+    }
+
     /// Obtain a list of foreign table creation commands
     ///
     /// Return a list of string, each of which must contain a CREATE FOREIGN TABLE
@@ -852,7 +1180,7 @@ pub trait ForeignDataWrapper<E: Into<ErrorReport>> {
         Self: Sized,
     {
         unsafe {
-            use crate::{import_foreign_schema, modify, scan};
+            use crate::{import_foreign_schema, modify, scan, upper};
             let mut fdw_routine =
                 FdwRoutine::<AllocatedByRust>::alloc_node(pg_sys::NodeTag::T_FdwRoutine);
 
@@ -865,6 +1193,9 @@ pub trait ForeignDataWrapper<E: Into<ErrorReport>> {
             fdw_routine.GetForeignPaths = Some(scan::get_foreign_paths::<E, Self>);
             fdw_routine.GetForeignPlan = Some(scan::get_foreign_plan::<E, Self>);
             fdw_routine.ExplainForeignScan = Some(scan::explain_foreign_scan::<E, Self>);
+
+            // upper path planning (aggregate pushdown)
+            fdw_routine.GetForeignUpperPaths = Some(upper::get_foreign_upper_paths::<E, Self>);
 
             // scan phase
             fdw_routine.BeginForeignScan = Some(scan::begin_foreign_scan::<E, Self>);

--- a/supabase-wrappers/src/interface.rs
+++ b/supabase-wrappers/src/interface.rs
@@ -1180,7 +1180,7 @@ pub trait ForeignDataWrapper<E: Into<ErrorReport>> {
         Self: Sized,
     {
         unsafe {
-            use crate::{import_foreign_schema, modify, scan, upper};
+            use crate::{import_foreign_schema, modify, scan};
             let mut fdw_routine =
                 FdwRoutine::<AllocatedByRust>::alloc_node(pg_sys::NodeTag::T_FdwRoutine);
 
@@ -1195,7 +1195,18 @@ pub trait ForeignDataWrapper<E: Into<ErrorReport>> {
             fdw_routine.ExplainForeignScan = Some(scan::explain_foreign_scan::<E, Self>);
 
             // upper path planning (aggregate pushdown)
-            fdw_routine.GetForeignUpperPaths = Some(upper::get_foreign_upper_paths::<E, Self>);
+            #[cfg(any(
+                feature = "pg13",
+                feature = "pg14",
+                feature = "pg15",
+                feature = "pg16",
+                feature = "pg17",
+                feature = "pg18"
+            ))]
+            {
+                use crate::upper;
+                fdw_routine.GetForeignUpperPaths = Some(upper::get_foreign_upper_paths::<E, Self>);
+            }
 
             // scan phase
             fdw_routine.BeginForeignScan = Some(scan::begin_foreign_scan::<E, Self>);

--- a/supabase-wrappers/src/interface.rs
+++ b/supabase-wrappers/src/interface.rs
@@ -1162,12 +1162,13 @@ pub trait ForeignDataWrapper<E: Into<ErrorReport>> {
     ) -> Result<(), E> {
         // This should not be called unless supported_aggregates() returns non-empty.
         // If we reach here, the FDW declared aggregate support but didn't override
-        // this method — emit a warning so the developer knows to implement it.
-        crate::utils::report_warning(
-            "begin_aggregate_scan called but not implemented; \
+        // this method — abort the transaction to prevent wrong results.
+        crate::utils::report_error(
+            pgrx::PgSqlErrorCode::ERRCODE_FDW_ERROR,
+            "begin_aggregate_scan() not implemented; \
              override this method when supported_aggregates() is non-empty",
         );
-        Ok(())
+        unreachable!()
     }
 
     /// Obtain a list of foreign table creation commands

--- a/supabase-wrappers/src/interface.rs
+++ b/supabase-wrappers/src/interface.rs
@@ -755,6 +755,7 @@ impl AggregateKind {
 ///     column: None,
 ///     distinct: false,
 ///     alias: "count".to_string(),
+///     type_oid: pgrx::pg_sys::INT8OID,
 /// };
 ///
 /// // SUM(amount) aggregate
@@ -767,6 +768,7 @@ impl AggregateKind {
 ///     }),
 ///     distinct: false,
 ///     alias: "total_amount".to_string(),
+///     type_oid: pgrx::pg_sys::FLOAT8OID,
 /// };
 /// ```
 #[derive(Debug, Clone)]
@@ -782,6 +784,9 @@ pub struct Aggregate {
 
     /// Output column name/alias for the aggregate result
     pub alias: String,
+
+    /// Result type OID of the aggregate function (from Aggref::aggtype)
+    pub type_oid: Oid,
 }
 
 impl Aggregate {
@@ -797,6 +802,7 @@ impl Aggregate {
     ///     column: None,
     ///     distinct: false,
     ///     alias: "cnt".to_string(),
+    ///     type_oid: pgrx::pg_sys::INT8OID,
     /// };
     /// assert_eq!(count_all.deparse(), "COUNT(*)");
     ///
@@ -805,6 +811,7 @@ impl Aggregate {
     ///     column: Some(Column { name: "price".to_string(), num: 1, type_oid: pgrx::pg_sys::Oid::INVALID }),
     ///     distinct: false,
     ///     alias: "total".to_string(),
+    ///     type_oid: pgrx::pg_sys::FLOAT8OID,
     /// };
     /// assert_eq!(sum_col.deparse(), "SUM(price)");
     /// ```
@@ -835,6 +842,7 @@ impl Aggregate {
     ///     column: None,
     ///     distinct: false,
     ///     alias: "cnt".to_string(),
+    ///     type_oid: pgrx::pg_sys::INT8OID,
     /// };
     /// assert_eq!(count_all.deparse_with_alias(), "COUNT(*) AS cnt");
     /// ```
@@ -1152,10 +1160,13 @@ pub trait ForeignDataWrapper<E: Into<ErrorReport>> {
         _quals: &[Qual],
         _options: &HashMap<String, String>,
     ) -> Result<(), E> {
-        // Default: This should not be called if supported_aggregates() returns empty.
-        // If called, it means the FDW declared aggregate support but didn't implement
-        // this method - which is a programming error. We'll just proceed with an
-        // empty result set by returning Ok.
+        // This should not be called unless supported_aggregates() returns non-empty.
+        // If we reach here, the FDW declared aggregate support but didn't override
+        // this method — emit a warning so the developer knows to implement it.
+        crate::utils::report_warning(
+            "begin_aggregate_scan called but not implemented; \
+             override this method when supported_aggregates() is non-empty",
+        );
         Ok(())
     }
 

--- a/supabase-wrappers/src/lib.rs
+++ b/supabase-wrappers/src/lib.rs
@@ -320,6 +320,17 @@ mod qual;
 mod scan;
 mod sort;
 
+// The upper module uses pgrx::PgList which requires PG features
+#[cfg(any(
+    feature = "pg13",
+    feature = "pg14",
+    feature = "pg15",
+    feature = "pg16",
+    feature = "pg17",
+    feature = "pg18"
+))]
+mod upper;
+
 /// PgBox'ed `FdwRoutine`, used in [`fdw_routine`](interface::ForeignDataWrapper::fdw_routine)
 pub type FdwRoutine<A = AllocatedByPostgres> = PgBox<pg_sys::FdwRoutine, A>;
 

--- a/supabase-wrappers/src/scan.rs
+++ b/supabase-wrappers/src/scan.rs
@@ -287,10 +287,99 @@ pub(super) extern "C-unwind" fn get_foreign_plan<E: Into<ErrorReport>, W: Foreig
 ) -> *mut pg_sys::ForeignScan {
     debug2!("---> get_foreign_plan");
     unsafe {
-        let state = PgBox::<FdwState<E, W>>::from_pg((*baserel).fdw_private as _);
+        let mut state = PgBox::<FdwState<E, W>>::from_pg((*baserel).fdw_private as _);
 
         // make foreign scan plan
         let scan_clauses = pg_sys::extract_actual_clauses(scan_clauses, false);
+
+        // Aggregate pushdown: state.aggregates was populated by upper.rs via the
+        // shared FdwState pointer (input_rel.fdw_private and output_rel.fdw_private
+        // alias the same object). That mutation is visible regardless of which
+        // path the planner picked, so it cannot be used as the discriminator —
+        // we must key off baserel.reloptkind. When the planner picked the upper
+        // aggregate path, baserel IS the upper rel; otherwise we are being called
+        // for the base-rel scan path (with a local Aggregate node above us) and
+        // must NOT treat this as an aggregate scan.
+        let is_agg = (*baserel).reloptkind == pg_sys::RelOptKind::RELOPT_UPPER_REL
+            && state.is_aggregate_scan();
+
+        if !is_agg && state.is_aggregate_scan() {
+            // Upper-path was registered but the planner chose the base-rel scan
+            // (typically because a local HashAgg over a small input was cheaper).
+            // Drop the aggregate state so begin_foreign_scan dispatches to
+            // begin_scan and the tuple slot is the base-rel's row type.
+            state.aggregates = Vec::new();
+            state.group_by = Vec::new();
+        }
+
+        let (final_tlist, agg_fdw_scan_tlist) = if is_agg {
+            // baserel here is the GROUP_AGG upper rel; its reltarget->exprs
+            // contains the aggregate outputs (Var nodes for GROUP BY columns
+            // and Aggref nodes for the aggregates). Build both the plan tlist
+            // and fdw_scan_tlist from it so:
+            //   1. final_tlist has the right Aggref/Var nodes for
+            //      set_foreignscan_references to rewrite into Var(INDEX_VAR,n).
+            //   2. fdw_scan_tlist drives ExecTypeFromTL to a tuple descriptor
+            //      whose attribute types match what iter_scan returns —
+            //      otherwise heap_form_tuple dereferences a non-pointer Datum
+            //      and segfaults.
+            let reltarget = (*baserel).reltarget;
+            let exprs = (*reltarget).exprs;
+            let n = if exprs.is_null() {
+                0
+            } else {
+                (*exprs).length as usize
+            };
+            let mut agg_tlist: *mut pg_sys::List = ptr::null_mut();
+            for i in 0..n {
+                let cell = (*exprs).elements.add(i);
+                let expr = (*cell).ptr_value as *mut pg_sys::Expr;
+                let tle = pg_sys::makeTargetEntry(
+                    expr,
+                    (i + 1) as pg_sys::AttrNumber,
+                    ptr::null_mut(),
+                    false,
+                );
+                // Preserve sortgrouprefs so Sort nodes can identify columns.
+                if !(*reltarget).sortgrouprefs.is_null() {
+                    (*tle).ressortgroupref = *(*reltarget).sortgrouprefs.add(i);
+                }
+                agg_tlist = pg_sys::lappend(agg_tlist, tle as *mut std::ffi::c_void);
+            }
+            let fdw_scan_tlist = pg_sys::list_copy(agg_tlist);
+
+            // Now that we know the upper path is in the plan, project state.tgts
+            // to match the aggregate output shape. iterate_foreign_scan uses
+            // tgts to map cells returned by the FDW's iter_scan into the
+            // correct attribute slots; for aggregate scans this is GROUP BY
+            // columns first, then aggregate result columns keyed by alias.
+            // We keep this off the base-rel-scan code path so state.tgts (the
+            // base-rel scan columns set in get_foreign_rel_size) is preserved
+            // when the planner picks the base-rel path.
+            let mut new_tgts = Vec::new();
+            let mut col_num = 1usize;
+            for col in &state.group_by {
+                new_tgts.push(Column {
+                    name: col.name.clone(),
+                    num: col_num,
+                    type_oid: col.type_oid,
+                });
+                col_num += 1;
+            }
+            for agg in &state.aggregates {
+                new_tgts.push(Column {
+                    name: agg.alias.clone(),
+                    num: col_num,
+                    type_oid: agg.type_oid,
+                });
+                col_num += 1;
+            }
+            state.tgts = new_tgts;
+
+            (agg_tlist, fdw_scan_tlist)
+        } else {
+            (tlist, ptr::null_mut())
+        };
 
         // 'serialize' state to list, basically what we're doing here is to store
         // the state pointer as an integer constant in the list, so it can be
@@ -302,12 +391,12 @@ pub(super) extern "C-unwind" fn get_foreign_plan<E: Into<ErrorReport>, W: Foreig
             PgMemoryContexts::For(state.tmp_ctx).switch_to(|_| FdwState::serialize_to_list(state));
 
         pg_sys::make_foreignscan(
-            tlist,
+            final_tlist,
             scan_clauses,
             (*baserel).relid,
             ptr::null_mut(),
             fdw_private as _,
-            ptr::null_mut(),
+            agg_fdw_scan_tlist,
             ptr::null_mut(),
             outer_plan,
         )
@@ -445,9 +534,14 @@ pub(super) extern "C-unwind" fn begin_foreign_scan<
                 result.report_unwrap();
             }
 
-            let rel = scan_state.ss_currentRelation;
-            let tup_desc = (*rel).rd_att;
-            let natts = (*tup_desc).natts as usize;
+            // For aggregate upper-rel scans, scanrelid=0 so ss_currentRelation is
+            // NULL. Use the number of output columns from state.tgts instead.
+            let natts = if state.is_aggregate_scan() {
+                state.tgts.len()
+            } else {
+                let rel = scan_state.ss_currentRelation;
+                (*(*rel).rd_att).natts as usize
+            };
 
             // initialize scan result lists
             state
@@ -495,6 +589,7 @@ pub(super) extern "C-unwind" fn iterate_foreign_scan<
                 return slot;
             }
 
+            let is_agg = state.is_aggregate_scan();
             PgMemoryContexts::For(state.tmp_ctx).switch_to(|_| {
                 for i in 0..state.row.cells.len() {
                     let att_idx = state.tgts[i].num - 1;
@@ -504,13 +599,32 @@ pub(super) extern "C-unwind" fn iterate_foreign_scan<
                             state.values[att_idx] = cell.into_datum().unwrap();
                             state.nulls[att_idx] = false;
                         }
-                        None => state.nulls[att_idx] = true,
+                        None => {
+                            state.nulls[att_idx] = true;
+                        }
                     }
                 }
 
-                (*slot).tts_values = state.values.as_mut_ptr();
-                (*slot).tts_isnull = state.nulls.as_mut_ptr();
-                pg_sys::ExecStoreVirtualTuple(slot);
+                if is_agg {
+                    // For aggregate scans the slot type is TTSOpsHeapTuple (because
+                    // fdw_scan_tlist != NIL).  ExecStoreVirtualTuple is only correct
+                    // for TTSOpsVirtual slots; using it on a HeapTuple slot leaves
+                    // hslot->tuple == NULL, which causes tts_heap_materialize (called
+                    // by Sort) to re-read tts_values after zeroing tts_nvalid —
+                    // resulting in a SIGSEGV when a Sort node is present (ORDER BY).
+                    // Form a proper HeapTuple and use ExecStoreHeapTuple instead.
+                    let desc = (*slot).tts_tupleDescriptor;
+                    let htup = pg_sys::heap_form_tuple(
+                        desc,
+                        state.values.as_mut_ptr(),
+                        state.nulls.as_mut_ptr(),
+                    );
+                    pg_sys::ExecStoreHeapTuple(htup, slot, true);
+                } else {
+                    (*slot).tts_values = state.values.as_mut_ptr();
+                    (*slot).tts_isnull = state.nulls.as_mut_ptr();
+                    pg_sys::ExecStoreVirtualTuple(slot);
+                }
             });
         }
 

--- a/supabase-wrappers/src/scan.rs
+++ b/supabase-wrappers/src/scan.rs
@@ -13,7 +13,7 @@ use std::os::raw::c_int;
 use std::ptr;
 
 use crate::instance;
-use crate::interface::{Cell, Column, Limit, Qual, Row, Sort, Value};
+use crate::interface::{Aggregate, Cell, Column, Limit, Qual, Row, Sort, Value};
 use crate::limit::*;
 use crate::memctx;
 use crate::options::options_to_hashmap;
@@ -24,24 +24,28 @@ use crate::sort::*;
 use crate::utils::{self, ReportableError, SerdeList, report_error};
 
 // Fdw private state for scan
-struct FdwState<E: Into<ErrorReport>, W: ForeignDataWrapper<E>> {
+pub(crate) struct FdwState<E: Into<ErrorReport>, W: ForeignDataWrapper<E>> {
     // foreign data wrapper instance
-    instance: Option<W>,
+    pub(crate) instance: Option<W>,
 
     // query conditions
-    quals: Vec<Qual>,
+    pub(crate) quals: Vec<Qual>,
 
     // query target column list
-    tgts: Vec<Column>,
+    pub(crate) tgts: Vec<Column>,
 
     // sort list
-    sorts: Vec<Sort>,
+    pub(crate) sorts: Vec<Sort>,
 
     // limit
-    limit: Option<Limit>,
+    pub(crate) limit: Option<Limit>,
 
     // foreign table options
-    opts: HashMap<String, String>,
+    pub(crate) opts: HashMap<String, String>,
+
+    // aggregate pushdown
+    pub(crate) aggregates: Vec<Aggregate>,
+    pub(crate) group_by: Vec<Column>,
 
     // temporary memory context per foreign table, created under Wrappers root
     // memory context
@@ -63,6 +67,8 @@ impl<E: Into<ErrorReport>, W: ForeignDataWrapper<E>> FdwState<E, W> {
             sorts: Vec::new(),
             limit: None,
             opts: HashMap::new(),
+            aggregates: Vec::new(),
+            group_by: Vec::new(),
             tmp_ctx,
             values: Vec::new(),
             nulls: Vec::new(),
@@ -83,6 +89,20 @@ impl<E: Into<ErrorReport>, W: ForeignDataWrapper<E>> FdwState<E, W> {
             )
         } else {
             Ok((0, 0))
+        }
+    }
+
+    #[inline]
+    pub(crate) fn is_aggregate_scan(&self) -> bool {
+        !self.aggregates.is_empty()
+    }
+
+    #[inline]
+    fn begin_aggregate_scan(&mut self) -> Result<(), E> {
+        if let Some(ref mut instance) = self.instance {
+            instance.begin_aggregate_scan(&self.aggregates, &self.group_by, &self.quals, &self.opts)
+        } else {
+            Ok(())
         }
     }
 
@@ -326,6 +346,14 @@ pub(super) extern "C-unwind" fn explain_foreign_scan<
 
         let value = ctx.pstrdup(&format!("limit = {:?}", state.limit));
         pg_sys::ExplainPropertyText(label, value, es);
+
+        if !state.aggregates.is_empty() {
+            let value = ctx.pstrdup(&format!("aggregates = {:?}", state.aggregates));
+            pg_sys::ExplainPropertyText(label, value, es);
+
+            let value = ctx.pstrdup(&format!("group_by = {:?}", state.group_by));
+            pg_sys::ExplainPropertyText(label, value, es);
+        }
     }
 }
 
@@ -405,7 +433,12 @@ pub(super) extern "C-unwind" fn begin_foreign_scan<
 
         // begin scan if it is not EXPLAIN statement
         if eflags & pg_sys::EXEC_FLAG_EXPLAIN_ONLY as c_int <= 0 {
-            let result = state.begin_scan();
+            // choose aggregate scan or normal scan based on state
+            let result = if state.is_aggregate_scan() {
+                state.begin_aggregate_scan()
+            } else {
+                state.begin_scan()
+            };
             if result.is_err() {
                 drop_fdw_state(state.as_ptr());
                 (*plan).fdw_private = ptr::null::<FdwState<E, W>>() as _;

--- a/supabase-wrappers/src/upper.rs
+++ b/supabase-wrappers/src/upper.rs
@@ -143,6 +143,12 @@ unsafe fn extract_aggregates(
                     }
                 };
 
+                // FILTER clause not supported for pushdown
+                if !(*aggref).aggfilter.is_null() {
+                    debug2!("Aggregate has FILTER clause, skipping pushdown");
+                    return None;
+                }
+
                 // DISTINCT only supported for COUNT(column)
                 if !(*aggref).aggdistinct.is_null() {
                     match kind {
@@ -189,6 +195,7 @@ unsafe fn extract_aggregates(
                     column,
                     distinct: !(*aggref).aggdistinct.is_null(),
                     alias: format!("agg_{resno}"),
+                    type_oid: (*aggref).aggtype,
                 });
             }
 
@@ -368,13 +375,7 @@ pub(super) extern "C-unwind" fn get_foreign_upper_paths<
                 new_tgts.push(Column {
                     name: agg.alias.clone(),
                     num: col_num,
-                    // Aggregate result type depends on the function; use the
-                    // column type as a reasonable default, or INVALID for COUNT(*).
-                    type_oid: agg
-                        .column
-                        .as_ref()
-                        .map(|c| c.type_oid)
-                        .unwrap_or(pg_sys::INT8OID),
+                    type_oid: agg.type_oid,
                 });
                 col_num += 1;
             }

--- a/supabase-wrappers/src/upper.rs
+++ b/supabase-wrappers/src/upper.rs
@@ -176,6 +176,14 @@ unsafe fn extract_aggregates(
                     None
                 };
 
+                // Aggregates that require a column (SUM, AVG, MIN, MAX, CountColumn)
+                // must have a resolved column reference. Reject pushdown for
+                // non-column expressions like SUM(a + b) to avoid invalid SQL.
+                if column.is_none() && kind != AggregateKind::Count {
+                    debug2!("Aggregate {kind:?} has no simple column reference, skipping pushdown");
+                    return None;
+                }
+
                 aggregates.push(Aggregate {
                     kind,
                     column,
@@ -206,30 +214,33 @@ unsafe fn extract_aggregates(
 /// # Safety
 ///
 /// All pointer parameters must be valid PostgreSQL planner structures.
+/// Returns `None` if any GROUP BY item is not a plain column reference,
+/// which means we cannot safely push down the grouping.
 unsafe fn extract_group_by_columns(
     root: *mut pg_sys::PlannerInfo,
     _input_rel: *mut pg_sys::RelOptInfo,
-) -> Vec<Column> {
+) -> Option<Vec<Column>> {
     unsafe {
         let mut group_by = Vec::new();
 
         let parse = (*root).parse;
         if parse.is_null() {
-            return group_by;
+            return Some(group_by);
         }
 
         let group_clause = (*parse).groupClause;
         if group_clause.is_null() || (*group_clause).length == 0 {
-            return group_by;
+            return Some(group_by);
         }
 
         let target_list = (*parse).targetList;
         if target_list.is_null() {
-            return group_by;
+            return Some(group_by);
         }
 
         for sort_group_clause in list_iter::<pg_sys::SortGroupClause>(group_clause) {
             let tle_resno = (*sort_group_clause).tleSortGroupRef;
+            let mut found = false;
 
             for tle in list_iter::<pg_sys::TargetEntry>(target_list) {
                 if (*tle).ressortgroupref == tle_resno {
@@ -238,13 +249,19 @@ unsafe fn extract_group_by_columns(
                         && let Some(col) = extract_column_from_var(root, expr as *mut pg_sys::Var)
                     {
                         group_by.push(col);
+                        found = true;
                     }
                     break;
                 }
             }
+
+            if !found {
+                debug2!("GROUP BY item is not a plain column, skipping pushdown");
+                return None;
+            }
         }
 
-        group_by
+        Some(group_by)
     }
 }
 
@@ -305,8 +322,11 @@ pub(super) extern "C-unwind" fn get_foreign_upper_paths<
             }
         }
 
-        // Extract GROUP BY columns
-        let group_by = extract_group_by_columns(root, input_rel);
+        // Extract GROUP BY columns (returns None if any item is not a plain column)
+        let group_by = match extract_group_by_columns(root, input_rel) {
+            Some(cols) => cols,
+            None => return,
+        };
         if !group_by.is_empty() {
             debug2!(
                 "Extracted GROUP BY columns: {:?}",
@@ -328,6 +348,38 @@ pub(super) extern "C-unwind" fn get_foreign_upper_paths<
         // Store aggregates and group_by in the FdwState so they survive to execution
         state.aggregates = aggregates.clone();
         state.group_by = group_by.clone();
+
+        // Rebuild state.tgts to reflect the aggregate output shape.
+        // The executor uses tgts for tuple validation/slot mapping, so it must
+        // match what iter_scan will return: GROUP BY columns first, then
+        // aggregate result columns (using alias as name).
+        {
+            let mut new_tgts = Vec::new();
+            let mut col_num = 1usize;
+            for col in &group_by {
+                new_tgts.push(Column {
+                    name: col.name.clone(),
+                    num: col_num,
+                    type_oid: col.type_oid,
+                });
+                col_num += 1;
+            }
+            for agg in &aggregates {
+                new_tgts.push(Column {
+                    name: agg.alias.clone(),
+                    num: col_num,
+                    // Aggregate result type depends on the function; use the
+                    // column type as a reasonable default, or INVALID for COUNT(*).
+                    type_oid: agg
+                        .column
+                        .as_ref()
+                        .map(|c| c.type_oid)
+                        .unwrap_or(pg_sys::INT8OID),
+                });
+                col_num += 1;
+            }
+            state.tgts = new_tgts;
+        }
 
         // Cost estimation
         let rows = if group_by.is_empty() { 1i64 } else { 100 };

--- a/supabase-wrappers/src/upper.rs
+++ b/supabase-wrappers/src/upper.rs
@@ -1,0 +1,376 @@
+//! Upper path planning for aggregate pushdown
+//!
+//! This module implements the GetForeignUpperPaths callback which enables
+//! aggregate pushdown to foreign data sources.
+
+use pgrx::pg_sys::panic::ErrorReport;
+use pgrx::{PgBox, debug2, pg_guard, pg_sys};
+use std::ptr;
+
+use crate::interface::{Aggregate, AggregateKind, Column};
+use crate::prelude::ForeignDataWrapper;
+use crate::scan::FdwState;
+
+/// Helper to iterate over a pg_sys::List using raw pointer access.
+/// Returns an iterator over pointers to the list elements.
+///
+/// # Safety
+///
+/// The caller must ensure `list` is a valid pg_sys::List pointer (or null).
+unsafe fn list_iter<T>(list: *mut pg_sys::List) -> impl Iterator<Item = *mut T> {
+    let len = if list.is_null() {
+        0
+    } else {
+        unsafe { (*list).length as usize }
+    };
+
+    (0..len).map(move |i| unsafe {
+        let cell = (*list).elements.add(i);
+        (*cell).ptr_value as *mut T
+    })
+}
+
+/// Map a PostgreSQL aggregate function OID to our AggregateKind enum
+/// by looking up the function name.
+fn oid_to_aggregate_kind(aggfnoid: pg_sys::Oid) -> Option<AggregateKind> {
+    unsafe {
+        let agg_name = pg_sys::get_func_name(aggfnoid);
+        if agg_name.is_null() {
+            return None;
+        }
+
+        let name_cstr = std::ffi::CStr::from_ptr(agg_name);
+        let name = name_cstr.to_str().ok()?;
+
+        match name {
+            "count" => {
+                let nargs = pg_sys::get_func_nargs(aggfnoid);
+                if nargs == 0 {
+                    Some(AggregateKind::Count)
+                } else {
+                    Some(AggregateKind::CountColumn)
+                }
+            }
+            "sum" => Some(AggregateKind::Sum),
+            "avg" => Some(AggregateKind::Avg),
+            "min" => Some(AggregateKind::Min),
+            "max" => Some(AggregateKind::Max),
+            _ => None,
+        }
+    }
+}
+
+/// Extract column info from a Var node.
+///
+/// # Safety
+///
+/// `var` must be a valid pointer to a pg_sys::Var node. `root` must be valid.
+unsafe fn extract_column_from_var(
+    root: *mut pg_sys::PlannerInfo,
+    var: *mut pg_sys::Var,
+) -> Option<Column> {
+    unsafe {
+        let relid = (*var).varno as pg_sys::Index;
+        let attno = (*var).varattno;
+        let rte = pg_sys::planner_rt_fetch(relid, root);
+        if rte.is_null() {
+            return None;
+        }
+        let rel_oid = (*rte).relid;
+        let att_name = pg_sys::get_attname(rel_oid, attno, false);
+        if att_name.is_null() {
+            return None;
+        }
+        let name_cstr = std::ffi::CStr::from_ptr(att_name);
+        let name = name_cstr.to_str().ok()?;
+        Some(Column {
+            name: name.to_string(),
+            num: attno as usize,
+            type_oid: (*var).vartype,
+        })
+    }
+}
+
+/// Extract aggregate information from the query's output relation target list.
+///
+/// # Safety
+///
+/// All pointer parameters must be valid PostgreSQL planner structures.
+unsafe fn extract_aggregates(
+    root: *mut pg_sys::PlannerInfo,
+    output_rel: *mut pg_sys::RelOptInfo,
+    extra: *mut std::ffi::c_void,
+) -> Option<Vec<Aggregate>> {
+    unsafe {
+        if extra.is_null() {
+            return None;
+        }
+
+        let group_extra = extra as *mut pg_sys::GroupPathExtraData;
+        if !(*group_extra).havingQual.is_null() {
+            debug2!("HAVING clause present, skipping aggregate pushdown");
+            return None;
+        }
+
+        let reltarget = (*output_rel).reltarget;
+        if reltarget.is_null() {
+            return None;
+        }
+
+        let exprs = (*reltarget).exprs;
+        if exprs.is_null() {
+            return None;
+        }
+
+        let mut aggregates = Vec::new();
+        let mut resno = 1;
+
+        for expr in list_iter::<pg_sys::Node>(exprs) {
+            if (*expr).type_ == pg_sys::NodeTag::T_Aggref {
+                let aggref = expr as *mut pg_sys::Aggref;
+
+                let kind = match oid_to_aggregate_kind((*aggref).aggfnoid) {
+                    Some(k) => k,
+                    None => {
+                        let func_name = pg_sys::get_func_name((*aggref).aggfnoid);
+                        if !func_name.is_null() {
+                            let name = std::ffi::CStr::from_ptr(func_name).to_string_lossy();
+                            debug2!("Unsupported aggregate function '{name}', skipping pushdown");
+                        } else {
+                            debug2!("Unknown aggregate function, skipping pushdown");
+                        }
+                        return None;
+                    }
+                };
+
+                // DISTINCT only supported for COUNT(column)
+                if !(*aggref).aggdistinct.is_null() {
+                    match kind {
+                        AggregateKind::CountColumn => {
+                            debug2!("COUNT(DISTINCT) detected, pushdown supported");
+                        }
+                        _ => {
+                            debug2!(
+                                "DISTINCT modifier on {kind:?} not supported, skipping pushdown"
+                            );
+                            return None;
+                        }
+                    }
+                }
+
+                // Get the column being aggregated (if any)
+                let column = if !(*aggref).args.is_null() && (*(*aggref).args).length > 0 {
+                    let first_cell = (*(*aggref).args).elements;
+                    let target_entry = (*first_cell).ptr_value as *mut pg_sys::TargetEntry;
+                    if !target_entry.is_null() {
+                        let arg_expr = (*target_entry).expr as *mut pg_sys::Node;
+                        if (*arg_expr).type_ == pg_sys::NodeTag::T_Var {
+                            extract_column_from_var(root, arg_expr as *mut pg_sys::Var)
+                        } else {
+                            None
+                        }
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                };
+
+                aggregates.push(Aggregate {
+                    kind,
+                    column,
+                    distinct: !(*aggref).aggdistinct.is_null(),
+                    alias: format!("agg_{resno}"),
+                });
+            }
+
+            resno += 1;
+        }
+
+        if aggregates.is_empty() {
+            return None;
+        }
+
+        debug2!(
+            "Extracted {} aggregates for pushdown: {:?}",
+            aggregates.len(),
+            aggregates.iter().map(|a| a.kind).collect::<Vec<_>>()
+        );
+
+        Some(aggregates)
+    }
+}
+
+/// Extract GROUP BY columns from the query.
+///
+/// # Safety
+///
+/// All pointer parameters must be valid PostgreSQL planner structures.
+unsafe fn extract_group_by_columns(
+    root: *mut pg_sys::PlannerInfo,
+    _input_rel: *mut pg_sys::RelOptInfo,
+) -> Vec<Column> {
+    unsafe {
+        let mut group_by = Vec::new();
+
+        let parse = (*root).parse;
+        if parse.is_null() {
+            return group_by;
+        }
+
+        let group_clause = (*parse).groupClause;
+        if group_clause.is_null() || (*group_clause).length == 0 {
+            return group_by;
+        }
+
+        let target_list = (*parse).targetList;
+        if target_list.is_null() {
+            return group_by;
+        }
+
+        for sort_group_clause in list_iter::<pg_sys::SortGroupClause>(group_clause) {
+            let tle_resno = (*sort_group_clause).tleSortGroupRef;
+
+            for tle in list_iter::<pg_sys::TargetEntry>(target_list) {
+                if (*tle).ressortgroupref == tle_resno {
+                    let expr = (*tle).expr as *mut pg_sys::Node;
+                    if (*expr).type_ == pg_sys::NodeTag::T_Var
+                        && let Some(col) = extract_column_from_var(root, expr as *mut pg_sys::Var)
+                    {
+                        group_by.push(col);
+                    }
+                    break;
+                }
+            }
+        }
+
+        group_by
+    }
+}
+
+/// GetForeignUpperPaths callback
+///
+/// Called by the PostgreSQL planner to create paths for upper-level processing
+/// (aggregation, sorting, etc.) that can be pushed down to the foreign server.
+#[pg_guard]
+pub(super) extern "C-unwind" fn get_foreign_upper_paths<
+    E: Into<ErrorReport>,
+    W: ForeignDataWrapper<E>,
+>(
+    root: *mut pg_sys::PlannerInfo,
+    stage: pg_sys::UpperRelationKind::Type,
+    input_rel: *mut pg_sys::RelOptInfo,
+    output_rel: *mut pg_sys::RelOptInfo,
+    extra: *mut std::ffi::c_void,
+) {
+    debug2!("---> get_foreign_upper_paths, stage: {stage:?}");
+
+    // Only handle GROUP_AGG stage
+    if stage != pg_sys::UpperRelationKind::UPPERREL_GROUP_AGG {
+        return;
+    }
+
+    unsafe {
+        // Get the FDW state from the input relation (set during get_foreign_rel_size)
+        let fdw_private = (*input_rel).fdw_private;
+        if fdw_private.is_null() {
+            return;
+        }
+
+        let mut state = PgBox::<FdwState<E, W>>::from_pg(fdw_private as _);
+
+        // Check if FDW supports any aggregates
+        let supported = {
+            let Some(ref instance) = state.instance else {
+                return;
+            };
+            let supported = instance.supported_aggregates();
+            if supported.is_empty() {
+                return;
+            }
+            supported
+        };
+
+        // Extract aggregates from the query
+        let aggregates = match extract_aggregates(root, output_rel, extra) {
+            Some(aggs) => aggs,
+            None => return,
+        };
+
+        // Check if all aggregates are supported
+        for agg in &aggregates {
+            if !supported.contains(&agg.kind) {
+                debug2!("Aggregate {:?} not supported, skipping pushdown", agg.kind);
+                return;
+            }
+        }
+
+        // Extract GROUP BY columns
+        let group_by = extract_group_by_columns(root, input_rel);
+        if !group_by.is_empty() {
+            debug2!(
+                "Extracted GROUP BY columns: {:?}",
+                group_by.iter().map(|c| c.name.as_str()).collect::<Vec<_>>()
+            );
+        }
+
+        // Check if GROUP BY is supported (if present)
+        if !group_by.is_empty() {
+            let Some(ref instance) = state.instance else {
+                return;
+            };
+            if !instance.supports_group_by() {
+                debug2!("GROUP BY not supported, skipping pushdown");
+                return;
+            }
+        }
+
+        // Store aggregates and group_by in the FdwState so they survive to execution
+        state.aggregates = aggregates.clone();
+        state.group_by = group_by.clone();
+
+        // Cost estimation
+        let rows = if group_by.is_empty() { 1i64 } else { 100 };
+        let startup_cost = state
+            .opts
+            .get("startup_cost")
+            .and_then(|c| c.parse::<f64>().ok())
+            .unwrap_or(0.0);
+        let total_cost = startup_cost + rows as f64;
+
+        debug2!(
+            "Aggregate pushdown cost estimate: rows={rows}, startup={startup_cost}, total={total_cost}"
+        );
+
+        // Store the FdwState pointer in output_rel->fdw_private so that
+        // get_foreign_plan can find it when building the plan for this path.
+        // This is the critical fix: previously fdw_private was null, so aggregates
+        // were extracted but never passed through to the executor.
+        (*output_rel).fdw_private = state.into_pg() as _;
+
+        // Create the foreign upper path
+        let path = pg_sys::create_foreign_upper_path(
+            root,
+            output_rel,
+            (*output_rel).reltarget, // pathtarget
+            rows as f64,             // rows
+            #[cfg(feature = "pg18")]
+            0, // disabled_nodes (pg18 only)
+            startup_cost,            // startup_cost
+            total_cost,              // total_cost
+            ptr::null_mut(),         // pathkeys
+            ptr::null_mut(),         // fdw_outerpath
+            #[cfg(any(feature = "pg17", feature = "pg18"))]
+            ptr::null_mut(), // fdw_restrictinfo (pg17+ only)
+            ptr::null_mut(),         // fdw_private (path-level, not needed)
+        );
+
+        pg_sys::add_path(output_rel, &mut ((*path).path));
+
+        debug2!(
+            "Created aggregate pushdown path: {} aggregates, {} group by columns",
+            aggregates.len(),
+            group_by.len()
+        );
+    }
+}

--- a/supabase-wrappers/src/upper.rs
+++ b/supabase-wrappers/src/upper.rs
@@ -352,44 +352,27 @@ pub(super) extern "C-unwind" fn get_foreign_upper_paths<
             }
         }
 
-        // Store aggregates and group_by in the FdwState so they survive to execution
+        // Store aggregates and group_by in the FdwState so they survive to
+        // execution. Note: input_rel.fdw_private and output_rel.fdw_private
+        // share the same FdwState pointer, so this mutation is visible through
+        // both. get_foreign_plan must therefore key off baserel.reloptkind to
+        // tell whether the planner actually picked the upper path or fell back
+        // to the base-rel scan with a local Aggregate on top.
         state.aggregates = aggregates.clone();
         state.group_by = group_by.clone();
 
-        // Rebuild state.tgts to reflect the aggregate output shape.
-        // The executor uses tgts for tuple validation/slot mapping, so it must
-        // match what iter_scan will return: GROUP BY columns first, then
-        // aggregate result columns (using alias as name).
-        {
-            let mut new_tgts = Vec::new();
-            let mut col_num = 1usize;
-            for col in &group_by {
-                new_tgts.push(Column {
-                    name: col.name.clone(),
-                    num: col_num,
-                    type_oid: col.type_oid,
-                });
-                col_num += 1;
-            }
-            for agg in &aggregates {
-                new_tgts.push(Column {
-                    name: agg.alias.clone(),
-                    num: col_num,
-                    type_oid: agg.type_oid,
-                });
-                col_num += 1;
-            }
-            state.tgts = new_tgts;
-        }
-
-        // Cost estimation
-        let rows = if group_by.is_empty() { 1i64 } else { 100 };
+        // Cost estimation. We deliberately price the pushdown at ~0 so the
+        // planner prefers it over the local HashAgg/GroupAgg alternatives that
+        // also live on grouped_rel — pushdown collapses the row stream at the
+        // remote side and is essentially always cheaper than fetching rows and
+        // aggregating locally.
+        let rows: i64 = 1;
         let startup_cost = state
             .opts
             .get("startup_cost")
             .and_then(|c| c.parse::<f64>().ok())
             .unwrap_or(0.0);
-        let total_cost = startup_cost + rows as f64;
+        let total_cost = startup_cost;
 
         debug2!(
             "Aggregate pushdown cost estimate: rows={rows}, startup={startup_cost}, total={total_cost}"

--- a/wrappers/dockerfiles/bigquery/data.yaml
+++ b/wrappers/dockerfiles/bigquery/data.yaml
@@ -66,3 +66,27 @@ projects:
           data:
             - id: 1
               time_col: "12:30:00.45"
+        - id: agg_test
+          columns:
+            - name: id
+              type: INTEGER
+              mode: REQUIRED
+            - name: name
+              type: STRING
+              mode: REQUIRED
+            - name: amount
+              type: NUMERIC
+              mode: REQUIRED
+          data:
+            - id: 1
+              name: alice
+              amount: 10.0
+            - id: 1
+              name: alice
+              amount: 20.0
+            - id: 2
+              name: bob
+              amount: 30.0
+            - id: 2
+              name: carol
+              amount: 40.0

--- a/wrappers/src/fdw/bigquery_fdw/README.md
+++ b/wrappers/src/fdw/bigquery_fdw/README.md
@@ -11,6 +11,7 @@ This is a foreign data wrapper for [BigQuery](https://cloud.google.com/bigquery)
 
 | Version | Date       | Notes                                                |
 | ------- | ---------- | ---------------------------------------------------- |
+| 0.1.7   | 2026-04-28 | Added aggregate pushdown support                     |
 | 0.1.6   | 2025-02-04 | Upgrade bq client lib to v0.25.1, support JSON type  |
 | 0.1.5   | 2024-09-30 | Support for pgrx 0.12.6                              |
 | 0.1.4   | 2023-07-13 | Added fdw stats collection                           |

--- a/wrappers/src/fdw/bigquery_fdw/bigquery_fdw.rs
+++ b/wrappers/src/fdw/bigquery_fdw/bigquery_fdw.rs
@@ -19,7 +19,7 @@ use crate::setup_rustls_default_crypto_provider;
 use supabase_wrappers::prelude::*;
 
 #[wrappers_fdw(
-    version = "0.1.6",
+    version = "0.1.7",
     author = "Supabase",
     website = "https://github.com/supabase/wrappers/tree/main/wrappers/src/fdw/bigquery_fdw",
     error_type = "BigQueryFdwError"
@@ -41,6 +41,61 @@ pub(crate) struct BigQueryFdw {
 impl BigQueryFdw {
     const FDW_NAME: &'static str = "BigQueryFdw";
 
+    // Resolve the FROM clause source for the deparsed remote SQL: either a
+    // sub-query in parentheses (passed through verbatim), or the
+    // backtick-quoted `project.dataset.table`.
+    fn resolved_table(&self) -> String {
+        if self.table.starts_with('(') {
+            self.table.clone()
+        } else {
+            format!("`{}.{}.{}`", self.project_id, self.dataset_id, self.table)
+        }
+    }
+
+    fn deparse_aggregate(
+        &self,
+        aggregates: &[Aggregate],
+        group_by: &[Column],
+        quals: &[Qual],
+    ) -> String {
+        // SELECT: group-by columns first, then aggregate expressions with
+        // their aliases. BigQuery's standard SQL is compatible with the
+        // default deparse output (e.g. `COUNT(*) AS agg_1`,
+        // `SUM(col) AS agg_2`, `COUNT(DISTINCT col) AS agg_3`).
+        let mut select_items: Vec<String> = group_by.iter().map(|c| c.name.clone()).collect();
+        for agg in aggregates {
+            select_items.push(agg.deparse_with_alias());
+        }
+
+        let mut sql = format!(
+            "select {} from {}",
+            select_items.join(", "),
+            self.resolved_table()
+        );
+
+        if !quals.is_empty() {
+            let cond = quals
+                .iter()
+                .map(|q| q.deparse())
+                .collect::<Vec<String>>()
+                .join(" and ");
+            if !cond.is_empty() {
+                sql.push_str(&format!(" where {cond}"));
+            }
+        }
+
+        if !group_by.is_empty() {
+            let cols = group_by
+                .iter()
+                .map(|c| c.name.as_str())
+                .collect::<Vec<_>>()
+                .join(", ");
+            sql.push_str(&format!(" group by {cols}"));
+        }
+
+        sql
+    }
+
     fn deparse(
         &self,
         quals: &[Qual],
@@ -57,11 +112,7 @@ impl BigQueryFdw {
                 .collect::<Vec<String>>()
                 .join(", ")
         };
-        let table = if self.table.starts_with('(') {
-            self.table.clone()
-        } else {
-            format!("`{}.{}.{}`", self.project_id, self.dataset_id, self.table,)
-        };
+        let table = self.resolved_table();
 
         let mut sql = if quals.is_empty() {
             format!("select {tgts} from {table}")
@@ -94,6 +145,70 @@ impl BigQueryFdw {
         }
 
         sql
+    }
+
+    // Issue a query against BigQuery and stash the result + pagination tokens
+    // on `self`. Shared between begin_scan and begin_aggregate_scan; both
+    // produce a SQL string and then iterate the same way through iter_scan.
+    fn run_query(&mut self, sql: String, options: &HashMap<String, String>) {
+        let location = options
+            .get("location")
+            .map(|t| t.to_owned())
+            .unwrap_or_else(|| "US".to_string());
+
+        let mut timeout: i32 = 30_000;
+        if let Some(timeout_str) = options.get("timeout") {
+            match timeout_str.parse::<i32>() {
+                Ok(t) => timeout = t,
+                Err(_) => report_error(
+                    PgSqlErrorCode::ERRCODE_FDW_ERROR,
+                    &format!("invalid timeout value: {timeout_str}"),
+                ),
+            }
+        }
+
+        if let Some(client) = &self.client {
+            let mut req = QueryRequest::new(sql);
+            req.location = Some(location);
+            req.timeout_ms = Some(timeout);
+
+            match self.rt.block_on(client.job().query(&self.project_id, req)) {
+                Ok(resp) => {
+                    if resp.job_complete == Some(false) {
+                        report_error(
+                            PgSqlErrorCode::ERRCODE_FDW_ERROR,
+                            &format!("query timeout {timeout}ms expired"),
+                        );
+                    } else {
+                        let rows_in = resp
+                            .total_rows
+                            .as_ref()
+                            .and_then(|v| v.parse::<i64>().ok())
+                            .unwrap_or(0i64);
+                        stats::inc_stats(Self::FDW_NAME, stats::Metric::RowsIn, rows_in);
+                        stats::inc_stats(Self::FDW_NAME, stats::Metric::RowsOut, rows_in);
+                        stats::inc_stats(
+                            Self::FDW_NAME,
+                            stats::Metric::BytesIn,
+                            resp.total_bytes_processed
+                                .as_ref()
+                                .and_then(|v| v.parse::<i64>().ok())
+                                .unwrap_or(0i64),
+                        );
+                        self.job_ref = resp.job_reference.clone();
+                        self.page_token = resp.page_token.clone();
+                        self.scan_result = Some(ResultSet::new_from_query_response(resp));
+                    }
+                }
+                Err(err) => {
+                    self.scan_result = None;
+                    report_error(
+                        PgSqlErrorCode::ERRCODE_FDW_ERROR,
+                        &format!("query failed: {err}"),
+                    );
+                }
+            }
+        }
     }
 
     // read one source row from result set and convert it to Postgres row
@@ -267,76 +382,8 @@ impl ForeignDataWrapper<BigQueryFdwError> for BigQueryFdw {
         self.table = require_option("table", options)?.to_string();
         self.tgt_cols = columns.to_vec();
 
-        let location = options
-            .get("location")
-            .map(|t| t.to_owned())
-            .unwrap_or_else(|| "US".to_string());
-
-        let mut timeout: i32 = 30_000;
-        if let Some(timeout_str) = options.get("timeout") {
-            match timeout_str.parse::<i32>() {
-                Ok(t) => timeout = t,
-                Err(_) => report_error(
-                    PgSqlErrorCode::ERRCODE_FDW_ERROR,
-                    &format!("invalid timeout value: {timeout_str}"),
-                ),
-            }
-        }
-
-        if let Some(client) = &self.client {
-            let sql = self.deparse(quals, columns, sorts, limit);
-            let mut req = QueryRequest::new(sql);
-            req.location = Some(location);
-            req.timeout_ms = Some(timeout);
-
-            // execute query on BigQuery
-            match self.rt.block_on(client.job().query(&self.project_id, req)) {
-                Ok(resp) => {
-                    if resp.job_complete == Some(false) {
-                        report_error(
-                            PgSqlErrorCode::ERRCODE_FDW_ERROR,
-                            &format!("query timeout {timeout}ms expired"),
-                        );
-                    } else {
-                        stats::inc_stats(
-                            Self::FDW_NAME,
-                            stats::Metric::RowsIn,
-                            resp.total_rows
-                                .as_ref()
-                                .and_then(|v| v.parse::<i64>().ok())
-                                .unwrap_or(0i64),
-                        );
-                        stats::inc_stats(
-                            Self::FDW_NAME,
-                            stats::Metric::RowsOut,
-                            resp.total_rows
-                                .as_ref()
-                                .and_then(|v| v.parse::<i64>().ok())
-                                .unwrap_or(0i64),
-                        );
-                        stats::inc_stats(
-                            Self::FDW_NAME,
-                            stats::Metric::BytesIn,
-                            resp.total_bytes_processed
-                                .as_ref()
-                                .and_then(|v| v.parse::<i64>().ok())
-                                .unwrap_or(0i64),
-                        );
-                        self.job_ref = resp.job_reference.clone();
-                        self.page_token = resp.page_token.clone();
-                        let rs = ResultSet::new_from_query_response(resp);
-                        self.scan_result = Some(rs);
-                    }
-                }
-                Err(err) => {
-                    self.scan_result = None;
-                    report_error(
-                        PgSqlErrorCode::ERRCODE_FDW_ERROR,
-                        &format!("query failed: {err}"),
-                    );
-                }
-            }
-        }
+        let sql = self.deparse(quals, columns, sorts, limit);
+        self.run_query(sql, options);
 
         Ok(())
     }
@@ -507,6 +554,50 @@ impl ForeignDataWrapper<BigQueryFdwError> for BigQueryFdw {
                 );
             }
         }
+        Ok(())
+    }
+
+    fn supported_aggregates(&self) -> Vec<AggregateKind> {
+        vec![
+            AggregateKind::Count,
+            AggregateKind::CountColumn,
+            AggregateKind::Sum,
+            AggregateKind::Avg,
+            AggregateKind::Min,
+            AggregateKind::Max,
+        ]
+    }
+
+    fn supports_group_by(&self) -> bool {
+        true
+    }
+
+    fn begin_aggregate_scan(
+        &mut self,
+        aggregates: &[Aggregate],
+        group_by: &[Column],
+        quals: &[Qual],
+        options: &HashMap<String, String>,
+    ) -> Result<(), BigQueryFdwError> {
+        self.table = require_option("table", options)?.to_string();
+
+        // tgt_cols must match the SELECT output order: GROUP BY columns first,
+        // then aggregate result columns named by their aliases. extract_row
+        // looks up each column by name in the BigQuery result, so each alias
+        // here must match the AS alias emitted by deparse_aggregate.
+        let mut tgt_cols: Vec<Column> = group_by.to_vec();
+        for (i, agg) in aggregates.iter().enumerate() {
+            tgt_cols.push(Column {
+                name: agg.alias.clone(),
+                num: group_by.len() + i + 1,
+                type_oid: agg.type_oid,
+            });
+        }
+        self.tgt_cols = tgt_cols;
+
+        let sql = self.deparse_aggregate(aggregates, group_by, quals);
+        self.run_query(sql, options);
+
         Ok(())
     }
 }

--- a/wrappers/src/fdw/bigquery_fdw/tests.rs
+++ b/wrappers/src/fdw/bigquery_fdw/tests.rs
@@ -214,4 +214,299 @@ mod tests {
             );
         });
     }
+
+    /// Verify aggregate queries are pushed down to BigQuery.
+    ///
+    /// Reads against the `agg_test` table seeded by
+    /// `wrappers/dockerfiles/bigquery/data.yaml`:
+    ///   id=1, name='alice', amount=10
+    ///   id=1, name='alice', amount=20  (duplicate name, same id)
+    ///   id=2, name='bob',   amount=30
+    ///   id=2, name='carol', amount=40
+    #[pg_test]
+    fn bigquery_aggregate_pushdown_test() {
+        Spi::connect_mut(|c| {
+            c.update(
+                r#"CREATE FOREIGN DATA WRAPPER bigquery_wrapper
+                         HANDLER big_query_fdw_handler VALIDATOR big_query_fdw_validator"#,
+                None,
+                &[],
+            )
+            .unwrap();
+            c.update(
+                r#"CREATE SERVER my_bigquery_server
+                         FOREIGN DATA WRAPPER bigquery_wrapper
+                         OPTIONS (
+                           project_id 'test_project',
+                           dataset_id 'test_dataset',
+                           api_endpoint 'http://localhost:9111',
+                           mock_auth 'true'
+                         )"#,
+                None,
+                &[],
+            )
+            .unwrap();
+            c.update(
+                r#"
+                  CREATE FOREIGN TABLE agg_test (
+                    id     bigint,
+                    name   text,
+                    amount numeric
+                  )
+                  SERVER my_bigquery_server
+                  OPTIONS (
+                    table 'agg_test'
+                  )
+             "#,
+                None,
+                &[],
+            )
+            .unwrap();
+            c.update(
+                r#"
+                  CREATE FOREIGN TABLE agg_test_sub (
+                    id     bigint,
+                    name   text,
+                    amount numeric
+                  )
+                  SERVER my_bigquery_server
+                  OPTIONS (
+                    table '(select id, name, amount from `test_project.test_dataset.agg_test` where id < 3)'
+                  )
+             "#,
+                None,
+                &[],
+            )
+            .unwrap();
+
+            // Helper macros: assert that EXPLAIN does (or does not) contain a
+            // local Aggregate node. Plan-node lines always include "(cost=...)";
+            // FDW EXPLAIN extras (e.g. "Wrappers: aggregates = [...]") do not,
+            // so combining both substrings avoids false positives from the FDW's
+            // own debug output.
+            macro_rules! assert_pushed_down {
+                ($c:expr, $sql:expr) => {{
+                    let explain = format!("EXPLAIN {}", $sql);
+                    let plan: Vec<String> = $c
+                        .select(&explain, None, &[])
+                        .unwrap()
+                        .filter_map(|r| r.get::<&str>(1).unwrap().map(|s| s.to_string()))
+                        .collect();
+                    assert!(
+                        !plan
+                            .iter()
+                            .any(|l| l.contains("Aggregate") && l.contains("(cost=")),
+                        "Expected pushdown for [{}] but plan shows local aggregation: {:?}",
+                        $sql,
+                        plan
+                    );
+                }};
+            }
+
+            macro_rules! assert_not_pushed_down {
+                ($c:expr, $sql:expr) => {{
+                    let explain = format!("EXPLAIN {}", $sql);
+                    let plan: Vec<String> = $c
+                        .select(&explain, None, &[])
+                        .unwrap()
+                        .filter_map(|r| r.get::<&str>(1).unwrap().map(|s| s.to_string()))
+                        .collect();
+                    assert!(
+                        plan.iter()
+                            .any(|l| l.contains("Aggregate") && l.contains("(cost=")),
+                        "Expected NO pushdown (local Aggregate) for [{}], plan: {:?}",
+                        $sql,
+                        plan
+                    );
+                }};
+            }
+
+            // --- COUNT(*) — whole-table scalar aggregate ---
+            assert_eq!(
+                c.select("SELECT COUNT(*) FROM agg_test", None, &[])
+                    .unwrap()
+                    .first()
+                    .get_one::<i64>()
+                    .unwrap()
+                    .unwrap(),
+                4
+            );
+            assert_pushed_down!(c, "SELECT COUNT(*) FROM agg_test");
+
+            // --- COUNT(name) GROUP BY id ---
+            let mut rows: Vec<(i64, i64)> = c
+                .select(
+                    "SELECT id, COUNT(name) AS cnt FROM agg_test GROUP BY id ORDER BY id",
+                    None,
+                    &[],
+                )
+                .unwrap()
+                .map(|r| {
+                    let id = r.get_by_name::<i64, _>("id").unwrap().unwrap();
+                    let cnt = r.get_by_name::<i64, _>("cnt").unwrap().unwrap();
+                    (id, cnt)
+                })
+                .collect();
+            rows.sort();
+            assert_eq!(rows, vec![(1, 2), (2, 2)]);
+            assert_pushed_down!(c, "SELECT id, COUNT(name) AS cnt FROM agg_test GROUP BY id");
+
+            // --- SUM(amount) GROUP BY id ---
+            let mut rows: Vec<(i64, pgrx::AnyNumeric)> = c
+                .select(
+                    "SELECT id, SUM(amount) AS s FROM agg_test GROUP BY id ORDER BY id",
+                    None,
+                    &[],
+                )
+                .unwrap()
+                .map(|r| {
+                    let id = r.get_by_name::<i64, _>("id").unwrap().unwrap();
+                    let s = r.get_by_name::<pgrx::AnyNumeric, _>("s").unwrap().unwrap();
+                    (id, s)
+                })
+                .collect();
+            rows.sort_by_key(|&(id, _)| id);
+            assert_eq!(rows.len(), 2);
+            assert_eq!(rows[0].0, 1);
+            assert_eq!(rows[1].0, 2);
+            assert!((f64::try_from(rows[0].1.clone()).unwrap() - 30.0).abs() < 1e-6);
+            assert!((f64::try_from(rows[1].1.clone()).unwrap() - 70.0).abs() < 1e-6);
+            assert_pushed_down!(c, "SELECT id, SUM(amount) FROM agg_test GROUP BY id");
+
+            // --- AVG(amount) — whole-table ---
+            let avg: pgrx::AnyNumeric = c
+                .select("SELECT AVG(amount) FROM agg_test", None, &[])
+                .unwrap()
+                .first()
+                .get_one::<pgrx::AnyNumeric>()
+                .unwrap()
+                .unwrap();
+            assert!((f64::try_from(avg).unwrap() - 25.0).abs() < 1e-6);
+            assert_pushed_down!(c, "SELECT AVG(amount) FROM agg_test");
+
+            // --- MIN / MAX in the same query ---
+            assert_eq!(
+                c.select("SELECT MIN(id), MAX(id) FROM agg_test", None, &[])
+                    .unwrap()
+                    .first()
+                    .get_two::<i64, i64>()
+                    .unwrap(),
+                (Some(1), Some(2))
+            );
+            assert_pushed_down!(c, "SELECT MIN(id), MAX(id) FROM agg_test");
+
+            // --- COUNT(DISTINCT name) — whole-table (alice, bob, carol = 3) ---
+            assert_eq!(
+                c.select("SELECT COUNT(DISTINCT name) FROM agg_test", None, &[])
+                    .unwrap()
+                    .first()
+                    .get_one::<i64>()
+                    .unwrap()
+                    .unwrap(),
+                3
+            );
+            assert_pushed_down!(c, "SELECT COUNT(DISTINCT name) FROM agg_test");
+
+            // --- WHERE + aggregate: the qual is pushed alongside the agg ---
+            let s: pgrx::AnyNumeric = c
+                .select("SELECT SUM(amount) FROM agg_test WHERE id = 1", None, &[])
+                .unwrap()
+                .first()
+                .get_one::<pgrx::AnyNumeric>()
+                .unwrap()
+                .unwrap();
+            assert!((f64::try_from(s).unwrap() - 30.0).abs() < 1e-6);
+            assert_pushed_down!(c, "SELECT SUM(amount) FROM agg_test WHERE id = 1");
+
+            // --- Aggregate over sub-query in `table` option ---
+            assert_eq!(
+                c.select("SELECT COUNT(*) FROM agg_test_sub", None, &[])
+                    .unwrap()
+                    .first()
+                    .get_one::<i64>()
+                    .unwrap()
+                    .unwrap(),
+                4
+            );
+            assert_pushed_down!(c, "SELECT COUNT(*) FROM agg_test_sub");
+
+            let mut rows: Vec<(i64, i64)> = c
+                .select(
+                    "SELECT id, COUNT(*)::bigint AS cnt FROM agg_test_sub GROUP BY id ORDER BY id",
+                    None,
+                    &[],
+                )
+                .unwrap()
+                .map(|r| {
+                    let id = r.get_by_name::<i64, _>("id").unwrap().unwrap();
+                    let cnt = r.get_by_name::<i64, _>("cnt").unwrap().unwrap();
+                    (id, cnt)
+                })
+                .collect();
+            rows.sort();
+            assert_eq!(rows, vec![(1, 2), (2, 2)]);
+            assert_pushed_down!(c, "SELECT id, COUNT(*) FROM agg_test_sub GROUP BY id");
+
+            // --- Negative cases: planner falls back to local Aggregate ---
+
+            // HAVING clause is not pushed down.
+            let mut rows: Vec<(i64, i64)> = c
+                .select(
+                    "SELECT id, COUNT(*)::bigint AS cnt FROM agg_test \
+                     GROUP BY id HAVING COUNT(*) > 1 ORDER BY id",
+                    None,
+                    &[],
+                )
+                .unwrap()
+                .map(|r| {
+                    let id = r.get_by_name::<i64, _>("id").unwrap().unwrap();
+                    let cnt = r.get_by_name::<i64, _>("cnt").unwrap().unwrap();
+                    (id, cnt)
+                })
+                .collect();
+            rows.sort();
+            assert_eq!(rows, vec![(1, 2), (2, 2)]);
+            assert_not_pushed_down!(
+                c,
+                "SELECT id, COUNT(*) FROM agg_test GROUP BY id HAVING COUNT(*) > 1"
+            );
+
+            // FILTER clause on aggregate is not pushed down.
+            let cnt: i64 = c
+                .select(
+                    "SELECT COUNT(*) FILTER (WHERE id = 1) FROM agg_test",
+                    None,
+                    &[],
+                )
+                .unwrap()
+                .first()
+                .get_one::<i64>()
+                .unwrap()
+                .unwrap();
+            assert_eq!(cnt, 2);
+            assert_not_pushed_down!(c, "SELECT COUNT(*) FILTER (WHERE id = 1) FROM agg_test");
+
+            // GROUP BY non-column expression is not pushed down.
+            let mut rows: Vec<(i64, i64)> = c
+                .select(
+                    "SELECT id + 1 AS g, COUNT(*)::bigint AS cnt FROM agg_test \
+                     GROUP BY id + 1 ORDER BY g",
+                    None,
+                    &[],
+                )
+                .unwrap()
+                .map(|r| {
+                    let g = r.get_by_name::<i64, _>("g").unwrap().unwrap();
+                    let cnt = r.get_by_name::<i64, _>("cnt").unwrap().unwrap();
+                    (g, cnt)
+                })
+                .collect();
+            rows.sort();
+            assert_eq!(rows, vec![(2, 2), (3, 2)]);
+            assert_not_pushed_down!(
+                c,
+                "SELECT id + 1 AS g, COUNT(*) FROM agg_test GROUP BY id + 1"
+            );
+        });
+    }
 }

--- a/wrappers/src/fdw/bigquery_fdw/tests.rs
+++ b/wrappers/src/fdw/bigquery_fdw/tests.rs
@@ -286,7 +286,13 @@ mod tests {
             // own debug output.
             macro_rules! assert_pushed_down {
                 ($c:expr, $sql:expr) => {{
-                    let explain = format!("EXPLAIN {}", $sql);
+                    // EXPLAIN ANALYZE — under the mock_auth setup the test
+                    // wiremock requires every BigQueryFdw::new() to be matched
+                    // by exactly one token fetch, which only happens when the
+                    // plan actually executes. Plan-node lines still contain
+                    // "Aggregate" and "(cost=" under EXPLAIN ANALYZE, so the
+                    // pushdown matchers are unchanged.
+                    let explain = format!("EXPLAIN ANALYZE {}", $sql);
                     let plan: Vec<String> = $c
                         .select(&explain, None, &[])
                         .unwrap()
@@ -305,7 +311,13 @@ mod tests {
 
             macro_rules! assert_not_pushed_down {
                 ($c:expr, $sql:expr) => {{
-                    let explain = format!("EXPLAIN {}", $sql);
+                    // EXPLAIN ANALYZE — under the mock_auth setup the test
+                    // wiremock requires every BigQueryFdw::new() to be matched
+                    // by exactly one token fetch, which only happens when the
+                    // plan actually executes. Plan-node lines still contain
+                    // "Aggregate" and "(cost=" under EXPLAIN ANALYZE, so the
+                    // pushdown matchers are unchanged.
+                    let explain = format!("EXPLAIN ANALYZE {}", $sql);
                     let plan: Vec<String> = $c
                         .select(&explain, None, &[])
                         .unwrap()

--- a/wrappers/src/fdw/clickhouse_fdw/README.md
+++ b/wrappers/src/fdw/clickhouse_fdw/README.md
@@ -11,6 +11,7 @@ This is a foreign data wrapper for [ClickHouse](https://clickhouse.com/). It is 
 
 | Version | Date       | Notes                                                |
 | ------- | ---------- | ---------------------------------------------------- |
+| 0.1.11  | 2026-04-28 | Added aggregate pushdown support                     |
 | 0.1.10  | 2026-02-04 | Implement re_scan() for nested loop joins            |
 | 0.1.9   | 2025-11-08 | Added stream_buffer_size foreign table option        |
 | 0.1.8   | 2025-10-27 | Refactor to read rows with async streaming           |

--- a/wrappers/src/fdw/clickhouse_fdw/clickhouse_fdw.rs
+++ b/wrappers/src/fdw/clickhouse_fdw/clickhouse_fdw.rs
@@ -363,7 +363,7 @@ where
 }
 
 #[wrappers_fdw(
-    version = "0.1.10",
+    version = "0.1.11",
     author = "Supabase",
     website = "https://github.com/supabase/wrappers/tree/main/wrappers/src/fdw/clickhouse_fdw",
     error_type = "ClickHouseFdwError"

--- a/wrappers/src/fdw/clickhouse_fdw/clickhouse_fdw.rs
+++ b/wrappers/src/fdw/clickhouse_fdw/clickhouse_fdw.rs
@@ -498,6 +498,81 @@ impl ClickHouseFdw {
         Ok(sql)
     }
 
+    fn deparse_aggregate(
+        &mut self,
+        aggregates: &[Aggregate],
+        group_by: &[Column],
+        quals: &[Qual],
+    ) -> ClickHouseFdwResult<String> {
+        let table = if self.table.starts_with('(') {
+            let re = Regex::new(r"\$\{(\w+)\}").unwrap();
+            let mut params = Vec::new();
+            let mut replacement = |caps: &Captures| -> ClickHouseFdwResult<String> {
+                let param = &caps[1];
+                for qual in quals.iter() {
+                    if qual.field == param {
+                        params.push(qual.clone());
+                        match &qual.value {
+                            Value::Cell(cell) => return Ok(cell.to_string()),
+                            Value::Array(arr) => {
+                                return Err(ClickHouseFdwError::NoArrayParameter(format!(
+                                    "{arr:?}"
+                                )));
+                            }
+                        }
+                    }
+                }
+                Err(ClickHouseFdwError::UnmatchedParameter(param.to_owned()))
+            };
+            let s = self.replace_all_params(&re, &mut replacement)?;
+            self.params = params;
+            s
+        } else {
+            self.table.clone()
+        };
+
+        // SELECT: group-by columns first, then aggregate expressions with aliases
+        let mut select_items: Vec<String> = group_by.iter().map(|c| c.name.clone()).collect();
+        for agg in aggregates {
+            select_items.push(agg.deparse_with_alias());
+        }
+        let mut sql = format!("select {} from {}", select_items.join(", "), &table);
+
+        // WHERE: same filtering as deparse() — skip params and array-valued quals
+        if !quals.is_empty() {
+            let mut formatter = Formatter {};
+            let cond = quals
+                .iter()
+                .filter(|q| {
+                    let is_param = self.params.iter().any(|p| p.field == q.field);
+                    let is_array = match &q.value {
+                        Value::Cell(c) => c.is_array(),
+                        _ => false,
+                    };
+                    !is_param && !is_array
+                })
+                .map(|q| q.deparse_with_fmt(&mut formatter))
+                .collect::<Vec<String>>()
+                .join(" and ");
+
+            if !cond.is_empty() {
+                sql.push_str(&format!(" where {cond}"));
+            }
+        }
+
+        // GROUP BY
+        if !group_by.is_empty() {
+            let cols = group_by
+                .iter()
+                .map(|c| c.name.as_str())
+                .collect::<Vec<_>>()
+                .join(", ");
+            sql.push_str(&format!(" group by {cols}"));
+        }
+
+        Ok(sql)
+    }
+
     fn fetch_next_row(&mut self) -> ClickHouseFdwResult<()> {
         if let Some(ref rx) = self.row_receiver {
             match rx.recv() {
@@ -1016,6 +1091,60 @@ impl ForeignDataWrapper<ClickHouseFdwError> for ClickHouseFdw {
 
         // execute query on ClickHouse
         self.rt.block_on(client.execute(&sql))?;
+        Ok(())
+    }
+
+    fn supported_aggregates(&self) -> Vec<AggregateKind> {
+        vec![
+            AggregateKind::Count,
+            AggregateKind::CountColumn,
+            AggregateKind::Sum,
+            AggregateKind::Avg,
+            AggregateKind::Min,
+            AggregateKind::Max,
+        ]
+    }
+
+    fn supports_group_by(&self) -> bool {
+        true
+    }
+
+    fn begin_aggregate_scan(
+        &mut self,
+        aggregates: &[Aggregate],
+        group_by: &[Column],
+        quals: &[Qual],
+        options: &HashMap<String, String>,
+    ) -> ClickHouseFdwResult<()> {
+        self.table = require_option("table", options)?.to_string();
+        self.params = Vec::new();
+        self.sql_query = self.deparse_aggregate(aggregates, group_by, quals)?;
+        self.is_scan_complete = false;
+        self.current_row_data = None;
+
+        // tgt_cols must match the SELECT output order: group-by columns first,
+        // then aggregate result columns named by their aliases. convert_row_simple
+        // looks up each column by name in the ClickHouse result row, so the alias
+        // in tgt_cols must match the AS alias in the SQL query.
+        let mut tgt_cols: Vec<Column> = group_by.to_vec();
+        for (i, agg) in aggregates.iter().enumerate() {
+            tgt_cols.push(Column {
+                name: agg.alias.clone(),
+                num: group_by.len() + i + 1,
+                type_oid: agg.type_oid,
+            });
+        }
+        self.tgt_cols = tgt_cols;
+
+        self.stream_buffer_size = options
+            .get("stream_buffer_size")
+            .map(|s| s.parse::<usize>().map(|size| size.clamp(1, 100_000)))
+            .transpose()
+            .map_err(ClickHouseFdwError::ParseIntError)?
+            .unwrap_or(1024);
+
+        self.setup_streaming()?;
+
         Ok(())
     }
 }

--- a/wrappers/src/fdw/clickhouse_fdw/tests.rs
+++ b/wrappers/src/fdw/clickhouse_fdw/tests.rs
@@ -908,4 +908,541 @@ mod tests {
             );
         });
     }
+
+    /// Verify that aggregate queries are pushed down to ClickHouse.
+    ///
+    /// With pushdown the PostgreSQL plan is a bare `ForeignScan` — there is no
+    /// local `Aggregate` / `HashAggregate` / `GroupAggregate` node on top.
+    /// We check this via `EXPLAIN` alongside correctness assertions.
+    ///
+    /// Test data (table `agg_test`):
+    ///   id=1, name='alice', amt=10  (row 1)
+    ///   id=1, name='alice', amt=20  (row 2 — duplicate name)
+    ///   id=2, name='bob',   amt=30  (row 3)
+    ///   id=2, name='carol', amt=40  (row 4)
+    #[pg_test]
+    fn clickhouse_aggregate_pushdown_test() {
+        Spi::connect_mut(|c| {
+            let clickhouse_pool = ch::Pool::new("tcp://default:default@localhost:9000/default");
+            let rt = create_async_runtime().expect("failed to create runtime");
+            let mut handle = rt
+                .block_on(async { clickhouse_pool.get_handle().await })
+                .expect("handle");
+
+            rt.block_on(async {
+                handle.execute("DROP TABLE IF EXISTS agg_test").await?;
+                handle
+                    .execute(
+                        "CREATE TABLE agg_test (
+                            id    Int64,
+                            name  String,
+                            amt   Float64
+                        ) engine = Memory",
+                    )
+                    .await?;
+                handle
+                    .execute(
+                        "INSERT INTO agg_test VALUES
+                            (1, 'alice', 10.0),
+                            (1, 'alice', 20.0),
+                            (2, 'bob',   30.0),
+                            (2, 'carol', 40.0)",
+                    )
+                    .await
+            })
+            .expect("agg_test in ClickHouse");
+
+            c.update(
+                "CREATE FOREIGN DATA WRAPPER clickhouse_agg_wrapper
+                 HANDLER click_house_fdw_handler VALIDATOR click_house_fdw_validator",
+                None,
+                &[],
+            )
+            .unwrap();
+            c.update(
+                "CREATE SERVER agg_server FOREIGN DATA WRAPPER clickhouse_agg_wrapper
+                 OPTIONS (conn_string 'tcp://default:default@localhost:9000/default')",
+                None,
+                &[],
+            )
+            .unwrap();
+            c.update(
+                "CREATE FOREIGN TABLE agg_test (
+                    id   bigint,
+                    name text,
+                    amt  double precision
+                 )
+                 SERVER agg_server
+                 OPTIONS (table 'agg_test')",
+                None,
+                &[],
+            )
+            .unwrap();
+
+            // Collect EXPLAIN output and assert no local Aggregate node is present.
+            // With pushdown the ForeignScan IS the aggregate; without pushdown
+            // PostgreSQL adds an Aggregate / HashAggregate / GroupAggregate node
+            // on top of the ForeignScan.
+            macro_rules! assert_pushed_down {
+                ($c:expr, $sql:expr) => {{
+                    let explain = format!("EXPLAIN {}", $sql);
+                    // EXPLAIN returns a single-column result. SpiHeapTupleData::get
+                    // uses 1-based ordinal access; SpiTupleTable::get_one is only
+                    // available on the table-level (after .first()), not on iterators.
+                    let plan: Vec<String> = $c
+                        .select(&explain, None, &[])
+                        .unwrap()
+                        .filter_map(|r| r.get::<&str>(1).unwrap().map(|s| s.to_string()))
+                        .collect();
+                    // PostgreSQL plan node lines always include "(cost=...)",
+                    // e.g. "HashAggregate  (cost=...)" or "->  Aggregate  (cost=...)".
+                    // The FDW's own EXPLAIN extra output (e.g. "Wrappers: aggregates = [...]")
+                    // does NOT include "(cost=", so we use both substrings to avoid
+                    // false positives from the FDW's debug info.
+                    assert!(
+                        !plan
+                            .iter()
+                            .any(|l| l.contains("Aggregate") && l.contains("(cost=")),
+                        "Expected pushdown for [{}] but plan shows local aggregation: {:?}",
+                        $sql,
+                        plan
+                    );
+                }};
+            }
+
+            // --- COUNT(*) — whole-table scalar aggregate ---
+            assert_eq!(
+                c.select("SELECT COUNT(*) FROM agg_test", None, &[])
+                    .unwrap()
+                    .first()
+                    .get_one::<i64>()
+                    .unwrap()
+                    .unwrap(),
+                4
+            );
+            assert_pushed_down!(c, "SELECT COUNT(*) FROM agg_test");
+
+            // --- COUNT(name) GROUP BY id ---
+            let mut rows: Vec<(i64, i64)> = c
+                .select(
+                    "SELECT id, COUNT(name) AS cnt FROM agg_test GROUP BY id ORDER BY id",
+                    None,
+                    &[],
+                )
+                .unwrap()
+                .map(|r| {
+                    let id = r.get_by_name::<i64, _>("id").unwrap().unwrap();
+                    let cnt = r.get_by_name::<i64, _>("cnt").unwrap().unwrap();
+                    (id, cnt)
+                })
+                .collect();
+            rows.sort();
+            assert_eq!(rows, vec![(1, 2), (2, 2)]);
+            assert_pushed_down!(c, "SELECT id, COUNT(name) AS cnt FROM agg_test GROUP BY id");
+
+            // --- SUM(amt) GROUP BY id ---
+            let mut rows: Vec<(i64, f64)> = c
+                .select(
+                    "SELECT id, SUM(amt) AS s FROM agg_test GROUP BY id ORDER BY id",
+                    None,
+                    &[],
+                )
+                .unwrap()
+                .map(|r| {
+                    let id = r.get_by_name::<i64, _>("id").unwrap().unwrap();
+                    let s = r.get_by_name::<f64, _>("s").unwrap().unwrap();
+                    (id, s)
+                })
+                .collect();
+            rows.sort_by_key(|&(id, _)| id);
+            assert_eq!(rows, vec![(1, 30.0), (2, 70.0)]);
+            assert_pushed_down!(c, "SELECT id, SUM(amt) AS s FROM agg_test GROUP BY id");
+
+            // --- AVG(amt) — whole-table ---
+            let avg: f64 = c
+                .select("SELECT AVG(amt) FROM agg_test", None, &[])
+                .unwrap()
+                .first()
+                .get_one::<f64>()
+                .unwrap()
+                .unwrap();
+            assert!(
+                (avg - 25.0).abs() < 1e-9,
+                "AVG(amt) expected 25.0, got {avg}"
+            );
+            assert_pushed_down!(c, "SELECT AVG(amt) FROM agg_test");
+
+            // --- MIN / MAX in the same query ---
+            assert_eq!(
+                c.select("SELECT MIN(id), MAX(id) FROM agg_test", None, &[])
+                    .unwrap()
+                    .first()
+                    .get_two::<i64, i64>()
+                    .unwrap(),
+                (Some(1), Some(2))
+            );
+            assert_pushed_down!(c, "SELECT MIN(id), MAX(id) FROM agg_test");
+
+            // --- COUNT(DISTINCT name) — whole-table (alice, bob, carol = 3) ---
+            assert_eq!(
+                c.select("SELECT COUNT(DISTINCT name) FROM agg_test", None, &[])
+                    .unwrap()
+                    .first()
+                    .get_one::<i64>()
+                    .unwrap()
+                    .unwrap(),
+                3
+            );
+            assert_pushed_down!(c, "SELECT COUNT(DISTINCT name) FROM agg_test");
+
+            // --- COUNT(DISTINCT name) GROUP BY id ---
+            // id=1: only 'alice' → 1; id=2: 'bob','carol' → 2
+            let mut rows: Vec<(i64, i64)> = c
+                .select(
+                    "SELECT id, COUNT(DISTINCT name) AS cnt FROM agg_test GROUP BY id ORDER BY id",
+                    None,
+                    &[],
+                )
+                .unwrap()
+                .map(|r| {
+                    let id = r.get_by_name::<i64, _>("id").unwrap().unwrap();
+                    let cnt = r.get_by_name::<i64, _>("cnt").unwrap().unwrap();
+                    (id, cnt)
+                })
+                .collect();
+            rows.sort();
+            assert_eq!(rows, vec![(1, 1), (2, 2)]);
+            assert_pushed_down!(
+                c,
+                "SELECT id, COUNT(DISTINCT name) AS cnt FROM agg_test GROUP BY id"
+            );
+
+            // --- WHERE + aggregate: qual is pushed alongside the aggregate ---
+            // 2 rows match id = 1, so SUM(amt) = 10 + 20 = 30.
+            let s: f64 = c
+                .select("SELECT SUM(amt) FROM agg_test WHERE id = 1", None, &[])
+                .unwrap()
+                .first()
+                .get_one::<f64>()
+                .unwrap()
+                .unwrap();
+            assert!((s - 30.0).abs() < 1e-9, "expected 30.0, got {s}");
+            assert_pushed_down!(c, "SELECT SUM(amt) FROM agg_test WHERE id = 1");
+
+            // ----------------- Negative pushdown cases -----------------
+            // For these, upper.rs's extract_aggregates / extract_group_by_columns
+            // bails out and we never register the upper path, so the planner
+            // falls back to a local HashAggregate / GroupAggregate above the
+            // base ForeignScan. The defensive guard in scan.rs (clearing
+            // state.aggregates when baserel.reloptkind != UPPER_REL) keeps
+            // execution on the regular scan path and produces correct results.
+
+            macro_rules! assert_not_pushed_down {
+                ($c:expr, $sql:expr) => {{
+                    let explain = format!("EXPLAIN {}", $sql);
+                    let plan: Vec<String> = $c
+                        .select(&explain, None, &[])
+                        .unwrap()
+                        .filter_map(|r| r.get::<&str>(1).unwrap().map(|s| s.to_string()))
+                        .collect();
+                    assert!(
+                        plan.iter()
+                            .any(|l| l.contains("Aggregate") && l.contains("(cost=")),
+                        "Expected NO pushdown (a local Aggregate node) for [{}], plan: {:?}",
+                        $sql,
+                        plan
+                    );
+                }};
+            }
+
+            // HAVING clause: extract_aggregates bails when havingQual is set.
+            let mut rows: Vec<(i64, i64)> = c
+                .select(
+                    "SELECT id, COUNT(*)::bigint AS cnt FROM agg_test \
+                     GROUP BY id HAVING COUNT(*) > 1 ORDER BY id",
+                    None,
+                    &[],
+                )
+                .unwrap()
+                .map(|r| {
+                    let id = r.get_by_name::<i64, _>("id").unwrap().unwrap();
+                    let cnt = r.get_by_name::<i64, _>("cnt").unwrap().unwrap();
+                    (id, cnt)
+                })
+                .collect();
+            rows.sort();
+            assert_eq!(rows, vec![(1, 2), (2, 2)]);
+            assert_not_pushed_down!(
+                c,
+                "SELECT id, COUNT(*) FROM agg_test GROUP BY id HAVING COUNT(*) > 1"
+            );
+
+            // Unsupported aggregate function: stddev_samp is not in
+            // supported_aggregates() and is not even recognized by
+            // oid_to_aggregate_kind, so extract_aggregates returns None.
+            // values [10,20,30,40] → mean=25, sample stddev = sqrt(500/3) ≈ 12.9099
+            let stddev: f64 = c
+                .select("SELECT STDDEV(amt) FROM agg_test", None, &[])
+                .unwrap()
+                .first()
+                .get_one::<f64>()
+                .unwrap()
+                .unwrap();
+            assert!(
+                (stddev - 12.909_944).abs() < 1e-3,
+                "expected ~12.910, got {stddev}"
+            );
+            assert_not_pushed_down!(c, "SELECT STDDEV(amt) FROM agg_test");
+
+            // FILTER clause on aggregate: aggref->aggfilter is non-NULL.
+            let cnt: i64 = c
+                .select(
+                    "SELECT COUNT(*) FILTER (WHERE id = 1) FROM agg_test",
+                    None,
+                    &[],
+                )
+                .unwrap()
+                .first()
+                .get_one::<i64>()
+                .unwrap()
+                .unwrap();
+            assert_eq!(cnt, 2);
+            assert_not_pushed_down!(c, "SELECT COUNT(*) FILTER (WHERE id = 1) FROM agg_test");
+
+            // DISTINCT modifier on a non-COUNT aggregate (only COUNT(DISTINCT)
+            // is allowed for pushdown). All four amt values are distinct.
+            let s: f64 = c
+                .select("SELECT SUM(DISTINCT amt) FROM agg_test", None, &[])
+                .unwrap()
+                .first()
+                .get_one::<f64>()
+                .unwrap()
+                .unwrap();
+            assert!((s - 100.0).abs() < 1e-9, "expected 100.0, got {s}");
+            assert_not_pushed_down!(c, "SELECT SUM(DISTINCT amt) FROM agg_test");
+
+            // Aggregate over a non-Var expression (OpExpr). 11+21+31+41 = 104.
+            let s: f64 = c
+                .select("SELECT SUM(amt + 1) FROM agg_test", None, &[])
+                .unwrap()
+                .first()
+                .get_one::<f64>()
+                .unwrap()
+                .unwrap();
+            assert!((s - 104.0).abs() < 1e-9, "expected 104.0, got {s}");
+            assert_not_pushed_down!(c, "SELECT SUM(amt + 1) FROM agg_test");
+
+            // GROUP BY a non-column expression. extract_group_by_columns finds
+            // the SortGroupClause's TLE expr is OpExpr (not T_Var) and bails.
+            let mut rows: Vec<(i64, i64)> = c
+                .select(
+                    "SELECT id + 1 AS g, COUNT(*)::bigint AS cnt FROM agg_test \
+                     GROUP BY id + 1 ORDER BY g",
+                    None,
+                    &[],
+                )
+                .unwrap()
+                .map(|r| {
+                    let g = r.get_by_name::<i64, _>("g").unwrap().unwrap();
+                    let cnt = r.get_by_name::<i64, _>("cnt").unwrap().unwrap();
+                    (g, cnt)
+                })
+                .collect();
+            rows.sort();
+            assert_eq!(rows, vec![(2, 2), (3, 2)]);
+            assert_not_pushed_down!(
+                c,
+                "SELECT id + 1 AS g, COUNT(*) FROM agg_test GROUP BY id + 1"
+            );
+        });
+    }
+
+    /// Aggregate pushdown over a sub-query specified in the `table` foreign-table
+    /// option (both the static and parameterized forms).  Reuses the `agg_test`
+    /// ClickHouse table created elsewhere in this module via cargo-pgrx's shared
+    /// test database; if run in isolation it (re)creates the table.
+    #[pg_test]
+    fn clickhouse_aggregate_subquery_test() {
+        Spi::connect_mut(|c| {
+            let clickhouse_pool = ch::Pool::new("tcp://default:default@localhost:9000/default");
+            let rt = create_async_runtime().expect("failed to create runtime");
+            let mut handle = rt
+                .block_on(async { clickhouse_pool.get_handle().await })
+                .expect("handle");
+
+            rt.block_on(async {
+                handle.execute("DROP TABLE IF EXISTS agg_sub_test").await?;
+                handle
+                    .execute(
+                        "CREATE TABLE agg_sub_test (
+                            id    Int64,
+                            name  String,
+                            amt   Float64
+                        ) engine = Memory",
+                    )
+                    .await?;
+                handle
+                    .execute(
+                        "INSERT INTO agg_sub_test VALUES
+                            (1, 'alice', 10.0),
+                            (1, 'alice', 20.0),
+                            (2, 'bob',   30.0),
+                            (2, 'carol', 40.0),
+                            (3, 'dan',   99.0)",
+                    )
+                    .await
+            })
+            .expect("agg_sub_test in ClickHouse");
+
+            c.update(
+                "CREATE FOREIGN DATA WRAPPER ch_sub_wrapper
+                 HANDLER click_house_fdw_handler VALIDATOR click_house_fdw_validator",
+                None,
+                &[],
+            )
+            .unwrap();
+            c.update(
+                "CREATE SERVER ch_sub_server FOREIGN DATA WRAPPER ch_sub_wrapper
+                 OPTIONS (conn_string 'tcp://default:default@localhost:9000/default')",
+                None,
+                &[],
+            )
+            .unwrap();
+
+            // --- Static sub-query (no params): aggregate must still push down.
+            // The remote side sees `SELECT ... FROM (select id, name, amt from
+            // agg_sub_test where id < 3) GROUP BY id`.
+            c.update(
+                "CREATE FOREIGN TABLE sub_static (
+                    id   bigint,
+                    name text,
+                    amt  double precision
+                 )
+                 SERVER ch_sub_server
+                 OPTIONS (table '(select id, name, amt from agg_sub_test where id < 3)')",
+                None,
+                &[],
+            )
+            .unwrap();
+
+            macro_rules! assert_pushed_down {
+                ($c:expr, $sql:expr) => {{
+                    let explain = format!("EXPLAIN {}", $sql);
+                    let plan: Vec<String> = $c
+                        .select(&explain, None, &[])
+                        .unwrap()
+                        .filter_map(|r| r.get::<&str>(1).unwrap().map(|s| s.to_string()))
+                        .collect();
+                    assert!(
+                        !plan
+                            .iter()
+                            .any(|l| l.contains("Aggregate") && l.contains("(cost=")),
+                        "Expected pushdown for [{}] but plan shows local aggregation: {:?}",
+                        $sql,
+                        plan
+                    );
+                }};
+            }
+
+            // Whole-table COUNT over the static sub-query.  id < 3 filters out
+            // the dan row, so only 4 rows remain.
+            let cnt: i64 = c
+                .select("SELECT COUNT(*) FROM sub_static", None, &[])
+                .unwrap()
+                .first()
+                .get_one::<i64>()
+                .unwrap()
+                .unwrap();
+            assert_eq!(cnt, 4);
+            assert_pushed_down!(c, "SELECT COUNT(*) FROM sub_static");
+
+            // GROUP BY over the sub-query.
+            let mut rows: Vec<(i64, i64)> = c
+                .select(
+                    "SELECT id, COUNT(*) AS cnt FROM sub_static GROUP BY id ORDER BY id",
+                    None,
+                    &[],
+                )
+                .unwrap()
+                .map(|r| {
+                    let id = r.get_by_name::<i64, _>("id").unwrap().unwrap();
+                    let cnt = r.get_by_name::<i64, _>("cnt").unwrap().unwrap();
+                    (id, cnt)
+                })
+                .collect();
+            rows.sort();
+            assert_eq!(rows, vec![(1, 2), (2, 2)]);
+            assert_pushed_down!(c, "SELECT id, COUNT(*) FROM sub_static GROUP BY id");
+
+            // SUM with extra WHERE on the foreign table: the WHERE qual is also
+            // pushed remotely (deparse_aggregate's WHERE-builder skips params
+            // and arrays but keeps regular quals).
+            let s: f64 = c
+                .select(
+                    "SELECT SUM(amt) FROM sub_static WHERE id = 2",
+                    None,
+                    &[],
+                )
+                .unwrap()
+                .first()
+                .get_one::<f64>()
+                .unwrap()
+                .unwrap();
+            assert!((s - 70.0).abs() < 1e-9, "expected 70.0, got {s}");
+            assert_pushed_down!(c, "SELECT SUM(amt) FROM sub_static WHERE id = 2");
+
+            // --- Parameterized sub-query: ${filter_id} is bound from a qual on
+            // the foreign-table column `filter_id`.  The qual is consumed as a
+            // parameter (not emitted as a remote WHERE clause).  Aggregate
+            // pushdown still applies — the deparsed remote SQL becomes
+            // `SELECT COUNT(*) AS agg_1 FROM (select 1 as filter_id, ...
+            //  from agg_sub_test where id = 1)`.
+            c.update(
+                "CREATE FOREIGN TABLE sub_param (
+                    filter_id bigint,
+                    id        bigint,
+                    name      text,
+                    amt       double precision
+                 )
+                 SERVER ch_sub_server
+                 OPTIONS (
+                    table '(select ${filter_id} as filter_id, id, name, amt \
+                            from agg_sub_test where id = ${filter_id})'
+                 )",
+                None,
+                &[],
+            )
+            .unwrap();
+
+            // id=1 → 2 rows.
+            let cnt: i64 = c
+                .select(
+                    "SELECT COUNT(*) FROM sub_param WHERE filter_id = 1",
+                    None,
+                    &[],
+                )
+                .unwrap()
+                .first()
+                .get_one::<i64>()
+                .unwrap()
+                .unwrap();
+            assert_eq!(cnt, 2);
+            assert_pushed_down!(c, "SELECT COUNT(*) FROM sub_param WHERE filter_id = 1");
+
+            // id=2 → SUM(amt) = 30 + 40 = 70.
+            let s: f64 = c
+                .select(
+                    "SELECT SUM(amt) FROM sub_param WHERE filter_id = 2",
+                    None,
+                    &[],
+                )
+                .unwrap()
+                .first()
+                .get_one::<f64>()
+                .unwrap()
+                .unwrap();
+            assert!((s - 70.0).abs() < 1e-9, "expected 70.0, got {s}");
+            assert_pushed_down!(c, "SELECT SUM(amt) FROM sub_param WHERE filter_id = 2");
+        });
+    }
 }

--- a/wrappers/src/fdw/clickhouse_fdw/tests.rs
+++ b/wrappers/src/fdw/clickhouse_fdw/tests.rs
@@ -1378,11 +1378,7 @@ mod tests {
             // pushed remotely (deparse_aggregate's WHERE-builder skips params
             // and arrays but keeps regular quals).
             let s: f64 = c
-                .select(
-                    "SELECT SUM(amt) FROM sub_static WHERE id = 2",
-                    None,
-                    &[],
-                )
+                .select("SELECT SUM(amt) FROM sub_static WHERE id = 2", None, &[])
                 .unwrap()
                 .first()
                 .get_one::<f64>()

--- a/wrappers/src/fdw/mssql_fdw/README.md
+++ b/wrappers/src/fdw/mssql_fdw/README.md
@@ -10,6 +10,7 @@ This is a foreign data wrapper for [Microsoft SQL Server](https://www.microsoft.
 
 | Version | Date       | Notes                                                |
 | ------- | ---------- | ---------------------------------------------------- |
+| 0.1.4   | 2026-04-28 | Add aggregate pushdown support                       |
 | 0.1.3   | 2025-02-12 | Fix Numeric type conversion error                    |
 | 0.1.2   | 2024-09-30 | Support for pgrx 0.12.6                              |
 | 0.1.1   | 2024-09-09 | Add boolean test qual support                        |

--- a/wrappers/src/fdw/mssql_fdw/mssql_fdw.rs
+++ b/wrappers/src/fdw/mssql_fdw/mssql_fdw.rs
@@ -1,5 +1,6 @@
 use crate::stats;
 use num_traits::cast::ToPrimitive;
+use pgrx::pg_sys;
 use pgrx::{PgBuiltInOids, PgOid, prelude::to_timestamp};
 use std::collections::HashMap;
 use tiberius::{
@@ -13,6 +14,27 @@ use tokio_util::compat::TokioAsyncWriteCompatExt;
 use supabase_wrappers::prelude::*;
 
 use super::{MssqlFdwError, MssqlFdwResult};
+
+// Map a Postgres expected aggregate result type to a SQL Server type that
+// (a) tiberius will read back into the same Rust scalar type that field_to_cell
+// expects for that Postgres OID and (b) holds the value without truncation.
+// We wrap every aggregate expression in `CAST(... AS <mssql_type>)` so that
+// MSSQL's natural result types (int32 for SUM/AVG over int, int32 for COUNT,
+// etc.) cannot mismatch what Postgres expects (int8 for SUM(int), numeric
+// for SUM(int8), int8 for COUNT, ...).
+fn pg_oid_to_mssql_cast(type_oid: pg_sys::Oid) -> Option<&'static str> {
+    match PgOid::from(type_oid) {
+        PgOid::BuiltIn(PgBuiltInOids::INT8OID) => Some("bigint"),
+        PgOid::BuiltIn(PgBuiltInOids::INT4OID) => Some("int"),
+        PgOid::BuiltIn(PgBuiltInOids::INT2OID) => Some("smallint"),
+        PgOid::BuiltIn(PgBuiltInOids::FLOAT4OID) => Some("real"),
+        PgOid::BuiltIn(PgBuiltInOids::FLOAT8OID) => Some("float"),
+        PgOid::BuiltIn(PgBuiltInOids::NUMERICOID) => Some("numeric(38,10)"),
+        PgOid::BuiltIn(PgBuiltInOids::DATEOID) => Some("date"),
+        PgOid::BuiltIn(PgBuiltInOids::TIMESTAMPOID) => Some("datetime2"),
+        _ => None,
+    }
+}
 
 // convert a source field to a wrappers cell
 fn field_to_cell(src_row: &tiberius::Row, tgt_col: &Column) -> MssqlFdwResult<Option<Cell>> {
@@ -94,7 +116,7 @@ impl CellFormatter for MssqlCellFormatter {
 }
 
 #[wrappers_fdw(
-    version = "0.1.3",
+    version = "0.1.4",
     author = "Supabase",
     website = "https://github.com/supabase/wrappers/tree/main/wrappers/src/fdw/mssql_fdw",
     error_type = "MssqlFdwError"
@@ -187,6 +209,88 @@ impl MssqlFdw {
 
             let real_limit = limit.offset + limit.count;
             sql.push_str(&format!(" offset 0 rows fetch next {real_limit} rows only",));
+        }
+
+        Ok(sql)
+    }
+
+    fn deparse_aggregate(
+        &self,
+        aggregates: &[Aggregate],
+        group_by: &[Column],
+        quals: &[Qual],
+    ) -> MssqlFdwResult<String> {
+        // SELECT: group-by columns first, then aggregate expressions with
+        // aliases. Each aggregate is wrapped in CAST(... AS <mssql_type>) so
+        // the value returned from MSSQL is read back into the exact Rust
+        // scalar type field_to_cell uses for the Postgres aggregate result
+        // type. COUNT is mapped to COUNT_BIG so the result fits Postgres'
+        // int8 expectation without overflow.
+        let mut select_items: Vec<String> = group_by.iter().map(|c| c.name.clone()).collect();
+        for agg in aggregates {
+            let inner = match agg.kind {
+                AggregateKind::Count => "count_big(*)".to_string(),
+                AggregateKind::CountColumn => {
+                    let col = agg.column.as_ref().map(|c| c.name.as_str()).unwrap_or("*");
+                    if agg.distinct {
+                        format!("count_big(distinct {col})")
+                    } else {
+                        format!("count_big({col})")
+                    }
+                }
+                _ => {
+                    let col = agg.column.as_ref().map(|c| c.name.as_str()).unwrap_or("*");
+                    format!("{}({})", agg.kind.sql_name().to_lowercase(), col)
+                }
+            };
+            let cast_type = pg_oid_to_mssql_cast(agg.type_oid).ok_or_else(|| {
+                MssqlFdwError::SyntaxError(format!(
+                    "aggregate result type oid {} is not supported for pushdown",
+                    agg.type_oid.to_u32()
+                ))
+            })?;
+            select_items.push(format!("cast({inner} as {cast_type}) as {}", agg.alias));
+        }
+
+        let mut sql = format!(
+            "select {} from {} as _wrappers_tbl",
+            select_items.join(", "),
+            &self.table
+        );
+
+        // WHERE — same boolean-test handling as deparse()
+        if !quals.is_empty() {
+            let cond = quals
+                .iter()
+                .map(|q| {
+                    let oper = q.operator.as_str();
+                    let mut fmt = MssqlCellFormatter {};
+                    if let Value::Cell(cell) = &q.value
+                        && let Cell::Bool(_) = cell
+                    {
+                        if oper == "is" {
+                            return format!("{} = {}", q.field, fmt.fmt_cell(cell));
+                        } else if oper == "is not" {
+                            return format!("{} <> {}", q.field, fmt.fmt_cell(cell));
+                        }
+                    }
+                    q.deparse_with_fmt(&mut fmt)
+                })
+                .collect::<Vec<String>>()
+                .join(" and ");
+            if !cond.is_empty() {
+                sql.push_str(&format!(" where {cond}"));
+            }
+        }
+
+        // GROUP BY
+        if !group_by.is_empty() {
+            let cols = group_by
+                .iter()
+                .map(|c| c.name.as_str())
+                .collect::<Vec<_>>()
+                .join(", ");
+            sql.push_str(&format!(" group by {cols}"));
         }
 
         Ok(sql)
@@ -289,6 +393,76 @@ impl ForeignDataWrapper<MssqlFdwError> for MssqlFdw {
 
     fn end_scan(&mut self) -> MssqlFdwResult<()> {
         self.scan_result.clear();
+        Ok(())
+    }
+
+    fn supported_aggregates(&self) -> Vec<AggregateKind> {
+        vec![
+            AggregateKind::Count,
+            AggregateKind::CountColumn,
+            AggregateKind::Sum,
+            AggregateKind::Avg,
+            AggregateKind::Min,
+            AggregateKind::Max,
+        ]
+    }
+
+    fn supports_group_by(&self) -> bool {
+        true
+    }
+
+    fn begin_aggregate_scan(
+        &mut self,
+        aggregates: &[Aggregate],
+        group_by: &[Column],
+        quals: &[Qual],
+        options: &HashMap<String, String>,
+    ) -> MssqlFdwResult<()> {
+        self.table = require_option("table", options)?.to_string();
+        self.iter_idx = 0;
+
+        // tgt_cols must match the SELECT output order: group-by columns first,
+        // then aggregate result columns named by their aliases. field_to_cell
+        // looks up each column by name in the tiberius row, so the alias here
+        // must match the AS alias emitted by deparse_aggregate.
+        let mut tgt_cols: Vec<Column> = group_by.to_vec();
+        for (i, agg) in aggregates.iter().enumerate() {
+            tgt_cols.push(Column {
+                name: agg.alias.clone(),
+                num: group_by.len() + i + 1,
+                type_oid: agg.type_oid,
+            });
+        }
+        self.tgt_cols = tgt_cols;
+
+        // create sql server client
+        let tcp = self
+            .rt
+            .block_on(TcpStream::connect(self.config.get_addr()))?;
+        tcp.set_nodelay(true)?;
+        let mut client = self
+            .rt
+            .block_on(Client::connect(self.config.clone(), tcp.compat_write()))?;
+
+        let sql = self.deparse_aggregate(aggregates, group_by, quals)?;
+
+        self.scan_result = self.rt.block_on(
+            self.rt
+                .block_on(client.simple_query(sql))?
+                .into_first_result(),
+        )?;
+
+        stats::inc_stats(
+            Self::FDW_NAME,
+            stats::Metric::RowsIn,
+            self.scan_result.len() as i64,
+        );
+        stats::inc_stats(
+            Self::FDW_NAME,
+            stats::Metric::RowsOut,
+            self.scan_result.len() as i64,
+        );
+
         Ok(())
     }
 }

--- a/wrappers/src/fdw/mssql_fdw/tests.rs
+++ b/wrappers/src/fdw/mssql_fdw/tests.rs
@@ -31,6 +31,12 @@ mod tests {
         rt.block_on(async {
             client
                 .execute(
+                    "IF OBJECT_ID('users', 'U') IS NOT NULL DROP TABLE users",
+                    &[],
+                )
+                .await?;
+            client
+                .execute(
                     r#"CREATE TABLE users (
                         id bigint,
                         name varchar(30),
@@ -198,5 +204,341 @@ mod tests {
             })
         });
         assert!(result.is_err());
+    }
+
+    /// Verify aggregate queries are pushed down to SQL Server.
+    ///
+    /// Test data (table `agg_test`):
+    ///   id=1, name='alice', amount=10.0
+    ///   id=1, name='alice', amount=20.0   (duplicate name)
+    ///   id=2, name='bob',   amount=30.0
+    ///   id=2, name='carol', amount=40.0
+    #[pg_test]
+    fn mssql_aggregate_pushdown_test() {
+        let rt = create_async_runtime().expect("failed to create runtime");
+
+        let mut config = Config::new();
+        config.host("localhost");
+        config.port(1433);
+        config.encryption(EncryptionLevel::NotSupported);
+        config.authentication(AuthMethod::sql_server("SA", "Password1234_56"));
+        config.trust_cert();
+
+        let tcp = rt
+            .block_on(TcpStream::connect(config.get_addr()))
+            .expect("cannot create TcpStream");
+        tcp.set_nodelay(true).expect("TcpStream set nodelay");
+
+        let mut client = rt
+            .block_on(Client::connect(config, tcp.compat_write()))
+            .expect("client connect");
+
+        rt.block_on(async {
+            client
+                .execute(
+                    "IF OBJECT_ID('agg_test', 'U') IS NOT NULL DROP TABLE agg_test",
+                    &[],
+                )
+                .await?;
+            client
+                .execute(
+                    "CREATE TABLE agg_test (
+                        id     bigint,
+                        name   varchar(30),
+                        amount numeric(18,2)
+                     )",
+                    &[],
+                )
+                .await?;
+            client
+                .execute(
+                    "INSERT INTO agg_test (id, name, amount) VALUES
+                        (1, 'alice', 10.0),
+                        (1, 'alice', 20.0),
+                        (2, 'bob',   30.0),
+                        (2, 'carol', 40.0)",
+                    &[],
+                )
+                .await
+        })
+        .expect("seed agg_test in SQL Server");
+
+        Spi::connect_mut(|c| {
+            c.update(
+                r#"CREATE FOREIGN DATA WRAPPER mssql_agg_wrapper
+                         HANDLER mssql_fdw_handler VALIDATOR mssql_fdw_validator"#,
+                None,
+                &[],
+            )
+            .unwrap();
+            c.update(
+                r#"CREATE SERVER mssql_agg_server
+                         FOREIGN DATA WRAPPER mssql_agg_wrapper
+                         OPTIONS (
+                           conn_string 'Server=localhost,1433;User=sa;Password=Password1234_56;Database=master;IntegratedSecurity=false;TrustServerCertificate=true;encrypt=DANGER_PLAINTEXT;ApplicationName=wrappers'
+                         )"#,
+                None,
+                &[],
+            )
+            .unwrap();
+            c.update(
+                r#"CREATE FOREIGN TABLE agg_test (
+                        id     bigint,
+                        name   text,
+                        amount numeric(18,2)
+                     )
+                     SERVER mssql_agg_server
+                     OPTIONS (table 'agg_test')"#,
+                None,
+                &[],
+            )
+            .unwrap();
+            c.update(
+                r#"CREATE FOREIGN TABLE agg_sub (
+                        id     bigint,
+                        name   text,
+                        amount numeric(18,2)
+                     )
+                     SERVER mssql_agg_server
+                     OPTIONS (table '(select * from agg_test where id < 3)')"#,
+                None,
+                &[],
+            )
+            .unwrap();
+
+            macro_rules! assert_pushed_down {
+                ($c:expr, $sql:expr) => {{
+                    let explain = format!("EXPLAIN {}", $sql);
+                    let plan: Vec<String> = $c
+                        .select(&explain, None, &[])
+                        .unwrap()
+                        .filter_map(|r| r.get::<&str>(1).unwrap().map(|s| s.to_string()))
+                        .collect();
+                    assert!(
+                        !plan
+                            .iter()
+                            .any(|l| l.contains("Aggregate") && l.contains("(cost=")),
+                        "Expected pushdown for [{}] but plan shows local aggregation: {:?}",
+                        $sql,
+                        plan
+                    );
+                }};
+            }
+
+            macro_rules! assert_not_pushed_down {
+                ($c:expr, $sql:expr) => {{
+                    let explain = format!("EXPLAIN {}", $sql);
+                    let plan: Vec<String> = $c
+                        .select(&explain, None, &[])
+                        .unwrap()
+                        .filter_map(|r| r.get::<&str>(1).unwrap().map(|s| s.to_string()))
+                        .collect();
+                    assert!(
+                        plan.iter()
+                            .any(|l| l.contains("Aggregate") && l.contains("(cost=")),
+                        "Expected NO pushdown (local Aggregate) for [{}], plan: {:?}",
+                        $sql,
+                        plan
+                    );
+                }};
+            }
+
+            // --- COUNT(*) — whole-table scalar aggregate (mapped to count_big)
+            let cnt: i64 = c
+                .select("SELECT COUNT(*) FROM agg_test", None, &[])
+                .unwrap()
+                .first()
+                .get_one::<i64>()
+                .unwrap()
+                .unwrap();
+            assert_eq!(cnt, 4);
+            assert_pushed_down!(c, "SELECT COUNT(*) FROM agg_test");
+
+            // --- COUNT(name) GROUP BY id ---
+            let mut rows: Vec<(i64, i64)> = c
+                .select(
+                    "SELECT id, COUNT(name) AS cnt FROM agg_test GROUP BY id ORDER BY id",
+                    None,
+                    &[],
+                )
+                .unwrap()
+                .map(|r| {
+                    let id = r.get_by_name::<i64, _>("id").unwrap().unwrap();
+                    let cnt = r.get_by_name::<i64, _>("cnt").unwrap().unwrap();
+                    (id, cnt)
+                })
+                .collect();
+            rows.sort();
+            assert_eq!(rows, vec![(1, 2), (2, 2)]);
+            assert_pushed_down!(c, "SELECT id, COUNT(name) AS cnt FROM agg_test GROUP BY id");
+
+            // --- SUM(amount) GROUP BY id (numeric → CAST to numeric(38,10)) ---
+            let mut rows: Vec<(i64, pgrx::AnyNumeric)> = c
+                .select(
+                    "SELECT id, SUM(amount) AS s FROM agg_test GROUP BY id ORDER BY id",
+                    None,
+                    &[],
+                )
+                .unwrap()
+                .map(|r| {
+                    let id = r.get_by_name::<i64, _>("id").unwrap().unwrap();
+                    let s = r.get_by_name::<pgrx::AnyNumeric, _>("s").unwrap().unwrap();
+                    (id, s)
+                })
+                .collect();
+            rows.sort_by_key(|&(id, _)| id);
+            assert_eq!(rows.len(), 2);
+            assert_eq!(rows[0].0, 1);
+            assert_eq!(rows[1].0, 2);
+            assert!(
+                f64::try_from(rows[0].1.clone()).unwrap() - 30.0 < 1e-6,
+                "SUM(amount) for id=1 expected 30, got {:?}",
+                rows[0].1
+            );
+            assert!(
+                f64::try_from(rows[1].1.clone()).unwrap() - 70.0 < 1e-6,
+                "SUM(amount) for id=2 expected 70, got {:?}",
+                rows[1].1
+            );
+            assert_pushed_down!(c, "SELECT id, SUM(amount) FROM agg_test GROUP BY id");
+
+            // --- AVG(amount) — whole-table ---
+            let avg: pgrx::AnyNumeric = c
+                .select("SELECT AVG(amount) FROM agg_test", None, &[])
+                .unwrap()
+                .first()
+                .get_one::<pgrx::AnyNumeric>()
+                .unwrap()
+                .unwrap();
+            let avg_f = f64::try_from(avg.clone()).unwrap();
+            assert!(
+                (avg_f - 25.0).abs() < 1e-6,
+                "AVG(amount) expected 25, got {avg_f}"
+            );
+            assert_pushed_down!(c, "SELECT AVG(amount) FROM agg_test");
+
+            // --- MIN / MAX in the same query (bigint → CAST to bigint) ---
+            assert_eq!(
+                c.select("SELECT MIN(id), MAX(id) FROM agg_test", None, &[])
+                    .unwrap()
+                    .first()
+                    .get_two::<i64, i64>()
+                    .unwrap(),
+                (Some(1), Some(2))
+            );
+            assert_pushed_down!(c, "SELECT MIN(id), MAX(id) FROM agg_test");
+
+            // --- COUNT(DISTINCT name) — whole-table (alice, bob, carol = 3) ---
+            assert_eq!(
+                c.select("SELECT COUNT(DISTINCT name) FROM agg_test", None, &[])
+                    .unwrap()
+                    .first()
+                    .get_one::<i64>()
+                    .unwrap()
+                    .unwrap(),
+                3
+            );
+            assert_pushed_down!(c, "SELECT COUNT(DISTINCT name) FROM agg_test");
+
+            // --- WHERE + aggregate: qual is pushed alongside the aggregate
+            let s: pgrx::AnyNumeric = c
+                .select("SELECT SUM(amount) FROM agg_test WHERE id = 1", None, &[])
+                .unwrap()
+                .first()
+                .get_one::<pgrx::AnyNumeric>()
+                .unwrap()
+                .unwrap();
+            assert!((f64::try_from(s).unwrap() - 30.0).abs() < 1e-6);
+            assert_pushed_down!(c, "SELECT SUM(amount) FROM agg_test WHERE id = 1");
+
+            // --- Aggregate over sub-query in `table` option ---
+            let cnt: i64 = c
+                .select("SELECT COUNT(*) FROM agg_sub", None, &[])
+                .unwrap()
+                .first()
+                .get_one::<i64>()
+                .unwrap()
+                .unwrap();
+            assert_eq!(cnt, 4);
+            assert_pushed_down!(c, "SELECT COUNT(*) FROM agg_sub");
+
+            let mut rows: Vec<(i64, i64)> = c
+                .select(
+                    "SELECT id, COUNT(*)::bigint AS cnt FROM agg_sub GROUP BY id ORDER BY id",
+                    None,
+                    &[],
+                )
+                .unwrap()
+                .map(|r| {
+                    let id = r.get_by_name::<i64, _>("id").unwrap().unwrap();
+                    let cnt = r.get_by_name::<i64, _>("cnt").unwrap().unwrap();
+                    (id, cnt)
+                })
+                .collect();
+            rows.sort();
+            assert_eq!(rows, vec![(1, 2), (2, 2)]);
+            assert_pushed_down!(c, "SELECT id, COUNT(*) FROM agg_sub GROUP BY id");
+
+            // --- Negative cases: planner falls back to local Aggregate ---
+
+            // HAVING clause is not pushed down.
+            let mut rows: Vec<(i64, i64)> = c
+                .select(
+                    "SELECT id, COUNT(*)::bigint AS cnt FROM agg_test \
+                     GROUP BY id HAVING COUNT(*) > 1 ORDER BY id",
+                    None,
+                    &[],
+                )
+                .unwrap()
+                .map(|r| {
+                    let id = r.get_by_name::<i64, _>("id").unwrap().unwrap();
+                    let cnt = r.get_by_name::<i64, _>("cnt").unwrap().unwrap();
+                    (id, cnt)
+                })
+                .collect();
+            rows.sort();
+            assert_eq!(rows, vec![(1, 2), (2, 2)]);
+            assert_not_pushed_down!(
+                c,
+                "SELECT id, COUNT(*) FROM agg_test GROUP BY id HAVING COUNT(*) > 1"
+            );
+
+            // FILTER clause is not pushed down.
+            let cnt: i64 = c
+                .select(
+                    "SELECT COUNT(*) FILTER (WHERE id = 1) FROM agg_test",
+                    None,
+                    &[],
+                )
+                .unwrap()
+                .first()
+                .get_one::<i64>()
+                .unwrap()
+                .unwrap();
+            assert_eq!(cnt, 2);
+            assert_not_pushed_down!(c, "SELECT COUNT(*) FILTER (WHERE id = 1) FROM agg_test");
+
+            // GROUP BY non-column expression is not pushed down.
+            let mut rows: Vec<(i64, i64)> = c
+                .select(
+                    "SELECT id + 1 AS g, COUNT(*)::bigint AS cnt FROM agg_test \
+                     GROUP BY id + 1 ORDER BY g",
+                    None,
+                    &[],
+                )
+                .unwrap()
+                .map(|r| {
+                    let g = r.get_by_name::<i64, _>("g").unwrap().unwrap();
+                    let cnt = r.get_by_name::<i64, _>("cnt").unwrap().unwrap();
+                    (g, cnt)
+                })
+                .collect();
+            rows.sort();
+            assert_eq!(rows, vec![(2, 2), (3, 2)]);
+            assert_not_pushed_down!(
+                c,
+                "SELECT id + 1 AS g, COUNT(*) FROM agg_test GROUP BY id + 1"
+            );
+        });
     }
 }


### PR DESCRIPTION
Continuation of https://github.com/supabase/wrappers/pull/549 by @JohnCari — picks up the aggregate pushdown work with a critical bug fix.

## Summary

- Add `AggregateKind` enum, `Aggregate` struct with `deparse()`/`deparse_with_alias()` methods
- Add FDW trait methods: `supported_aggregates()`, `supports_group_by()`, `get_aggregate_rel_size()`, `begin_aggregate_scan()` — all with backward-compatible defaults
- Add `GetForeignUpperPaths` callback in new `upper.rs` module
- Register `GetForeignUpperPaths` in `fdw_routine()`
- PG version compat: PG13–PG18 (`disabled_nodes`, `fdw_restrictinfo`)

### Critical fix from #549

**Bug**: `upper.rs` extracted aggregates and group_by from the query but passed `fdw_private: ptr::null_mut()` when creating the foreign upper path. The executor never received the aggregate info, so `begin_aggregate_scan()` was never called.

**Fix**: Store aggregates and group_by in `FdwState`, pass the state pointer through `output_rel->fdw_private` so it survives from planning to execution. `begin_foreign_scan` now detects aggregate paths and dispatches to `begin_aggregate_scan()`.

## Test plan

- [x] `cargo fmt --check` passes
- [x] `clippy -D warnings` passes (zero warnings)
- [x] `cargo test` — 19 passed, 0 failed (unit + doc tests)
- [x] `cargo pgrx test --features "helloworld_fdw pg16"` — compiles and passes
- [x] Backward compat: existing FDWs without aggregate support are unaffected (empty `supported_aggregates()` default)