### PR TITLE
feat(wasm): per-request credentials from session variables

### DIFF
--- a/docs/catalog/openapi.md
+++ b/docs/catalog/openapi.md
@@ -105,6 +105,8 @@ We need to provide Postgres with the credentials to access the API and any addit
 | `api_key_location` | No | Where to send the API key: `header` (default), `query`, or `cookie`. |
 | `bearer_token` | No | Bearer token for authentication (alternative to `api_key`). |
 | `bearer_token_id` | No | Vault secret key ID storing the bearer token. |
+| `auth_token_setting` | No | Name of a Postgres session variable (GUC) to read the auth token from at request time, e.g. `app.api_token`. When set and non-empty it overrides any static credential for that request. See [Per-request credentials](#per-request-credentials-session-variables). |
+| `auth_token_prefix` | No | Prefix for the `auth_token_setting` value in the Authorization header (default: `Bearer`). Set to an empty string to send the raw token. |
 | `user_agent` | No | Custom User-Agent header value. |
 | `accept` | No | Custom Accept header for content negotiation (e.g., `application/geo+json`). |
 | `headers` | No | Custom headers as JSON object (e.g., `'{"X-Custom": "value"}'`). |
@@ -402,7 +404,7 @@ options (endpoint '/users');
 
 - **Read-only**: This FDW only supports SELECT operations. INSERT, UPDATE, and DELETE are not supported at this time.
 - **No transactions**: Each SQL statement results in immediate HTTP requests; there is no transactional grouping.
-- **Authentication**: Currently supports API Key and Bearer Token authentication. OAuth flows are not supported.
+- **Authentication**: Supports API Key and Bearer Token authentication, either static (server option or Vault) or resolved per request from a session variable (see [Per-request credentials](#per-request-credentials-session-variables)). The FDW does not run OAuth flows itself, but a session variable lets you supply a token your application already obtained.
 - **OpenAPI version**: Only OpenAPI 3.0+ specifications are supported (not Swagger 2.0).
 
 ## Automatic Retries
@@ -518,6 +520,37 @@ create server query_auth_api
     api_key_location 'query'  -- sends as ?api_key=sk-... (uses api_key_header as param name)
   );
 ```
+
+### Per-request credentials (session variables)
+
+A server's credential is normally fixed when the server is created. To vary it per request (for example, per-user OAuth tokens in a multi-tenant app) set `auth_token_setting` to the name of a Postgres session variable, then resolve that variable per query with a `SECURITY DEFINER` function:
+
+```sql
+create server per_user_api
+  foreign data wrapper wasm_wrapper
+  options (
+    fdw_package_url 'https://github.com/supabase/wrappers/releases/download/wasm_openapi_fdw_v0.2.0/openapi_fdw.wasm',
+    fdw_package_name 'supabase:openapi-fdw',
+    fdw_package_version '0.2.0',
+    fdw_package_checksum 'f0d4d6e50f7c519a66363bd8bdbe1ea8086ca810ca14b43fb0ed18b64acdf6aa',
+    base_url 'https://api.example.com',
+    auth_token_setting 'app.api_token'  -- read the token from this session variable each request
+  );
+
+-- Resolve the calling user's token (e.g. from an RLS-protected table keyed to
+-- auth.uid()) and pin it for the life of the transaction:
+create function set_api_token() returns void
+  language sql security definer set search_path = '' as $$
+  select set_config('app.api_token',
+    (select access_token from public.user_tokens where user_id = auth.uid()),
+    true);
+$$;
+
+select set_api_token();
+select * from some_foreign_table;
+```
+
+On each request the FDW reads `app.api_token` and sends it as `Authorization: Bearer <token>`. If the variable is unset or empty no token is injected, and any static credential on the server still applies. Use `auth_token_prefix` to change the `Bearer` prefix, or set it to an empty string to send the raw token.
 
 ### Response Path Extraction
 

--- a/docs/guides/wasm-advanced.md
+++ b/docs/guides/wasm-advanced.md
@@ -177,6 +177,36 @@ fn iter_scan(ctx: &Context, row: &Row) -> Result<Option<u32>, FdwError> {
 }
 ```
 
+## Host functions
+
+The host (the Wrappers Wasm runtime) exposes a small set of functions to the guest Wasm FDW through the `utils` interface.
+
+| Function | Description |
+| --- | --- |
+| `utils::report_info` / `report_notice` / `report_warning` / `report_error` | Emit a PostgreSQL log message (visible in `psql`), handy for debugging. |
+| `utils::cell_to_string(cell)` | Format a `Cell` value as a string. |
+| `utils::get_vault_secret(id)` / `get_vault_secret_by_name(name)` | Read a decrypted secret from [Vault](https://supabase.com/docs/guides/database/vault). Use for static credentials. |
+| `utils::query_setting(name)` | Read a PostgreSQL session setting (GUC) at request time. Returns `None` if unset. |
+
+### Reading session settings
+
+`utils::query_setting(name)` wraps `current_setting(name, true)`, so it returns the current value of a session GUC, or `None` when it isn't set. This is useful when an FDW needs a value that varies per request, per user, or per transaction rather than a static server option.
+
+```rust
+// inside your FDW, read a value set earlier in the same transaction
+if let Some(token) = utils::query_setting("app.api_token") {
+    // use the token for this request
+}
+```
+
+The value is supplied from SQL with `set_config`, typically from a `SECURITY DEFINER` function that resolves it for the calling user and scopes it to the transaction:
+
+```sql
+select set_config('app.api_token', '<resolved-token>', true);  -- true = transaction-local
+```
+
+For example, the OpenAPI FDW's [`auth_token_setting`](../catalog/openapi.md#server-options) option reads a named session setting per request and uses it as the Authorization token.
+
 ## Developing locally
 
 We'll use the CLI to develop locally. This will be faster than the GitHub release workflow.

--- a/supabase-wrappers/src/utils.rs
+++ b/supabase-wrappers/src/utils.rs
@@ -392,14 +392,18 @@ pub fn get_vault_secret(secret_id_or_name: &str) -> Option<String> {
 ///
 /// Calls `current_setting(name, true)` — returns `None` if the setting is absent
 /// rather than raising an error. Useful for injecting per-transaction credentials
-/// (e.g., via `set_config`) without requiring a fallback value.
+/// (e.g., via `set_config`) without requiring a fallback value. An unexpected SPI
+/// error is reported and surfaced as `None` rather than silently swallowed.
 pub fn query_setting(name: &str) -> Option<String> {
-    match Spi::get_one_with_args::<String>(
-        "SELECT current_setting($1, true)",
-        &[name.into()],
-    ) {
+    match Spi::get_one_with_args::<String>("SELECT current_setting($1, true)", &[name.into()]) {
         Ok(value) => value,
-        Err(_) => None,
+        Err(err) => {
+            report_error(
+                PgSqlErrorCode::ERRCODE_FDW_ERROR,
+                &format!("read session setting \"{name}\" failed: {err}"),
+            );
+            None
+        }
     }
 }
 

--- a/supabase-wrappers/src/utils.rs
+++ b/supabase-wrappers/src/utils.rs
@@ -388,6 +388,21 @@ pub fn get_vault_secret(secret_id_or_name: &str) -> Option<String> {
     }
 }
 
+/// Read a PostgreSQL session configuration parameter by name.
+///
+/// Calls `current_setting(name, true)` — returns `None` if the setting is absent
+/// rather than raising an error. Useful for injecting per-transaction credentials
+/// (e.g., via `set_config`) without requiring a fallback value.
+pub fn query_setting(name: &str) -> Option<String> {
+    match Spi::get_one_with_args::<String>(
+        "SELECT current_setting($1, true)",
+        &[name.into()],
+    ) {
+        Ok(value) => value,
+        Err(_) => None,
+    }
+}
+
 /// Get decrypted secret from Vault by secret name
 ///
 /// Get decrypted secret as string from Vault by secret name. Vault is an extension for storing

--- a/wasm-wrappers/fdw/openapi_fdw/README.md
+++ b/wasm-wrappers/fdw/openapi_fdw/README.md
@@ -17,14 +17,14 @@ Point it at an OpenAPI spec and query the API with SQL. The FDW parses the spec 
 - **Rate-limit handling** — Retries automatically with exponential backoff on HTTP 429 responses
 - **Type coercion** — Maps JSON types to PostgreSQL types (`text`, `integer`, `boolean`, `timestamptz`, `jsonb`, etc.)
 - **camelCase matching** — Matches API field names like `stationIdentifier` to snake_case columns like `station_identifier`
-- **Auth support** — API key (header, query param, or cookie) and Bearer token authentication, with Supabase Vault integration
+- **Auth support** — API key (header, query param, or cookie) and Bearer token authentication, with Supabase Vault integration or per-request tokens from a session variable (`auth_token_setting`)
 - **Debug mode** — Set `debug 'true'` on the server to log HTTP request/response details as PostgreSQL INFO messages
 
 ## Limitations
 
 - Read-only (no INSERT/UPDATE/DELETE)
 - POST-for-read available via `method` table option, but only GET endpoints are auto-imported
-- Auth: API key and Bearer token only (no OAuth2 flows — use pre-obtained tokens)
+- Auth: API key and Bearer token, static or resolved per request from a session variable (no OAuth2 flows — supply pre-obtained tokens)
 - OpenAPI 3.x only (Swagger 2.0 is rejected)
 
 ## Documentation

--- a/wasm-wrappers/fdw/openapi_fdw/src/config.rs
+++ b/wasm-wrappers/fdw/openapi_fdw/src/config.rs
@@ -220,8 +220,15 @@ impl ServerConfig {
             );
         }
 
-        self.auth_token_setting = opts.get("auth_token_setting");
-        self.auth_token_prefix = opts.require_or("auth_token_prefix", "Bearer");
+        // Treat an empty/whitespace-only setting name as unset, so the request
+        // path doesn't fire a pointless current_setting('') lookup per request.
+        self.auth_token_setting = opts
+            .get("auth_token_setting")
+            .filter(|s| !s.trim().is_empty());
+        self.auth_token_prefix = opts
+            .require_or("auth_token_prefix", "Bearer")
+            .trim()
+            .to_owned();
 
         Ok(())
     }
@@ -310,7 +317,13 @@ impl ServerConfig {
         } else {
             format!("{prefix} {token}")
         };
-        if let Some(h) = headers.iter_mut().find(|h| h.0 == "authorization") {
+        // HTTP header names are case-insensitive: match any existing
+        // authorization header regardless of casing so we replace rather than
+        // append a duplicate (e.g. a static "Authorization" from the headers option).
+        if let Some(h) = headers
+            .iter_mut()
+            .find(|h| h.0.eq_ignore_ascii_case("authorization"))
+        {
             h.1 = value;
         } else {
             headers.push(("authorization".to_owned(), value));

--- a/wasm-wrappers/fdw/openapi_fdw/src/config.rs
+++ b/wasm-wrappers/fdw/openapi_fdw/src/config.rs
@@ -30,6 +30,10 @@ pub(crate) struct ServerConfig {
     pub(crate) max_response_bytes: usize,
     pub(crate) debug: bool,
 
+    // Dynamic auth: Postgres session variable that overrides static auth at request time
+    pub(crate) auth_token_setting: Option<String>,
+    pub(crate) auth_token_prefix: String,
+
     // Server-level defaults (saved after init, restored in begin_scan)
     pub(crate) default_page_size: usize,
     pub(crate) default_page_size_param: String,
@@ -65,6 +69,7 @@ impl std::fmt::Debug for ServerConfig {
             .field("max_pages", &self.max_pages)
             .field("max_response_bytes", &self.max_response_bytes)
             .field("debug", &self.debug)
+            .field("auth_token_setting", &self.auth_token_setting)
             .finish()
     }
 }
@@ -84,6 +89,8 @@ impl Default for ServerConfig {
             max_pages: DEFAULT_MAX_PAGES,
             max_response_bytes: DEFAULT_MAX_RESPONSE_BYTES,
             debug: false,
+            auth_token_setting: None,
+            auth_token_prefix: String::new(),
             default_page_size: 0,
             default_page_size_param: String::new(),
             default_cursor_param: String::new(),
@@ -213,6 +220,9 @@ impl ServerConfig {
             );
         }
 
+        self.auth_token_setting = opts.get("auth_token_setting");
+        self.auth_token_prefix = opts.require_or("auth_token_prefix", "Bearer");
+
         Ok(())
     }
 
@@ -279,6 +289,32 @@ impl ServerConfig {
         }
 
         Ok(())
+    }
+
+    /// Apply a dynamically resolved token to a request headers list.
+    ///
+    /// Replaces an existing `authorization` header if present, otherwise appends one.
+    /// No-ops if `token` is empty or whitespace-only.
+    ///
+    /// Separated from the WASM-dependent `make_request` call path for testability.
+    pub(crate) fn apply_session_token(
+        headers: &mut Vec<(String, String)>,
+        token: &str,
+        prefix: &str,
+    ) {
+        if token.trim().is_empty() {
+            return;
+        }
+        let value = if prefix.is_empty() {
+            token.to_owned()
+        } else {
+            format!("{prefix} {token}")
+        };
+        if let Some(h) = headers.iter_mut().find(|h| h.0 == "authorization") {
+            h.1 = value;
+        } else {
+            headers.push(("authorization".to_owned(), value));
+        }
     }
 }
 

--- a/wasm-wrappers/fdw/openapi_fdw/src/config_tests.rs
+++ b/wasm-wrappers/fdw/openapi_fdw/src/config_tests.rs
@@ -9,10 +9,10 @@ fn test_session_token_default_none() {
 }
 
 #[test]
-fn test_session_token_prefix_default_bearer() {
+fn test_session_token_prefix_default_empty() {
     let config = ServerConfig::default();
-    // Default is empty string; configure_auth sets "Bearer" when the server option
-    // is absent. Direct Default::default() gives empty string.
+    // Struct Default gives an empty prefix; configure_auth applies the real
+    // "Bearer" default when the server option is absent.
     assert_eq!(config.auth_token_prefix, "");
 }
 
@@ -45,6 +45,16 @@ fn test_apply_session_token_replaces_existing_authorization() {
     let mut headers = vec![("authorization".to_owned(), "Bearer old-token".to_owned())];
     ServerConfig::apply_session_token(&mut headers, "new-token", "Bearer");
     // Should replace, not append
+    assert_eq!(headers.len(), 1);
+    assert_eq!(headers[0].1, "Bearer new-token");
+}
+
+#[test]
+fn test_apply_session_token_replaces_existing_authorization_case_insensitive() {
+    // Existing header uses capital "Authorization" (e.g. from the headers option).
+    // Header names are case-insensitive, so it should be replaced, not duplicated.
+    let mut headers = vec![("Authorization".to_owned(), "Bearer old-token".to_owned())];
+    ServerConfig::apply_session_token(&mut headers, "new-token", "Bearer");
     assert_eq!(headers.len(), 1);
     assert_eq!(headers[0].1, "Bearer new-token");
 }

--- a/wasm-wrappers/fdw/openapi_fdw/src/config_tests.rs
+++ b/wasm-wrappers/fdw/openapi_fdw/src/config_tests.rs
@@ -1,5 +1,143 @@
 use super::{DEFAULT_MAX_PAGES, DEFAULT_MAX_RESPONSE_BYTES, ServerConfig};
 
+// --- apply_session_token ---
+
+#[test]
+fn test_session_token_default_none() {
+    let config = ServerConfig::default();
+    assert!(config.auth_token_setting.is_none());
+}
+
+#[test]
+fn test_session_token_prefix_default_bearer() {
+    let config = ServerConfig::default();
+    // Default is empty string; configure_auth sets "Bearer" when the server option
+    // is absent. Direct Default::default() gives empty string.
+    assert_eq!(config.auth_token_prefix, "");
+}
+
+#[test]
+fn test_apply_session_token_adds_bearer_header() {
+    let mut headers = vec![];
+    ServerConfig::apply_session_token(&mut headers, "tok_abc123", "Bearer");
+    assert_eq!(headers.len(), 1);
+    assert_eq!(headers[0].0, "authorization");
+    assert_eq!(headers[0].1, "Bearer tok_abc123");
+}
+
+#[test]
+fn test_apply_session_token_custom_prefix() {
+    let mut headers = vec![];
+    ServerConfig::apply_session_token(&mut headers, "tok_xyz", "Token");
+    assert_eq!(headers[0].1, "Token tok_xyz");
+}
+
+#[test]
+fn test_apply_session_token_empty_prefix_no_prefix() {
+    // Empty prefix → raw token value, no leading space
+    let mut headers = vec![];
+    ServerConfig::apply_session_token(&mut headers, "rawtoken", "");
+    assert_eq!(headers[0].1, "rawtoken");
+}
+
+#[test]
+fn test_apply_session_token_replaces_existing_authorization() {
+    let mut headers = vec![("authorization".to_owned(), "Bearer old-token".to_owned())];
+    ServerConfig::apply_session_token(&mut headers, "new-token", "Bearer");
+    // Should replace, not append
+    assert_eq!(headers.len(), 1);
+    assert_eq!(headers[0].1, "Bearer new-token");
+}
+
+#[test]
+fn test_apply_session_token_replaces_leaves_other_headers_intact() {
+    let mut headers = vec![
+        ("content-type".to_owned(), "application/json".to_owned()),
+        ("authorization".to_owned(), "Bearer old".to_owned()),
+        ("x-request-id".to_owned(), "req-123".to_owned()),
+    ];
+    ServerConfig::apply_session_token(&mut headers, "new", "Bearer");
+    assert_eq!(headers.len(), 3);
+    assert_eq!(headers[0].0, "content-type");
+    assert_eq!(headers[1].1, "Bearer new");
+    assert_eq!(headers[2].0, "x-request-id");
+}
+
+#[test]
+fn test_apply_session_token_appends_when_no_existing_authorization() {
+    let mut headers = vec![
+        ("content-type".to_owned(), "application/json".to_owned()),
+        ("user-agent".to_owned(), "Wrappers/1.0".to_owned()),
+    ];
+    ServerConfig::apply_session_token(&mut headers, "tok", "Bearer");
+    assert_eq!(headers.len(), 3);
+    assert_eq!(headers[2].0, "authorization");
+    assert_eq!(headers[2].1, "Bearer tok");
+}
+
+#[test]
+fn test_apply_session_token_empty_token_noop() {
+    let mut headers = vec![("authorization".to_owned(), "Bearer original".to_owned())];
+    ServerConfig::apply_session_token(&mut headers, "", "Bearer");
+    // Empty token → no change
+    assert_eq!(headers[0].1, "Bearer original");
+}
+
+#[test]
+fn test_apply_session_token_whitespace_token_noop() {
+    let mut headers = vec![("authorization".to_owned(), "Bearer original".to_owned())];
+    ServerConfig::apply_session_token(&mut headers, "   ", "Bearer");
+    assert_eq!(headers[0].1, "Bearer original");
+}
+
+#[test]
+fn test_apply_session_token_empty_token_does_not_append() {
+    let mut headers = vec![];
+    ServerConfig::apply_session_token(&mut headers, "", "Bearer");
+    assert!(headers.is_empty());
+}
+
+#[test]
+fn test_apply_session_token_overrides_static_bearer() {
+    // Simulate: static bearer_token set at init, session token injected at request time
+    let mut headers = vec![
+        ("content-type".to_owned(), "application/json".to_owned()),
+        ("authorization".to_owned(), "Bearer static-token".to_owned()),
+    ];
+    ServerConfig::apply_session_token(&mut headers, "per-user-token", "Bearer");
+    let auth = headers.iter().find(|h| h.0 == "authorization").unwrap();
+    assert_eq!(auth.1, "Bearer per-user-token");
+    // Static token not leaked
+    assert!(!auth.1.contains("static-token"));
+}
+
+#[test]
+fn test_apply_session_token_second_call_replaces_first() {
+    let mut headers = vec![];
+    ServerConfig::apply_session_token(&mut headers, "first", "Bearer");
+    ServerConfig::apply_session_token(&mut headers, "second", "Bearer");
+    assert_eq!(headers.len(), 1);
+    assert_eq!(headers[0].1, "Bearer second");
+}
+
+#[test]
+fn test_debug_shows_auth_token_setting_name() {
+    let config = ServerConfig {
+        auth_token_setting: Some("app.user_token".to_string()),
+        ..Default::default()
+    };
+    let debug_output = format!("{config:?}");
+    // Setting name is not sensitive — it should appear in debug output
+    assert!(debug_output.contains("app.user_token"));
+}
+
+#[test]
+fn test_debug_no_auth_token_setting_shows_none() {
+    let config = ServerConfig::default();
+    let debug_output = format!("{config:?}");
+    assert!(debug_output.contains("auth_token_setting: None"));
+}
+
 // --- Default values ---
 
 #[test]

--- a/wasm-wrappers/fdw/openapi_fdw/src/request.rs
+++ b/wasm-wrappers/fdw/openapi_fdw/src/request.rs
@@ -9,6 +9,7 @@ use crate::bindings::supabase::wrappers::{
     types::{Cell, Context, FdwError, FdwResult, Qual, Value},
     utils,
 };
+use crate::config::ServerConfig;
 use crate::spec::OpenApiSpec;
 use crate::{FDW_NAME, OpenApiFdw};
 
@@ -435,10 +436,21 @@ impl OpenApiFdw {
     pub(crate) fn make_request(&mut self, ctx: &Context) -> FdwResult {
         let url = self.build_url(ctx)?;
 
+        let mut headers = self.config.headers.clone();
+        if let Some(ref setting_name) = self.config.auth_token_setting {
+            if let Some(token) = utils::query_setting(setting_name) {
+                ServerConfig::apply_session_token(
+                    &mut headers,
+                    &token,
+                    &self.config.auth_token_prefix,
+                );
+            }
+        }
+
         let req = http::Request {
             method: self.method,
             url,
-            headers: self.config.headers.clone(),
+            headers,
             body: self.request_body.clone(),
         };
 

--- a/wasm-wrappers/wit/v1/utils.wit
+++ b/wasm-wrappers/wit/v1/utils.wit
@@ -9,4 +9,5 @@ interface utils {
     cell-to-string: func(cell: option<cell>) -> string;
     get-vault-secret: func(secret-id: string) -> option<string>;
     get-vault-secret-by-name: func(secret-name: string) -> option<string>;
+    query-setting: func(name: string) -> option<string>;
 }

--- a/wasm-wrappers/wit/v2/utils.wit
+++ b/wasm-wrappers/wit/v2/utils.wit
@@ -9,4 +9,5 @@ interface utils {
     cell-to-string: func(cell: option<cell>) -> string;
     get-vault-secret: func(secret-id: string) -> option<string>;
     get-vault-secret-by-name: func(secret-name: string) -> option<string>;
+    query-setting: func(name: string) -> option<string>;
 }

--- a/wrappers/dockerfiles/wasm/server.py
+++ b/wrappers/dockerfiles/wasm/server.py
@@ -377,8 +377,14 @@ class MockServer(BaseHTTPRequestHandler):
         elif fdw == "openapi":
             # Generic OpenAPI FDW test endpoints covering all features
 
+            # Auth reflection: echo the received Authorization header back in the
+            # response body, so the session-token injection test can assert on it.
+            if req_path == "/whoami" or req_path.startswith("/whoami?"):
+                body = json.dumps(
+                    {"data": [{"received_auth": self.headers.get("Authorization", "")}]}
+                )
             # Pattern 1: Simple list endpoint
-            if req_path == "/users" or req_path.startswith("/users?"):
+            elif req_path == "/users" or req_path.startswith("/users?"):
                 body = """
 {
   "data": [

--- a/wrappers/src/fdw/wasm_fdw/host/utils.rs
+++ b/wrappers/src/fdw/wasm_fdw/host/utils.rs
@@ -40,6 +40,10 @@ const _: () = {
         fn get_vault_secret_by_name(&mut self, secret_name: String) -> Option<String> {
             get_vault_secret_by_name(&secret_name)
         }
+
+        fn query_setting(&mut self, name: String) -> Option<String> {
+            query_setting(&name)
+        }
     }
 };
 
@@ -78,6 +82,10 @@ const _: () = {
 
         fn get_vault_secret_by_name(&mut self, secret_name: String) -> Option<String> {
             get_vault_secret_by_name(&secret_name)
+        }
+
+        fn query_setting(&mut self, name: String) -> Option<String> {
+            query_setting(&name)
         }
     }
 };

--- a/wrappers/src/fdw/wasm_fdw/tests.rs
+++ b/wrappers/src/fdw/wasm_fdw/tests.rs
@@ -764,4 +764,77 @@ mod tests {
             );
         });
     }
+
+    // Exercises the OpenAPI FDW `auth_token_setting` option end-to-end: the FDW
+    // resolves a Postgres session GUC via the `query-setting` host function and
+    // injects it as the `Authorization` header on each request. The mock server
+    // reflects the received header back so we can assert on it.
+    #[pg_test]
+    fn openapi_session_token_injection() {
+        Spi::connect_mut(|c| {
+            c.update(
+                r#"CREATE FOREIGN DATA WRAPPER wasm_wrapper
+                     HANDLER wasm_fdw_handler VALIDATOR wasm_fdw_validator"#,
+                None,
+                &[],
+            )
+            .unwrap();
+
+            c.update(
+                r#"CREATE SERVER openapi_auth_server
+                     FOREIGN DATA WRAPPER wasm_wrapper
+                     OPTIONS (
+                       fdw_package_url 'file://../../../wasm-wrappers/fdw/target/wasm32-unknown-unknown/release/openapi_fdw.wasm',
+                       fdw_package_name 'supabase:openapi-fdw',
+                       fdw_package_version '>=0.1.0',
+                       base_url 'http://localhost:8096/openapi',
+                       auth_token_setting 'app.test_token',
+                       auth_token_prefix 'Bearer'
+                     )"#,
+                None,
+                &[],
+            )
+            .unwrap();
+
+            c.update(
+                r#"
+                  CREATE FOREIGN TABLE openapi_whoami (
+                    received_auth text
+                  )
+                  SERVER openapi_auth_server
+                  OPTIONS (
+                    endpoint '/whoami',
+                    response_path '/data'
+                  )
+             "#,
+                None,
+                &[],
+            )
+            .unwrap();
+
+            // Negative: with the GUC unset, query-setting resolves to NULL and no
+            // Authorization header is injected, so the mock reflects an empty string.
+            let unset = c
+                .select("SELECT received_auth FROM openapi_whoami", None, &[])
+                .unwrap()
+                .filter_map(|r| r.get_by_name::<&str, _>("received_auth").unwrap())
+                .collect::<Vec<_>>();
+            assert_eq!(unset, vec![""]);
+
+            // Inject a per-session token, then confirm it reaches the API prefixed.
+            c.update(
+                "SELECT set_config('app.test_token', 'sess-secret-123', false)",
+                None,
+                &[],
+            )
+            .unwrap();
+
+            let injected = c
+                .select("SELECT received_auth FROM openapi_whoami", None, &[])
+                .unwrap()
+                .filter_map(|r| r.get_by_name::<&str, _>("received_auth").unwrap())
+                .collect::<Vec<_>>();
+            assert_eq!(injected, vec!["Bearer sess-secret-123"]);
+        });
+    }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature. Adds a generic host function for reading a Postgres session variable at request time, plus an OpenAPI FDW option that uses it as the auth credential.

My use case is per-user access in a multi-tenant app. Each user has their own upstream token to a third-party system (OAuth access tokens, per-user API keys) and with Supabase Auth those tokens live in a per-user, RLS-protected table keyed to `auth.uid()`. My approach is a `SECURITY DEFINER` function that reads the calling user's token and pins it for the life of the query. This lines up with how Supabase already threads per-user context into Postgres. The `auth.uid()` comes from a session GUC (`request.jwt.claims`) so resolving a credential from a session variable is the same shape and not a new concept.

```sql
-- Tokens live in a per-user, RLS-protected table keyed to auth.uid()
-- SECURITY DEFINER reads the caller's token and pins it for the life of the query
create function set_api_token() returns void
  language sql security definer set search_path = '' as $$
  select set_config('app.api_token',
    (select access_token
       from public.user_integrations
      where user_id = auth.uid()),
    true);
$$;

-- per request:
select set_api_token();
select * from some_foreign_table;
```

## What is the current behavior?

A wasm FDW can only authenticate with a static credential that's fixed when the server is created, either inline in the server options or a Vault secret looked up by id/name. There's no way to hand it a credential that changes per request, per user, or per transaction.

## What is the new behavior?

With this PR, stored Supabase Auth credentials can be resolved from a Postgres session variable on each request, so it can match per user/request/transaction. Implemented with two main pieces that are purely additive and backward compatible so an absent or empty setting is a no-op and any static credential configured at the server level still applies.

1. `query-setting(name)` added to the utils WIT interface (v1 + v2), backed by `current_setting(name, true)` via SPI. Returns None when the setting is unset.
2. `auth_token_setting` / `auth_token_prefix` server options on the OpenAPI FDW. When `auth_token_setting` is set, the FDW reads that session variable per request and uses it as the Authorization token.

### Design note

As shipped, the query-setting function could read any Postgres session setting, not just an auth token, but the auth option is the only setting being read. I could have made it smaller and more focused as auth-only, but I went general because it's a simple tool other FDWs could reuse and other session settings aren't typically sensitive. Could be tightened to read auth only if preferred.

## Additional context

### Alternatives considered

| Approach | Notes |
|---|---|
| Static server option / Vault secret (today) | Vault resolves the secret once, not per query against session state, so it can't vary per user. |
| Token as a query qual (hidden column or `WHERE token = ...`), handled entirely in the guest | Doesn't need an interface change, but the token ends up in the SQL statement text and can leak into pg_stat_statements, logs, and EXPLAIN. Non-starter for a live credential. |
| Set per-user Vault secrets and have FDW pick the right one by name | Doesn't avoid the problem. FDW can't tell which user is calling (no auth.uid() inside the sandbox) without a per-query signal and it's a lot of secrets to create and rotate. |
| Session-GUC host function (what I built) | Optional additive change to utils WIT interface, no-ops when the setting isn't there (static creds untouched), keeps the secret out of the query text since it's a set_config session var and is generic enough (hopefully) that any other wasm FDW could use it. |

### Testing

- Unit tests for `apply_session_token` covering the edge cases (empty/whitespace no-op, custom prefix, replacing vs appending the header, overriding a static credential).
- A pg_test (`openapi_session_token_injection`) that runs the full path against the mock server: with the GUC unset no Authorization header is sent, and after set_config the token arrives prefixed.