### PR TITLE
chore: bump Wrappers version to 0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7729,7 +7729,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "supabase-wrappers"
-version = "0.1.26"
+version = "0.1.27"
 dependencies = [
  "pgrx",
  "pgrx-tests",
@@ -9840,7 +9840,7 @@ dependencies = [
 
 [[package]]
 name = "wrappers"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "arrow-array 55.2.0",

--- a/supabase-wrappers/Cargo.toml
+++ b/supabase-wrappers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "supabase-wrappers"
-version = "0.1.26"
+version = "0.1.27"
 authors = ["Supabase Inc. https://supabase.com/"]
 license = "Apache-2.0"
 description = "Postgres Foreign Data Wrapper development framework in Rust."

--- a/wrappers/Cargo.toml
+++ b/wrappers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wrappers"
-version = "0.6.0"
+version = "0.6.1"
 publish = false
 homepage = "https://github.com/supabase/wrappers/tree/main/wrappers"
 repository = "https://github.com/supabase/wrappers/tree/main/wrappers"


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to bump Wrappers version to 0.6.1. Major changes in this release:

- Added MySQL FDW
- Added DynamoDB FDW
- Added aggregate pushdown support in Wrappers framework, and implemented it for ClickHouse, MSSQL, BigQuery and MySQL FDW
- Added schema evolution for Iceberg FDW

## What is the current behavior?

N/A

## What is the new behavior?

N/A

## Additional context

N/A
