### PR TITLE
ci: make manual release workflow runs always as dry-run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,11 @@ on:
         required: true
         default: true
         type: boolean
+      version:
+        description: "Fake version tag for dry-run packaging (e.g. v0.0.0-dry-run)"
+        required: false
+        default: "v0.0.0-dry-run"
+        type: string
   push:
     # Sequence of patterns matched against refs/tags
     tags:
@@ -146,6 +151,14 @@ jobs:
         run: |
           cd wrappers
 
+          # Resolve effective version: use input for manual dry-runs, tag for real releases
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            EFFECTIVE_VERSION="${{ inputs.version }}"
+          else
+            EFFECTIVE_VERSION="${{ github.ref_name }}"
+          fi
+          echo "Building version: ${EFFECTIVE_VERSION}"
+
           # Add postgres package repo and install requested postgres version
           sudo apt update
           sudo apt remove -y postgres*
@@ -187,7 +200,7 @@ jobs:
           cargo pgrx package --no-default-features --features pg${{ matrix.postgres }},${{ matrix.features }}
 
           # Extension version and path
-          extension_version=${{ github.ref_name }}
+          extension_version=${EFFECTIVE_VERSION}
           extension_dir=../target/release/${{ matrix.extension_name }}-pg${{ matrix.postgres }}/usr/share/postgresql/${{ matrix.postgres }}/extension
           # strip the leading v
           deb_version=${extension_version:1}
@@ -205,7 +218,7 @@ jobs:
           cp `find ../target/release -type f -name "${{ matrix.extension_name }}*"` archive
 
           # name of the package directory before packaging
-          package_dir=${{ matrix.extension_name }}-${{ github.ref_name }}-pg${{ matrix.postgres }}-${{ matrix.box.arch }}-linux-gnu
+          package_dir=${{ matrix.extension_name }}-${EFFECTIVE_VERSION}-pg${{ matrix.postgres }}-${{ matrix.box.arch }}-linux-gnu
 
           # Copy files into directory structure
           mkdir -p ${package_dir}/usr/lib/postgresql/lib
@@ -258,5 +271,5 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.extension_name }}-${{ github.ref_name }}-pg${{ matrix.postgres }}-${{ matrix.box.arch }}-linux-gnu
-          path: ./wrappers/${{ matrix.extension_name }}-${{ github.ref_name }}-pg${{ matrix.postgres }}-${{ matrix.box.arch }}-linux-gnu.deb
+          name: ${{ matrix.extension_name }}-${{ inputs.version }}-pg${{ matrix.postgres }}-${{ matrix.box.arch }}-linux-gnu
+          path: ./wrappers/${{ matrix.extension_name }}-${{ inputs.version }}-pg${{ matrix.postgres }}-${{ matrix.box.arch }}-linux-gnu.deb

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,13 +4,8 @@ name: Release
 on:
   workflow_dispatch:
     inputs:
-      dry_run:
-        description: "Run build/package jobs without publishing crates.io or GitHub Release assets"
-        required: true
-        default: true
-        type: boolean
       version:
-        description: "Fake version tag for dry-run packaging (e.g. v0.0.0)"
+        description: "Version tag to use for manual dry-run packaging (e.g. v0.0.0)"
         required: false
         default: "v0.0.0"
         type: string
@@ -275,7 +270,7 @@ jobs:
           asset_content_type: application/vnd.debian.binary-package
 
       - name: Upload dry-run artifact
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
+        if: ${{ github.event_name == 'workflow_dispatch' }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.extension_name }}-${{ inputs.version }}-pg${{ matrix.postgres }}-${{ matrix.box.arch }}-linux-gnu

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,7 +180,7 @@ jobs:
           sudo chmod a+rwx `/usr/lib/postgresql/${{ matrix.postgres }}/bin/pg_config --pkglibdir` `/usr/lib/postgresql/${{ matrix.postgres }}/bin/pg_config --sharedir`/extension /var/run/postgresql/
 
           # Ensure installed pg_config is first on path
-          export PATH=$PATH:/usr/lib/postgresql/${{ matrix.postgres }}/bin
+          export PATH=/usr/lib/postgresql/${{ matrix.postgres }}/bin:$PATH
 
           # Extra toolchain + linker config for arm64
           if [[ "${{ matrix.box.arch }}" == "arm64" ]]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,9 +10,9 @@ on:
         default: true
         type: boolean
       version:
-        description: "Fake version tag for dry-run packaging (e.g. v0.0.0-dry-run)"
+        description: "Fake version tag for dry-run packaging (e.g. v0.0.0)"
         required: false
-        default: "v0.0.0-dry-run"
+        default: "v0.0.0"
         type: string
   push:
     # Sequence of patterns matched against refs/tags
@@ -110,8 +110,7 @@ jobs:
           - wrappers
         pgrx_version:
           - 0.16.1
-        #postgres: [14, 15, 16, 17, 18]
-        postgres: [15]
+        postgres: [14, 15, 16, 17, 18]
         features:
           - "all_fdws"
         box:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,10 +152,18 @@ jobs:
 
           # Resolve effective version: use input for manual dry-runs, tag for real releases
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            EFFECTIVE_VERSION="${{ inputs.version }}"
+            RAW_VERSION="${{ inputs.version }}"
           else
-            EFFECTIVE_VERSION="${{ github.ref_name }}"
+            RAW_VERSION="${{ github.ref_name }}"
           fi
+
+          if [[ -z "${RAW_VERSION}" ]]; then
+            echo "Version must not be empty"
+            exit 1
+          fi
+
+          NORMALIZED_VERSION="${RAW_VERSION#v}"
+          EFFECTIVE_VERSION="v${NORMALIZED_VERSION}"
           echo "Building version: ${EFFECTIVE_VERSION}"
 
           # Add postgres package repo and install requested postgres version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -261,7 +261,7 @@ jobs:
 
       - name: Get upload url
         if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
-        run: echo UPLOAD_URL=$(curl --silent https://api.github.com/repos/${{ github.repository }}/releases/latest | jq .upload_url --raw-output) >> $GITHUB_ENV
+        run: echo UPLOAD_URL=$(curl --silent https://api.github.com/repos/${{ github.repository }}/releases/tags/${{ github.ref_name }} | jq .upload_url --raw-output) >> $GITHUB_ENV
 
       - name: Upload release asset
         if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,6 +161,15 @@ jobs:
           # Ensure installed pg_config is first on path
           export PATH=$PATH:/usr/lib/postgresql/${{ matrix.postgres }}/bin
 
+          # Extra toolchain + linker config for arm64
+          if [[ "${{ matrix.box.arch }}" == "arm64" ]]; then
+            sudo apt update
+            sudo apt install -y lld
+            export RUSTFLAGS="-C link-arg=-fuse-ld=lld"
+            export CFLAGS="${CFLAGS:-} -fPIC"
+            export CXXFLAGS="${CXXFLAGS:-} -fPIC"
+          fi
+          
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --profile minimal --default-toolchain 1.88.0 && \
             rustup --version && \
             rustc --version && \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,7 +105,8 @@ jobs:
           - wrappers
         pgrx_version:
           - 0.16.1
-        postgres: [14, 15, 16, 17, 18]
+        #postgres: [14, 15, 16, 17, 18]
+        postgres: [15]
         features:
           - "all_fdws"
         box:
@@ -169,7 +170,7 @@ jobs:
             export CFLAGS="${CFLAGS:-} -fPIC"
             export CXXFLAGS="${CXXFLAGS:-} -fPIC"
           fi
-          
+
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --profile minimal --default-toolchain 1.88.0 && \
             rustup --version && \
             rustc --version && \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,13 @@ name: Release
 
 
 on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Run build/package jobs without publishing crates.io or GitHub Release assets"
+        required: true
+        default: true
+        type: boolean
   push:
     # Sequence of patterns matched against refs/tags
     tags:
@@ -13,6 +20,7 @@ permissions:
 jobs:
   publish-to-crates-io:
     name: Publish to crates.io
+    if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     environment: release
     permissions:
@@ -76,6 +84,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Create Release
+        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
         id: create_release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -221,9 +230,11 @@ jobs:
           sudo dpkg-deb --build --root-owner-group ${package_dir}
 
       - name: Get upload url
+        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
         run: echo UPLOAD_URL=$(curl --silent https://api.github.com/repos/${{ github.repository }}/releases/latest | jq .upload_url --raw-output) >> $GITHUB_ENV
 
       - name: Upload release asset
+        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
         uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -232,3 +243,10 @@ jobs:
           asset_path: ./wrappers/${{ matrix.extension_name }}-${{ github.ref_name }}-pg${{ matrix.postgres }}-${{ matrix.box.arch }}-linux-gnu.deb
           asset_name: ${{ matrix.extension_name }}-${{ github.ref_name }}-pg${{ matrix.postgres }}-${{ matrix.box.arch }}-linux-gnu.deb
           asset_content_type: application/vnd.debian.binary-package
+
+      - name: Upload dry-run artifact
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.extension_name }}-${{ github.ref_name }}-pg${{ matrix.postgres }}-${{ matrix.box.arch }}-linux-gnu
+          path: ./wrappers/${{ matrix.extension_name }}-${{ github.ref_name }}-pg${{ matrix.postgres }}-${{ matrix.box.arch }}-linux-gnu.deb


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR makes the release workflow testable on non-tag branches by adding a manual trigger with a version input, that builds artifacts without publishing to crates.io or GitHub Releases.

## What is the current behavior?

The current release workflow is trigged by tagging which makes testing this workflow itself hard.

## What is the new behavior?

- Added one input `version` for manual triggering for this workflow
- Update the release workflow so `workflow_dispatch` runs are always treated as dry-runs without publishing to crates.io or GitHub Releases.

## Additional context

This PR also made a minor fix for the [linking issue on arm64 platform](https://github.com/supabase/wrappers/actions/runs/25477532780/job/74769620315) in release workflow, this fix replaced `ld` with `lld` as the default linker to avoid linking issue like below:

```
error: linking with `cc` failed
relocation truncated to fit: R_AARCH64_CALL26 against symbol `__aarch64_ldadd8_relax`
collect2: error: ld returned 1 exit status
error: could not compile `wrappers` (lib)
```
