### PR TITLE
chore(openapi): bump openapi_fdw version to 0.2.1 and update documentation

### DIFF
--- a/docs/catalog/openapi.md
+++ b/docs/catalog/openapi.md
@@ -18,6 +18,7 @@ This wrapper allows you to query any REST API endpoint as a PostgreSQL foreign t
 
 | Version | Wasm Package URL | Checksum | Required Wrappers Version |
 | ------- | ---------------- | -------- | ------------------------- |
+| 0.2.1 | `https://github.com/supabase/wrappers/releases/download/wasm_openapi_fdw_v0.2.1/openapi_fdw.wasm` | `tbd` | >=0.5.0 |
 | 0.2.0 | `https://github.com/supabase/wrappers/releases/download/wasm_openapi_fdw_v0.2.0/openapi_fdw.wasm` | `f0d4d6e50f7c519a66363bd8bdbe1ea8086ca810ca14b43fb0ed18b64acdf6aa` | >=0.5.0 |
 | 0.1.4 | `https://github.com/supabase/wrappers/releases/download/wasm_openapi_fdw_v0.1.4/openapi_fdw.wasm` | `dd434f8565b060b181d1e69e1e4d5c8b9c3ac5ca444056d3c2fb939038d308fe` | >=0.5.0 |
 

--- a/wasm-wrappers/fdw/Cargo.lock
+++ b/wasm-wrappers/fdw/Cargo.lock
@@ -227,7 +227,7 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "openapi_fdw"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/wasm-wrappers/fdw/openapi_fdw/Cargo.toml
+++ b/wasm-wrappers/fdw/openapi_fdw/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openapi_fdw"
-version = "0.2.0"
+version = "0.2.1"
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }

--- a/wasm-wrappers/fdw/openapi_fdw/wit/world.wit
+++ b/wasm-wrappers/fdw/openapi_fdw/wit/world.wit
@@ -1,4 +1,4 @@
-package supabase:openapi-fdw@0.2.0;
+package supabase:openapi-fdw@0.2.1;
 
 world openapi {
     import supabase:wrappers/http@0.2.0;


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to bump `openapi_fdw` version to 0.2.1 and update documentation.

## What is the current behavior?

The `openapi_fdw` current version is 0.2.0.

## What is the new behavior?

The `openapi_fdw` version will be 0.2.1, with the latest change #599 and #604.

## Additional context

N/A
