### PR TITLE
feat(mongodb): [WRA-22] add MongoDB foreign data wrapper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -1875,6 +1875,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2255,6 +2266,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "cranelift-assembler-x64"
 version = "0.123.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2437,6 +2457,12 @@ checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam"
@@ -2630,6 +2656,12 @@ dependencies = [
  "quote",
  "syn 2.0.108",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "deadpool"
@@ -3468,9 +3500,23 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -3660,6 +3706,76 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hickory-net"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "hickory-proto",
+ "idna",
+ "ipnet",
+ "jni",
+ "rand 0.10.1",
+ "thiserror 2.0.17",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-proto"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
+dependencies = [
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni",
+ "once_cell",
+ "prefix-trie",
+ "rand 0.10.1",
+ "ring",
+ "thiserror 2.0.17",
+ "tinyvec",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-net",
+ "hickory-proto",
+ "ipconfig",
+ "ipnet",
+ "jni",
+ "moka",
+ "ndk-context",
+ "once_cell",
+ "parking_lot 0.12.5",
+ "rand 0.10.1",
+ "resolv-conf",
+ "smallvec",
+ "system-configuration 0.7.0",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+]
 
 [[package]]
 name = "hkdf"
@@ -3958,7 +4074,7 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry",
+ "windows-registry 0.5.3",
 ]
 
 [[package]]
@@ -4278,10 +4394,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipconfig"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
+dependencies = [
+ "socket2 0.6.1",
+ "widestring",
+ "windows-registry 0.6.1",
+ "windows-result 0.4.1",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+dependencies = [
+ "serde 1.0.228",
+]
 
 [[package]]
 name = "iri-string"
@@ -4386,6 +4518,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
 dependencies = [
  "jiff-tzdb",
+]
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.17",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.108",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -5010,6 +5191,9 @@ dependencies = [
  "futures-io",
  "futures-util",
  "hex",
+ "hickory-net",
+ "hickory-proto",
+ "hickory-resolver",
  "hmac",
  "macro_magic",
  "md-5",
@@ -5155,6 +5339,12 @@ dependencies = [
  "security-framework-sys",
  "tempfile",
 ]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "nix"
@@ -5358,6 +5548,10 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "once_cell_polyfill"
@@ -6148,6 +6342,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "prefix-trie"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
+dependencies = [
+ "either",
+ "ipnet",
+ "num-traits 0.2.19",
+]
+
+[[package]]
 name = "pretty-hex"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6570,6 +6775,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6607,6 +6818,17 @@ checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -6665,6 +6887,12 @@ checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_hc"
@@ -6978,6 +7206,12 @@ dependencies = [
  "tracing",
  "wasm-timer",
 ]
+
+[[package]]
+name = "resolv-conf"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "retain_mut"
@@ -7691,7 +7925,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -7708,7 +7942,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -7771,6 +8005,16 @@ name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
 
 [[package]]
 name = "simdutf8"
@@ -8066,6 +8310,17 @@ name = "system-configuration"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags 2.10.0",
+ "core-foundation 0.9.4",
+ "system-configuration-sys 0.6.0",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
  "bitflags 2.10.0",
  "core-foundation 0.9.4",
@@ -9050,7 +9305,16 @@ version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.46.0",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -9178,6 +9442,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.244.0",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.12.0",
+ "wasm-encoder 0.244.0",
+ "wasmparser 0.244.0",
+]
+
+[[package]]
 name = "wasm-streams"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9236,6 +9522,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b722dcf61e0ea47440b53ff83ccb5df8efec57a69d150e4f24882e4eba7e24a4"
 dependencies = [
  "bitflags 2.10.0",
+ "indexmap 2.12.0",
+ "semver",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.10.0",
+ "hashbrown 0.15.5",
  "indexmap 2.12.0",
  "semver",
 ]
@@ -9353,7 +9651,7 @@ dependencies = [
  "syn 2.0.108",
  "wasmtime-internal-component-util",
  "wasmtime-internal-wit-bindgen",
- "wit-parser",
+ "wit-parser 0.236.1",
 ]
 
 [[package]]
@@ -9493,7 +9791,7 @@ dependencies = [
  "bitflags 2.10.0",
  "heck 0.5.0",
  "indexmap 2.12.0",
- "wit-parser",
+ "wit-parser 0.236.1",
 ]
 
 [[package]]
@@ -9566,6 +9864,12 @@ dependencies = [
  "wasite",
  "web-sys",
 ]
+
+[[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "winapi"
@@ -9731,6 +10035,17 @@ dependencies = [
  "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -10066,6 +10381,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "wit-parser 0.244.0",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "indexmap 2.12.0",
+ "prettyplease",
+ "syn 2.0.108",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.10.0",
+ "indexmap 2.12.0",
+ "log",
+ "serde 1.0.228",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder 0.244.0",
+ "wasm-metadata",
+ "wasmparser 0.244.0",
+ "wit-parser 0.244.0",
+]
+
+[[package]]
 name = "wit-parser"
 version = "0.236.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10081,6 +10466,24 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser 0.236.1",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.12.0",
+ "log",
+ "semver",
+ "serde 1.0.228",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.244.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,6 +1663,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "bson"
+version = "2.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969a9ba84b0ff843813e7249eed1678d9b6607ce5a3b8f0a47af3fcf7978e6e"
+dependencies = [
+ "ahash 0.8.12",
+ "base64 0.22.1",
+ "bitvec",
+ "chrono",
+ "getrandom 0.2.16",
+ "getrandom 0.3.4",
+ "hex",
+ "indexmap 2.12.0",
+ "js-sys",
+ "once_cell",
+ "rand 0.9.2",
+ "serde 1.0.228",
+ "serde_bytes",
+ "serde_json",
+ "time",
+ "uuid",
+]
+
+[[package]]
 name = "btoi"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2187,6 +2211,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2660,6 +2693,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive-syn-parse"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d65d7ce8132b7c0e54497a4d9a55a1c2a0912a0d786cf894472ba818fba45762"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
+]
+
+[[package]]
+name = "derive-where"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d08b3a0bcc0d079199cd476b2cae8435016ec11d1c0986c6901c5ac223041534"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
+]
+
+[[package]]
 name = "derive_builder"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2688,6 +2743,29 @@ checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
  "syn 2.0.108",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case 0.10.0",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.108",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -3957,7 +4035,7 @@ dependencies = [
  "serde_with",
  "strum 0.27.2",
  "tokio",
- "typed-builder",
+ "typed-builder 0.20.1",
  "url",
  "uuid",
  "zstd",
@@ -3980,7 +4058,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
- "typed-builder",
+ "typed-builder 0.20.1",
  "uuid",
 ]
 
@@ -4711,6 +4789,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "macro_magic"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc33f9f0351468d26fbc53d9ce00a096c8522ecb42f19b50f34f2c422f76d21d"
+dependencies = [
+ "macro_magic_core",
+ "macro_magic_macros",
+ "quote",
+ "syn 2.0.108",
+]
+
+[[package]]
+name = "macro_magic_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1687dc887e42f352865a393acae7cf79d98fab6351cde1f58e9e057da89bf150"
+dependencies = [
+ "const-random",
+ "derive-syn-parse",
+ "macro_magic_core_macros",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
+]
+
+[[package]]
+name = "macro_magic_core_macros"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b02abfe41815b5bd98dbd4260173db2c116dda171dc0fe7838cb206333b83308"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
+]
+
+[[package]]
+name = "macro_magic_macros"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ea28ee64b88876bf45277ed9a5817c1817df061a74f2b988971a12570e5869"
+dependencies = [
+ "macro_magic_core",
+ "quote",
+ "syn 2.0.108",
+]
+
+[[package]]
 name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4849,6 +4975,79 @@ dependencies = [
  "smallvec",
  "tagptr",
  "uuid",
+]
+
+[[package]]
+name = "mongocrypt"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da0cd419a51a5fb44819e290fbdb0665a54f21dead8923446a799c7f4d26ad9"
+dependencies = [
+ "bson",
+ "mongocrypt-sys",
+ "once_cell",
+ "serde 1.0.228",
+]
+
+[[package]]
+name = "mongocrypt-sys"
+version = "0.1.5+1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224484c5d09285a7b8cb0a0c117e847ebd14cb6e4470ecf68cdb89c503b0edb9"
+
+[[package]]
+name = "mongodb"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "276ba0cd571553d1f6936c6f180964776ece6ab7507dc8765f8a9c9c49d8cd00"
+dependencies = [
+ "base64 0.22.1",
+ "bitflags 2.10.0",
+ "bson",
+ "derive-where",
+ "derive_more",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "hex",
+ "hmac",
+ "macro_magic",
+ "md-5",
+ "mongocrypt",
+ "mongodb-internal-macros",
+ "pbkdf2",
+ "percent-encoding",
+ "rand 0.9.2",
+ "rustc_version_runtime",
+ "rustls 0.23.37",
+ "serde 1.0.228",
+ "serde_bytes",
+ "serde_with",
+ "sha1",
+ "sha2",
+ "socket2 0.6.1",
+ "stringprep",
+ "strsim",
+ "take_mut",
+ "thiserror 2.0.17",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tokio-util",
+ "typed-builder 0.22.0",
+ "uuid",
+ "webpki-roots 1.0.3",
+]
+
+[[package]]
+name = "mongodb-internal-macros"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99ceb1a9a1018e470077ec94cf3a8c2d0e6da542b2c05ea95a59a0a627147375"
+dependencies = [
+ "macro_magic",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -5492,6 +5691,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5640,7 +5848,7 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07a767cb9faa612f1ba7f13718136d4006950d6f253b414ef487a03e85c47a94"
 dependencies = [
- "convert_case",
+ "convert_case 0.8.0",
  "eyre",
  "petgraph 0.8.3",
  "proc-macro2",
@@ -6931,6 +7139,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version_runtime"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dd18cd2bae1820af0b6ad5e54f4a51d0f3fcc53b05f845675074efcc7af071d"
+dependencies = [
+ "rustc_version",
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.37.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7371,6 +7589,7 @@ version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
+ "indexmap 2.12.0",
  "itoa",
  "memchr",
  "ryu",
@@ -7878,6 +8097,12 @@ name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
+
+[[package]]
+name = "take_mut"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
 
 [[package]]
 name = "tap"
@@ -8434,7 +8659,16 @@ version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd9d30e3a08026c78f246b173243cf07b3696d274debd26680773b6773c2afc7"
 dependencies = [
- "typed-builder-macro",
+ "typed-builder-macro 0.20.1",
+]
+
+[[package]]
+name = "typed-builder"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "398a3a3c918c96de527dc11e6e846cd549d4508030b8a33e1da12789c856b81a"
+dependencies = [
+ "typed-builder-macro 0.22.0",
 ]
 
 [[package]]
@@ -8442,6 +8676,17 @@ name = "typed-builder-macro"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c36781cc0e46a83726d9879608e4cf6c2505237e263a8eb8c24502989cfdb28"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
+]
+
+[[package]]
+name = "typed-builder-macro"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e48cea23f68d1f78eb7bc092881b6bb88d3d6b5b7e6234f6f9c911da1ffb221"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9857,6 +10102,7 @@ dependencies = [
  "aws-sdk-s3vectors",
  "aws-smithy-async",
  "aws-smithy-types",
+ "bson",
  "bytes",
  "chrono",
  "chrono-tz 0.6.3",
@@ -9875,6 +10121,7 @@ dependencies = [
  "iceberg-catalog-rest",
  "iceberg-catalog-s3tables",
  "jwt-simple",
+ "mongodb",
  "mysql_async",
  "num-traits 0.2.19",
  "parquet",

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 | [HubSpot](./wasm-wrappers/fdw/hubspot_fdw)      | A Wasm FDW for [HubSpot](https://www.hubspot.com/)                            | ✅   | ❌     |
 | [Infura](./wasm-wrappers/fdw/infura_fdw)        | A Wasm FDW for [Infura](https://www.infura.io/) blockchain data               | ✅   | ❌     |
 | [Logflare](./wrappers/src/fdw/logflare_fdw)     | A FDW for [Logflare](https://logflare.app/)                                   | ✅   | ❌     |
+| [MongoDB](./wrappers/src/fdw/mongodb_fdw)       | A FDW for [MongoDB](https://www.mongodb.com/)                                 | ✅   | ✅     |
 | [MySQL](./wrappers/src/fdw/mysql_fdw)           | A FDW for [MySQL](https://www.mysql.com/)                                     | ✅   | ✅     |
 | [Notion](./wasm-wrappers/fdw/notion_fdw)        | A Wasm FDW for [Notion](https://www.notion.so/)                               | ✅   | ❌     |
 | [OpenAPI](./wasm-wrappers/fdw/openapi_fdw)      | A Wasm FDW for any [OpenAPI](https://www.openapis.org/) 3.0+ REST API         | ✅   | ❌     |

--- a/docs/catalog/mongodb.md
+++ b/docs/catalog/mongodb.md
@@ -1,0 +1,329 @@
+---
+source:
+documentation:
+author: Supabase
+tags:
+  - native
+---
+
+# MongoDB
+
+[MongoDB](https://www.mongodb.com/) is a popular open-source document database that stores data as flexible BSON documents.
+
+The MongoDB Wrapper allows you to read and write data from MongoDB within your Postgres database. Top-level BSON fields are mapped to declared columns by exact name; missing fields surface as SQL `NULL`. A special `_doc jsonb` column receives the full document for nested and array access.
+
+## Preparation
+
+Before you can query MongoDB, you need to enable the Wrappers extension and store your credentials in Postgres.
+
+### Enable Wrappers
+
+Make sure the `wrappers` extension is installed on your database:
+
+```sql
+create extension if not exists wrappers with schema extensions;
+```
+
+### Enable the MongoDB Wrapper
+
+Enable the `mongodb_wrapper` FDW:
+
+```sql
+create foreign data wrapper mongodb_wrapper
+  handler mongodb_fdw_handler
+  validator mongodb_fdw_validator;
+```
+
+### Store your credentials (optional)
+
+By default, Postgres stores FDW credentials inside `pg_catalog.pg_foreign_server` in plain text. Anyone with access to this table will be able to view these credentials. Wrappers is designed to work with [Vault](https://supabase.com/docs/guides/database/vault), which provides an additional level of security for storing credentials. We recommend using Vault to store your credentials.
+
+```sql
+-- Save your MongoDB connection string in Vault and retrieve the created `key_id`
+select vault.create_secret(
+  'mongodb://user:password@host:27017/?replicaSet=rs0',
+  'mongodb',
+  'MongoDB connection string for Wrappers'
+);
+```
+
+### Connecting to MongoDB
+
+We need to provide Postgres with the credentials to connect to MongoDB, and any additional options. We can do this using the `create server` command:
+
+=== "With Vault"
+
+    ```sql
+    create server mongo_server
+      foreign data wrapper mongodb_wrapper
+      options (
+        conn_string_id '<key_ID>' -- The Key ID from above.
+      );
+    ```
+
+=== "Without Vault"
+
+    ```sql
+    create server mongo_server
+      foreign data wrapper mongodb_wrapper
+      options (
+        conn_string 'mongodb://user:password@host:27017/?replicaSet=rs0'
+      );
+    ```
+
+The connection string follows the standard MongoDB URI format and supports `mongodb://` and `mongodb+srv://` schemes. Credentials, TLS options, replica set names, and other driver options can all be encoded in the URI.
+
+Some connection string examples:
+
+- `mongodb://root:secret@localhost:27017/`
+- `mongodb://app_user:password@db.example.com:27017/?tls=true`
+- `mongodb+srv://user:password@cluster.example.mongodb.net/?retryWrites=true`
+- `mongodb://user:pass@host1:27017,host2:27017/?replicaSet=rs0`
+
+### Create a schema
+
+We recommend creating a schema to hold all the foreign tables:
+
+```sql
+create schema if not exists mongo;
+```
+
+## Options
+
+The following options are available when creating MongoDB foreign tables:
+
+- `database` - MongoDB database name, required
+- `collection` - MongoDB collection name, required
+- `rowid_column` - Column to use as the row identifier, optional for data scan, required for data modify. The conventional value is `_id`.
+
+## Entities
+
+### Collections
+
+The MongoDB Wrapper supports data reads and writes from MongoDB collections.
+
+#### Operations
+
+| Object      | Select | Insert | Update | Delete | Truncate |
+| ----------- | :----: | :----: | :----: | :----: | :------: |
+| Collections |   ✅    |   ✅    |   ✅    |   ✅    |    ❌     |
+
+#### Usage
+
+```sql
+create foreign table mongo.users (
+  _id text,
+  name text,
+  age int,
+  created_at timestamp,
+  _doc jsonb
+)
+  server mongo_server
+  options (
+    database 'app',
+    collection 'users',
+    rowid_column '_id'
+  );
+```
+
+#### Notes
+
+- Supports `where`, `order by`, and `limit` clause pushdown
+- Documents are streamed one at a time from MongoDB; no full buffering in memory
+- A column named `_doc` of type `jsonb` receives the complete document and can be used with Postgres JSON operators (`->`, `->>`) to access nested fields and arrays
+- When `rowid_column` is set, INSERT, UPDATE, and DELETE are supported
+
+## Schema Mapping
+
+Each column declared on the foreign table maps to a top-level BSON field of the same name (exact match):
+
+- If a document does not contain a field, the corresponding column is set to `NULL`.
+- Dots in column names are treated as literal characters — they do not traverse embedded documents. Use the `_doc` column for nested field access.
+- If a column named `_doc` of type `jsonb` is declared, it receives the full BSON document serialized as JSON. When `_doc` is declared, projection is disabled so that the complete document is returned from MongoDB.
+
+Example: access a nested `address.city` field via `_doc`:
+
+```sql
+select _doc->>'name', _doc->'address'->>'city'
+from mongo.users;
+```
+
+## Query Pushdown Support
+
+This FDW supports `where`, `order by`, and `limit` clause pushdown.
+
+### Supported Operators
+
+The following SQL predicates are translated to MongoDB filter operators:
+
+| SQL predicate     | MongoDB filter          |
+| ----------------- | ----------------------- |
+| `=`               | `{field: {$eq: v}}`     |
+| `!=`              | `{field: {$ne: v}}`     |
+| `<`               | `{field: {$lt: v}}`     |
+| `<=`              | `{field: {$lte: v}}`    |
+| `>`               | `{field: {$gt: v}}`     |
+| `>=`              | `{field: {$gte: v}}`    |
+| `IN (...)`        | `{field: {$in: [...]}}`  |
+| `NOT IN (...)`    | `{field: {$nin: [...]}}` |
+| `IS NULL`         | `{field: {$eq: null}}`  |
+| `IS NOT NULL`     | `{field: {$ne: null}}`  |
+
+Multiple `where` predicates are AND'd at the top level of the filter document. Predicates with `OR` semantics are combined via `$or: [...]`. Any predicate shape that is not supported is omitted from the MongoDB filter and re-checked by Postgres after the rows are returned — the result is always correct, and the fallback is automatic.
+
+## Supported Data Types
+
+| BSON Type   | Postgres Type           | Notes                                                                                           |
+| ----------- | ----------------------- | ----------------------------------------------------------------------------------------------- |
+| Boolean     | bool                    |                                                                                                 |
+| Int32       | int2 / int4 / int8      |                                                                                                 |
+| Int64       | int8 / numeric          |                                                                                                 |
+| Double      | float8 / float4         |                                                                                                 |
+| Decimal128  | numeric                 |                                                                                                 |
+| String      | text / varchar          |                                                                                                 |
+| ObjectId    | text                    | Returned as a 24-character lowercase hex string. A 24-char hex value in a qual is coerced back to `ObjectId` for the filter. |
+| DateTime    | timestamp / timestamptz |                                                                                                 |
+| Document    | jsonb                   |                                                                                                 |
+| Array       | jsonb                   |                                                                                                 |
+| Binary      | bytea                   |                                                                                                 |
+| Null / missing | any                  | Column is set to `NULL`                                                                         |
+
+!!! note
+
+    `_id` fields that are `ObjectId` values are returned as their 24-character hex representation. When querying by `_id` with a 24-character hex string, the value is automatically coerced back to an `ObjectId` for the filter — no explicit casting is required.
+
+## Writes
+
+INSERT, UPDATE, and DELETE are enabled when `rowid_column` is set on the foreign table.
+
+- **INSERT**: Each non-null column is written as a top-level BSON field. Null columns are omitted entirely (not stored as explicit BSON nulls). If `_id` is not supplied, MongoDB generates an `ObjectId` automatically.
+- **UPDATE**: Non-null columns are passed to `$set`; null columns are passed to `$unset`, which removes the field from the document. The document is located by matching `rowid_column`.
+- **DELETE**: The document matching `rowid_column = rowid` is deleted via `delete_one`.
+
+## Limitations
+
+This section describes important limitations and considerations when using this FDW:
+
+- Aggregate pushdown is not supported — `COUNT`, `SUM`, `AVG`, `MIN`, and `MAX` are computed in Postgres after fetching rows
+- `import foreign schema` is not supported; foreign table definitions must be declared manually
+- `LIKE` predicates are not pushed down to MongoDB `$regex`; pattern matching happens in Postgres
+- Nested field path access (e.g., `address.city`) is not supported as column names — use the `_doc jsonb` column and Postgres JSON operators instead
+- Multi-document transactions and batched writes are not supported in v1
+- Change streams are not supported
+- Materialized views using foreign tables may fail during logical backups
+
+## Examples
+
+### Basic example
+
+This example shows how to query a MongoDB collection from Postgres.
+
+```sql
+-- Create the server
+create server mongo_server
+  foreign data wrapper mongodb_wrapper
+  options (
+    conn_string 'mongodb://localhost:27017/'
+  );
+
+-- Create the foreign table
+create foreign table mongo.users (
+  _id text,
+  name text,
+  age int,
+  created_at timestamp,
+  _doc jsonb
+)
+  server mongo_server
+  options (
+    database 'app',
+    collection 'users'
+  );
+
+-- Query all users
+select _id, name, age from mongo.users;
+
+-- Filter with pushdown
+select name from mongo.users where age > 25;
+
+-- Access nested fields via _doc
+select _doc->>'email', _doc->'address'->>'city'
+from mongo.users
+where name = 'Alice';
+```
+
+### Data modification example
+
+This example demonstrates INSERT, UPDATE, and DELETE on a foreign table. The `rowid_column` option is required for data modification:
+
+```sql
+create foreign table mongo.users (
+  _id text,
+  name text,
+  age int,
+  _doc jsonb
+)
+  server mongo_server
+  options (
+    database 'app',
+    collection 'users',
+    rowid_column '_id'
+  );
+
+-- Insert a new document (_id is generated by MongoDB if omitted)
+insert into mongo.users (name, age)
+values ('Alice', 30);
+
+-- Update a document (null columns remove the field via $unset)
+update mongo.users
+set age = 31
+where _id = '507f1f77bcf86cd799439011';
+
+-- Remove a field by setting it to null
+update mongo.users
+set age = null
+where _id = '507f1f77bcf86cd799439011';
+
+-- Delete a document
+delete from mongo.users
+where _id = '507f1f77bcf86cd799439011';
+```
+
+### Using Vault for credentials
+
+```sql
+-- Store the connection string in Vault
+select vault.create_secret(
+  'mongodb+srv://user:password@cluster.example.mongodb.net/',
+  'mongodb_atlas',
+  'MongoDB Atlas connection string'
+);
+
+-- Create the server using the Vault secret ID
+create server mongo_atlas_server
+  foreign data wrapper mongodb_wrapper
+  options (
+    conn_string_id '<key_ID>'
+  );
+
+create foreign table mongo.products (
+  _id text,
+  name text,
+  price numeric,
+  in_stock bool
+)
+  server mongo_atlas_server
+  options (
+    database 'shop',
+    collection 'products',
+    rowid_column '_id'
+  );
+
+-- Query with multiple pushed-down predicates
+select name, price
+from mongo.products
+where in_stock = true
+  and price < 100
+order by price
+limit 10;
+```

--- a/docs/catalog/mongodb.md
+++ b/docs/catalog/mongodb.md
@@ -169,7 +169,7 @@ The following SQL predicates are translated to MongoDB filter operators:
 | `IS NULL`         | `{field: {$eq: null}}`  |
 | `IS NOT NULL`     | `{field: {$ne: null}}`  |
 
-Multiple `where` predicates are AND'd at the top level of the filter document. Predicates with `OR` semantics are combined via `$or: [...]`. Any predicate shape that is not supported is omitted from the MongoDB filter and re-checked by Postgres after the rows are returned — the result is always correct, and the fallback is automatic.
+Multiple `where` predicates are AND'd at the top level of the filter document. Array-form predicates like `IN (...)` / `NOT IN (...)` (and the equivalent `= ANY(ARRAY[...])` / `<> ALL(ARRAY[...])`) are pushed down as `$in` / `$nin`. Arbitrary `OR` predicates between unrelated columns are not pushed down — they are re-checked by Postgres. Any predicate shape that is not supported is omitted from the MongoDB filter and re-checked by Postgres after the rows are returned, so the result is always correct.
 
 ## Supported Data Types
 

--- a/docs/catalog/mongodb.md
+++ b/docs/catalog/mongodb.md
@@ -173,20 +173,20 @@ Multiple `where` predicates are AND'd at the top level of the filter document. P
 
 ## Supported Data Types
 
-| BSON Type   | Postgres Type           | Notes                                                                                           |
-| ----------- | ----------------------- | ----------------------------------------------------------------------------------------------- |
-| Boolean     | bool                    |                                                                                                 |
-| Int32       | int2 / int4 / int8      |                                                                                                 |
-| Int64       | int8 / numeric          |                                                                                                 |
-| Double      | float8 / float4         |                                                                                                 |
-| Decimal128  | numeric                 |                                                                                                 |
-| String      | text / varchar          |                                                                                                 |
+| BSON Type   | Postgres Type           | Notes                    |
+| ----------- | ----------------------- | ------------------------ |
+| Boolean     | bool                    |                          |
+| Int32       | int2 / int4 / int8      |                          |
+| Int64       | int8 / numeric          |                          |
+| Double      | float8 / float4         |                          |
+| Decimal128  | numeric                 |                          |
+| String      | text / varchar          |                          |
 | ObjectId    | text                    | Returned as a 24-character lowercase hex string. A 24-char hex value in a qual is coerced back to `ObjectId` for the filter. |
-| DateTime    | timestamp / timestamptz |                                                                                                 |
-| Document    | jsonb                   |                                                                                                 |
-| Array       | jsonb                   |                                                                                                 |
-| Binary      | bytea                   |                                                                                                 |
-| Null / missing | any                  | Column is set to `NULL`                                                                         |
+| DateTime    | timestamp / timestamptz |                          |
+| Document    | jsonb                   |                          |
+| Array       | jsonb                   |                          |
+| Binary      | bytea                   |                          |
+| Null / missing | any                  | Column is set to `NULL`  |
 
 !!! note
 

--- a/wrappers/.ci/docker-compose-native.yaml
+++ b/wrappers/.ci/docker-compose-native.yaml
@@ -263,7 +263,7 @@ services:
       timeout: 5s
       retries: 20
 
-  mongo:
+  mongodb:
     image: mongo:7
     container_name: mongo-local
     ports:

--- a/wrappers/.ci/docker-compose-native.yaml
+++ b/wrappers/.ci/docker-compose-native.yaml
@@ -262,3 +262,14 @@ services:
       interval: 10s
       timeout: 5s
       retries: 20
+
+  mongo:
+    image: mongo:7
+    container_name: mongo-local
+    ports:
+      - "27017:27017"
+    healthcheck:
+      test: ["CMD", "sh", "-c", "echo 'db.runCommand({ ping: 1 })' | mongosh --quiet"]
+      interval: 10s
+      timeout: 5s
+      retries: 5

--- a/wrappers/Cargo.toml
+++ b/wrappers/Cargo.toml
@@ -151,6 +151,16 @@ mysql_fdw = [
     "serde_json",
     "thiserror",
 ]
+mongodb_fdw = [
+    "mongodb",
+    "bson",
+    "tokio",
+    "futures-util",
+    "serde_json",
+    "thiserror",
+    "mongodb/bson-2",
+    "mongodb/compat-3-3-0",
+]
 redis_fdw = [
     "redis",
     "serde_json",
@@ -222,6 +232,7 @@ native_fdws = [
     "auth0_fdw",
     "mssql_fdw",
     "mysql_fdw",
+    "mongodb_fdw",
     "redis_fdw",
     "cognito_fdw",
     "iceberg_fdw",
@@ -307,6 +318,10 @@ arrow-json = { version = "57.3.0", optional = true }
 
 # for mysql_fdw
 mysql_async = { version = "0.36.1", optional = true, default-features = false, features = ["default-rustls"] }
+
+# for mongodb_fdw
+mongodb = { version = "3.2", optional = true, default-features = false, features = ["rustls-tls"] }
+bson = { version = "2.13", optional = true, features = ["chrono-0_4"] }
 
 # for mssql_fdw
 tiberius = { version = "0.12.2", features = [

--- a/wrappers/Cargo.toml
+++ b/wrappers/Cargo.toml
@@ -320,7 +320,7 @@ arrow-json = { version = "57.3.0", optional = true }
 mysql_async = { version = "0.36.1", optional = true, default-features = false, features = ["default-rustls"] }
 
 # for mongodb_fdw
-mongodb = { version = "3.2", optional = true, default-features = false, features = ["rustls-tls"] }
+mongodb = { version = "3.2", optional = true, default-features = false, features = ["rustls-tls", "dns-resolver"] }
 bson = { version = "2.13", optional = true, features = ["chrono-0_4"] }
 
 # for mssql_fdw

--- a/wrappers/src/fdw/mod.rs
+++ b/wrappers/src/fdw/mod.rs
@@ -34,6 +34,9 @@ mod mssql_fdw;
 #[cfg(feature = "mysql_fdw")]
 mod mysql_fdw;
 
+#[cfg(feature = "mongodb_fdw")]
+mod mongodb_fdw;
+
 #[cfg(feature = "redis_fdw")]
 mod redis_fdw;
 

--- a/wrappers/src/fdw/mongodb_fdw/README.md
+++ b/wrappers/src/fdw/mongodb_fdw/README.md
@@ -1,0 +1,13 @@
+# MongoDB Foreign Data Wrapper
+
+This is a foreign data wrapper for [MongoDB](https://www.mongodb.com/). It is developed using [Wrappers](https://github.com/supabase/wrappers) and supports data scan and modification.
+
+## Documentation
+
+[https://fdw.dev/catalog/mongodb/](https://fdw.dev/catalog/mongodb/)
+
+## Changelog
+
+| Version | Date       | Notes           |
+| ------- | ---------- | --------------- |
+| 0.1.0   | 2026-06-01 | Initial version |

--- a/wrappers/src/fdw/mongodb_fdw/mod.rs
+++ b/wrappers/src/fdw/mongodb_fdw/mod.rs
@@ -1,0 +1,56 @@
+#![allow(clippy::module_inception)]
+mod mongodb_fdw;
+mod tests;
+
+use pgrx::pg_sys::panic::ErrorReport;
+use pgrx::prelude::PgSqlErrorCode;
+use thiserror::Error;
+
+use supabase_wrappers::prelude::{CreateRuntimeError, OptionsError};
+
+#[derive(Error, Debug)]
+enum MongodbFdwError {
+    #[error("column '{0}' data type is not supported")]
+    UnsupportedColumnType(String),
+
+    #[error("column conversion failure: {0}")]
+    ConversionError(String),
+
+    #[error("client is not initialized")]
+    NoClient,
+
+    #[error("{0}")]
+    MongoError(#[from] mongodb::error::Error),
+
+    #[error("invalid bson: {0}")]
+    BsonError(String),
+
+    #[error("{0}")]
+    PgrxNumericError(#[from] pgrx::datum::numeric_support::error::Error),
+
+    #[error("{0}")]
+    CreateRuntimeError(#[from] CreateRuntimeError),
+
+    #[error("{0}")]
+    OptionsError(#[from] OptionsError),
+
+    #[error("vault secret not found for id '{0}'")]
+    VaultSecretNotFound(String),
+}
+
+impl From<MongodbFdwError> for ErrorReport {
+    fn from(value: MongodbFdwError) -> Self {
+        match value {
+            MongodbFdwError::CreateRuntimeError(e) => e.into(),
+            MongodbFdwError::OptionsError(e) => e.into(),
+            MongodbFdwError::MongoError(_) => ErrorReport::new(
+                PgSqlErrorCode::ERRCODE_FDW_ERROR,
+                "mongodb connection or query error".to_string(),
+                "check connection string and collection",
+            ),
+            other => ErrorReport::new(PgSqlErrorCode::ERRCODE_FDW_ERROR, format!("{other}"), ""),
+        }
+    }
+}
+
+type MongodbFdwResult<T> = Result<T, MongodbFdwError>;

--- a/wrappers/src/fdw/mongodb_fdw/mod.rs
+++ b/wrappers/src/fdw/mongodb_fdw/mod.rs
@@ -36,6 +36,12 @@ enum MongodbFdwError {
 
     #[error("vault secret not found for id '{0}'")]
     VaultSecretNotFound(String),
+
+    #[error("server option 'conn_string' or 'conn_string_id' is required")]
+    MissingConnString,
+
+    #[error("server options 'conn_string' and 'conn_string_id' cannot both be set")]
+    ConflictingConnString,
 }
 
 impl From<MongodbFdwError> for ErrorReport {

--- a/wrappers/src/fdw/mongodb_fdw/mod.rs
+++ b/wrappers/src/fdw/mongodb_fdw/mod.rs
@@ -6,7 +6,7 @@ use pgrx::pg_sys::panic::ErrorReport;
 use pgrx::prelude::PgSqlErrorCode;
 use thiserror::Error;
 
-use supabase_wrappers::prelude::{CreateRuntimeError, OptionsError};
+use supabase_wrappers::prelude::{CreateRuntimeError, OptionsError, sanitize_error_message};
 
 #[derive(Error, Debug)]
 enum MongodbFdwError {
@@ -43,12 +43,13 @@ impl From<MongodbFdwError> for ErrorReport {
         match value {
             MongodbFdwError::CreateRuntimeError(e) => e.into(),
             MongodbFdwError::OptionsError(e) => e.into(),
-            MongodbFdwError::MongoError(e) => ErrorReport::new(
-                PgSqlErrorCode::ERRCODE_FDW_ERROR,
-                format!("mongodb error: {e}"),
-                "check connection string and collection",
-            ),
-            other => ErrorReport::new(PgSqlErrorCode::ERRCODE_FDW_ERROR, format!("{other}"), ""),
+            // SECURITY: Sanitize error messages to prevent credential leakage —
+            // mongodb URI parse errors and some driver errors can echo the
+            // raw connection string back.
+            _ => {
+                let error_message = sanitize_error_message(&format!("{value}"));
+                ErrorReport::new(PgSqlErrorCode::ERRCODE_FDW_ERROR, error_message, "")
+            }
         }
     }
 }

--- a/wrappers/src/fdw/mongodb_fdw/mod.rs
+++ b/wrappers/src/fdw/mongodb_fdw/mod.rs
@@ -43,9 +43,9 @@ impl From<MongodbFdwError> for ErrorReport {
         match value {
             MongodbFdwError::CreateRuntimeError(e) => e.into(),
             MongodbFdwError::OptionsError(e) => e.into(),
-            MongodbFdwError::MongoError(_) => ErrorReport::new(
+            MongodbFdwError::MongoError(e) => ErrorReport::new(
                 PgSqlErrorCode::ERRCODE_FDW_ERROR,
-                "mongodb connection or query error".to_string(),
+                format!("mongodb error: {e}"),
                 "check connection string and collection",
             ),
             other => ErrorReport::new(PgSqlErrorCode::ERRCODE_FDW_ERROR, format!("{other}"), ""),

--- a/wrappers/src/fdw/mongodb_fdw/mongodb_fdw.rs
+++ b/wrappers/src/fdw/mongodb_fdw/mongodb_fdw.rs
@@ -477,6 +477,72 @@ impl ForeignDataWrapper<MongodbFdwError> for MongodbFdw {
         Ok(())
     }
 
+    fn update(&mut self, rowid: &Cell, new_row: &Row) -> MongodbFdwResult<()> {
+        let mut set_doc = Document::new();
+        let mut unset_doc = Document::new();
+
+        for (name, cell) in new_row.iter() {
+            if name == &self.rowid_col || name == "_doc" {
+                continue;
+            }
+            match cell {
+                Some(c) => {
+                    set_doc.insert(name, cell_to_bson(name, c));
+                }
+                None => {
+                    unset_doc.insert(name, "");
+                }
+            }
+        }
+
+        let mut update = Document::new();
+        if !set_doc.is_empty() {
+            update.insert("$set", set_doc);
+        }
+        if !unset_doc.is_empty() {
+            update.insert("$unset", unset_doc);
+        }
+        if update.is_empty() {
+            return Ok(());
+        }
+
+        let filter = doc! { &self.rowid_col: cell_to_bson(&self.rowid_col, rowid) };
+        let (database, collection) = self
+            .modify_target
+            .clone()
+            .ok_or(MongodbFdwError::NoClient)?;
+        let client = self.client()?.clone();
+
+        self.rt.block_on(async move {
+            client
+                .database(&database)
+                .collection::<Document>(&collection)
+                .update_one(filter, update)
+                .await
+        })?;
+        stats::inc_stats(Self::FDW_NAME, stats::Metric::RowsOut, 1);
+        Ok(())
+    }
+
+    fn delete(&mut self, rowid: &Cell) -> MongodbFdwResult<()> {
+        let filter = doc! { &self.rowid_col: cell_to_bson(&self.rowid_col, rowid) };
+        let (database, collection) = self
+            .modify_target
+            .clone()
+            .ok_or(MongodbFdwError::NoClient)?;
+        let client = self.client()?.clone();
+
+        self.rt.block_on(async move {
+            client
+                .database(&database)
+                .collection::<Document>(&collection)
+                .delete_one(filter)
+                .await
+        })?;
+        stats::inc_stats(Self::FDW_NAME, stats::Metric::RowsOut, 1);
+        Ok(())
+    }
+
     fn end_modify(&mut self) -> MongodbFdwResult<()> {
         self.modify_target = None;
         Ok(())

--- a/wrappers/src/fdw/mongodb_fdw/mongodb_fdw.rs
+++ b/wrappers/src/fdw/mongodb_fdw/mongodb_fdw.rs
@@ -314,6 +314,34 @@ pub(crate) struct MongodbFdw {
 
 impl MongodbFdw {
     const FDW_NAME: &'static str = "MongodbFdw";
+
+    fn client(&self) -> MongodbFdwResult<&Client> {
+        self.client.as_ref().ok_or(MongodbFdwError::NoClient)
+    }
+
+    fn run_find(&mut self) -> MongodbFdwResult<()> {
+        let state = self
+            .scan_state
+            .as_ref()
+            .cloned()
+            .ok_or(MongodbFdwError::NoClient)?;
+        let client = self.client()?.clone();
+        let collection = client
+            .database(&state.database)
+            .collection::<Document>(&state.collection);
+
+        let cursor = self.rt.block_on(async {
+            use mongodb::options::FindOptions;
+            let mut opts = FindOptions::default();
+            opts.sort = state.sort.clone();
+            opts.limit = state.limit;
+            opts.projection = state.projection.clone();
+            collection.find(state.filter.clone()).with_options(opts).await
+        })?;
+
+        self.cursor = Some(cursor);
+        Ok(())
+    }
 }
 
 impl ForeignDataWrapper<MongodbFdwError> for MongodbFdw {
@@ -345,19 +373,62 @@ impl ForeignDataWrapper<MongodbFdwError> for MongodbFdw {
 
     fn begin_scan(
         &mut self,
-        _quals: &[Qual],
-        _columns: &[Column],
-        _sorts: &[Sort],
-        _limit: &Option<Limit>,
-        _options: &HashMap<String, String>,
+        quals: &[Qual],
+        columns: &[Column],
+        sorts: &[Sort],
+        limit: &Option<Limit>,
+        options: &HashMap<String, String>,
     ) -> MongodbFdwResult<()> {
-        // Filled in by Task 6.
-        Ok(())
+        let database = require_option("database", options)?.to_string();
+        let collection = require_option("collection", options)?.to_string();
+
+        self.tgt_cols = columns.to_vec();
+        self.scanned_row_cnt = 0;
+        self.scan_state = Some(ScanState {
+            database,
+            collection,
+            filter: quals_to_filter(quals),
+            sort: sorts_to_doc(sorts),
+            limit: limit_value(limit),
+            projection: columns_to_projection(columns),
+        });
+        self.run_find()
     }
 
-    fn iter_scan(&mut self, _row: &mut Row) -> MongodbFdwResult<Option<()>> {
-        // Filled in by Task 7.
+    fn iter_scan(&mut self, row: &mut Row) -> MongodbFdwResult<Option<()>> {
+        use futures_util::StreamExt;
+
+        if let Some(cursor) = &mut self.cursor {
+            let doc = self.rt.block_on(async { cursor.next().await });
+
+            if let Some(doc_result) = doc {
+                let doc = doc_result?;
+                let mut tgt_row = Row::new();
+                for col in &self.tgt_cols.clone() {
+                    if col.name == "_doc" {
+                        tgt_row.push(&col.name, Some(doc_to_jsonb_cell(&doc)?));
+                        continue;
+                    }
+                    let cell = match doc.get(&col.name) {
+                        Some(v) => bson_to_cell(v, col)?,
+                        None => None,
+                    };
+                    tgt_row.push(&col.name, cell);
+                }
+                row.replace_with(tgt_row);
+                self.scanned_row_cnt += 1;
+                return Ok(Some(()));
+            }
+        }
+
+        stats::inc_stats(Self::FDW_NAME, stats::Metric::RowsIn, self.scanned_row_cnt as i64);
+        stats::inc_stats(Self::FDW_NAME, stats::Metric::RowsOut, self.scanned_row_cnt as i64);
         Ok(None)
+    }
+
+    fn re_scan(&mut self) -> MongodbFdwResult<()> {
+        self.scanned_row_cnt = 0;
+        self.run_find()
     }
 
     fn end_scan(&mut self) -> MongodbFdwResult<()> {

--- a/wrappers/src/fdw/mongodb_fdw/mongodb_fdw.rs
+++ b/wrappers/src/fdw/mongodb_fdw/mongodb_fdw.rs
@@ -1,12 +1,116 @@
 use crate::stats;
-use bson::Document;
+use bson::{Bson, Document};
 use mongodb::{Client, Cursor};
-use pgrx::pg_sys;
+use pgrx::{pg_sys, varlena, PgBuiltInOids, PgOid, prelude::to_timestamp};
 use std::collections::HashMap;
 
 use supabase_wrappers::prelude::*;
 
 use super::{MongodbFdwError, MongodbFdwResult};
+
+/// Convert a full BSON document into a `Cell::Json` (used for the `_doc` column
+/// and for nested-document / array columns).
+fn doc_to_jsonb_cell(doc: &Document) -> MongodbFdwResult<Cell> {
+    let v: serde_json::Value = bson::to_bson(doc)
+        .map_err(|e| MongodbFdwError::BsonError(e.to_string()))?
+        .into_relaxed_extjson();
+    Ok(Cell::Json(pgrx::JsonB(v)))
+}
+
+fn bson_to_jsonb_cell(b: &Bson) -> MongodbFdwResult<Cell> {
+    let v: serde_json::Value = b.clone().into_relaxed_extjson();
+    Ok(Cell::Json(pgrx::JsonB(v)))
+}
+
+/// Convert one BSON value into a `Cell` matching the declared column type.
+/// Returns Ok(None) when the BSON value is `Null` (column should be SQL NULL).
+fn bson_to_cell(value: &Bson, tgt_col: &Column) -> MongodbFdwResult<Option<Cell>> {
+    if matches!(value, Bson::Null) {
+        return Ok(None);
+    }
+
+    let col_name = tgt_col.name.as_str();
+    let mismatch = |bson_kind: &str| {
+        MongodbFdwError::ConversionError(format!(
+            "column '{col_name}': cannot convert bson {bson_kind} to postgres type"
+        ))
+    };
+
+    let cell = match PgOid::from(tgt_col.type_oid) {
+        PgOid::BuiltIn(PgBuiltInOids::BOOLOID) => match value {
+            Bson::Boolean(b) => Cell::Bool(*b),
+            _ => return Err(mismatch(&format!("{:?}", value.element_type()))),
+        },
+        PgOid::BuiltIn(PgBuiltInOids::INT2OID) => match value {
+            Bson::Int32(v) => Cell::I16((*v) as i16),
+            Bson::Int64(v) => Cell::I16((*v) as i16),
+            _ => return Err(mismatch(&format!("{:?}", value.element_type()))),
+        },
+        PgOid::BuiltIn(PgBuiltInOids::INT4OID) => match value {
+            Bson::Int32(v) => Cell::I32(*v),
+            Bson::Int64(v) => Cell::I32((*v) as i32),
+            _ => return Err(mismatch(&format!("{:?}", value.element_type()))),
+        },
+        PgOid::BuiltIn(PgBuiltInOids::INT8OID) => match value {
+            Bson::Int32(v) => Cell::I64((*v) as i64),
+            Bson::Int64(v) => Cell::I64(*v),
+            _ => return Err(mismatch(&format!("{:?}", value.element_type()))),
+        },
+        PgOid::BuiltIn(PgBuiltInOids::FLOAT4OID) => match value {
+            Bson::Double(v) => Cell::F32(*v as f32),
+            _ => return Err(mismatch(&format!("{:?}", value.element_type()))),
+        },
+        PgOid::BuiltIn(PgBuiltInOids::FLOAT8OID) => match value {
+            Bson::Double(v) => Cell::F64(*v),
+            _ => return Err(mismatch(&format!("{:?}", value.element_type()))),
+        },
+        PgOid::BuiltIn(PgBuiltInOids::NUMERICOID) => match value {
+            Bson::Decimal128(d) => {
+                Cell::Numeric(pgrx::AnyNumeric::try_from(d.to_string().as_str())?)
+            }
+            Bson::Double(v) => Cell::Numeric(pgrx::AnyNumeric::try_from(*v)?),
+            Bson::Int64(v) => Cell::Numeric(pgrx::AnyNumeric::from(*v)),
+            Bson::Int32(v) => Cell::Numeric(pgrx::AnyNumeric::from(*v)),
+            _ => return Err(mismatch(&format!("{:?}", value.element_type()))),
+        },
+        PgOid::BuiltIn(PgBuiltInOids::TEXTOID)
+        | PgOid::BuiltIn(PgBuiltInOids::VARCHAROID) => match value {
+            Bson::String(s) => Cell::String(s.clone()),
+            Bson::ObjectId(oid) => Cell::String(oid.to_hex()),
+            _ => return Err(mismatch(&format!("{:?}", value.element_type()))),
+        },
+        PgOid::BuiltIn(PgBuiltInOids::TIMESTAMPOID) => match value {
+            Bson::DateTime(dt) => {
+                let secs = dt.timestamp_millis() as f64 / 1000.0;
+                let ts = to_timestamp(secs);
+                Cell::Timestamp(ts.to_utc())
+            }
+            _ => return Err(mismatch(&format!("{:?}", value.element_type()))),
+        },
+        PgOid::BuiltIn(PgBuiltInOids::TIMESTAMPTZOID) => match value {
+            Bson::DateTime(dt) => {
+                let secs = dt.timestamp_millis() as f64 / 1000.0;
+                let ts = to_timestamp(secs);
+                Cell::Timestamptz(ts)
+            }
+            _ => return Err(mismatch(&format!("{:?}", value.element_type()))),
+        },
+        PgOid::BuiltIn(PgBuiltInOids::JSONBOID) => match value {
+            Bson::Document(d) => doc_to_jsonb_cell(d)?,
+            Bson::Array(_) => bson_to_jsonb_cell(value)?,
+            other => bson_to_jsonb_cell(other)?,
+        },
+        PgOid::BuiltIn(PgBuiltInOids::BYTEAOID) => match value {
+            Bson::Binary(bin) => {
+                Cell::Bytea(varlena::rust_byte_slice_to_bytea(&bin.bytes).into_pg())
+            }
+            _ => return Err(mismatch(&format!("{:?}", value.element_type()))),
+        },
+        _ => return Err(MongodbFdwError::UnsupportedColumnType(col_name.to_string())),
+    };
+
+    Ok(Some(cell))
+}
 
 /// Cached state from begin_scan so re_scan can replay without re-deparsing.
 #[derive(Clone, Default)]

--- a/wrappers/src/fdw/mongodb_fdw/mongodb_fdw.rs
+++ b/wrappers/src/fdw/mongodb_fdw/mongodb_fdw.rs
@@ -1,0 +1,104 @@
+use crate::stats;
+use bson::Document;
+use mongodb::{Client, Cursor};
+use pgrx::pg_sys;
+use std::collections::HashMap;
+
+use supabase_wrappers::prelude::*;
+
+use super::{MongodbFdwError, MongodbFdwResult};
+
+/// Cached state from begin_scan so re_scan can replay without re-deparsing.
+#[derive(Clone, Default)]
+struct ScanState {
+    database: String,
+    collection: String,
+    filter: Document,
+    sort: Option<Document>,
+    limit: Option<i64>,
+    projection: Option<Document>,
+}
+
+#[wrappers_fdw(
+    version = "0.1.0",
+    author = "Supabase",
+    website = "https://github.com/supabase/wrappers/tree/main/wrappers/src/fdw/mongodb_fdw",
+    error_type = "MongodbFdwError"
+)]
+pub(crate) struct MongodbFdw {
+    rt: Runtime,
+    client: Option<Client>,
+    tgt_cols: Vec<Column>,
+    rowid_col: String,
+    scan_state: Option<ScanState>,
+    cursor: Option<Cursor<Document>>,
+    scanned_row_cnt: usize,
+}
+
+impl MongodbFdw {
+    const FDW_NAME: &'static str = "MongodbFdw";
+}
+
+impl ForeignDataWrapper<MongodbFdwError> for MongodbFdw {
+    fn new(server: ForeignServer) -> MongodbFdwResult<Self> {
+        let rt = create_async_runtime()?;
+        let conn_str = match server.options.get("conn_string") {
+            Some(s) => s.to_owned(),
+            None => {
+                let id = require_option("conn_string_id", &server.options)?;
+                get_vault_secret(id)
+                    .ok_or_else(|| MongodbFdwError::VaultSecretNotFound(id.to_string()))?
+            }
+        };
+
+        let client = rt.block_on(async { Client::with_uri_str(&conn_str).await })?;
+
+        stats::inc_stats(Self::FDW_NAME, stats::Metric::CreateTimes, 1);
+
+        Ok(MongodbFdw {
+            rt,
+            client: Some(client),
+            tgt_cols: Vec::new(),
+            rowid_col: String::default(),
+            scan_state: None,
+            cursor: None,
+            scanned_row_cnt: 0,
+        })
+    }
+
+    fn begin_scan(
+        &mut self,
+        _quals: &[Qual],
+        _columns: &[Column],
+        _sorts: &[Sort],
+        _limit: &Option<Limit>,
+        _options: &HashMap<String, String>,
+    ) -> MongodbFdwResult<()> {
+        // Filled in by Task 6.
+        Ok(())
+    }
+
+    fn iter_scan(&mut self, _row: &mut Row) -> MongodbFdwResult<Option<()>> {
+        // Filled in by Task 7.
+        Ok(None)
+    }
+
+    fn end_scan(&mut self) -> MongodbFdwResult<()> {
+        self.cursor = None;
+        self.scan_state = None;
+        Ok(())
+    }
+
+    fn validator(
+        options: Vec<Option<String>>,
+        catalog: Option<pg_sys::Oid>,
+    ) -> MongodbFdwResult<()> {
+        if let Some(oid) = catalog
+            && oid == FOREIGN_TABLE_RELATION_ID
+        {
+            check_options_contain(&options, "database")?;
+            check_options_contain(&options, "collection")?;
+        }
+        Ok(())
+    }
+}

--- a/wrappers/src/fdw/mongodb_fdw/mongodb_fdw.rs
+++ b/wrappers/src/fdw/mongodb_fdw/mongodb_fdw.rs
@@ -310,6 +310,7 @@ pub(crate) struct MongodbFdw {
     scan_state: Option<ScanState>,
     cursor: Option<Cursor<Document>>,
     scanned_row_cnt: usize,
+    modify_target: Option<(String, String)>, // (database, collection)
 }
 
 impl MongodbFdw {
@@ -368,6 +369,7 @@ impl ForeignDataWrapper<MongodbFdwError> for MongodbFdw {
             scan_state: None,
             cursor: None,
             scanned_row_cnt: 0,
+            modify_target: None,
         })
     }
 
@@ -434,6 +436,49 @@ impl ForeignDataWrapper<MongodbFdwError> for MongodbFdw {
     fn end_scan(&mut self) -> MongodbFdwResult<()> {
         self.cursor = None;
         self.scan_state = None;
+        Ok(())
+    }
+
+    fn begin_modify(&mut self, options: &HashMap<String, String>) -> MongodbFdwResult<()> {
+        let database = require_option("database", options)?.to_string();
+        let collection = require_option("collection", options)?.to_string();
+        self.rowid_col = require_option("rowid_column", options)?.to_string();
+        self.modify_target = Some((database, collection));
+        Ok(())
+    }
+
+    fn insert(&mut self, src: &Row) -> MongodbFdwResult<()> {
+        // Build the BSON document, skipping the `_doc` meta column and
+        // omitting null fields so Mongo doesn't store explicit nulls.
+        let mut doc = Document::new();
+        for (name, cell) in src.iter() {
+            if name == "_doc" {
+                continue;
+            }
+            if let Some(c) = cell {
+                doc.insert(name, cell_to_bson(name, c));
+            }
+        }
+
+        let (database, collection) = self
+            .modify_target
+            .clone()
+            .ok_or(MongodbFdwError::NoClient)?;
+        let client = self.client()?.clone();
+
+        self.rt.block_on(async move {
+            client
+                .database(&database)
+                .collection::<Document>(&collection)
+                .insert_one(doc)
+                .await
+        })?;
+        stats::inc_stats(Self::FDW_NAME, stats::Metric::RowsOut, 1);
+        Ok(())
+    }
+
+    fn end_modify(&mut self) -> MongodbFdwResult<()> {
+        self.modify_target = None;
         Ok(())
     }
 

--- a/wrappers/src/fdw/mongodb_fdw/mongodb_fdw.rs
+++ b/wrappers/src/fdw/mongodb_fdw/mongodb_fdw.rs
@@ -1,5 +1,5 @@
 use crate::stats;
-use bson::{Bson, Document, oid::ObjectId};
+use bson::{doc, Bson, Document, oid::ObjectId};
 use mongodb::{Client, Cursor};
 use pgrx::{pg_sys, varlena, PgBuiltInOids, PgOid, prelude::to_timestamp};
 use std::collections::HashMap;
@@ -159,6 +159,130 @@ fn cell_to_bson(field_name: &str, cell: &Cell) -> Bson {
         Cell::Uuid(u) => Bson::String(u.to_string()),
         _ => Bson::Null,
     }
+}
+
+/// Translate a single qual to a Mongo filter clause `{field: {$op: value}}`
+/// or `{field: ...}` when the operator is a top-level shortcut. Returns
+/// `None` when the qual cannot be pushed down (caller drops it; Postgres
+/// re-checks).
+fn qual_to_filter(qual: &Qual) -> Option<Document> {
+    let field = &qual.field;
+
+    // OR-of-equals (e.g., `f = ANY(ARRAY[a,b,c])` or `f <> ALL(ARRAY[...])`):
+    // translate to $in / $nin based on the per-element operator.
+    if qual.use_or {
+        if let Value::Array(cells) = &qual.value {
+            let vals: Vec<Bson> = cells.iter().map(|c| cell_to_bson(field, c)).collect();
+            return match qual.operator.as_str() {
+                "=" => Some(doc! { field: { "$in": vals } }),
+                "<>" | "!=" => Some(doc! { field: { "$nin": vals } }),
+                _ => None,
+            };
+        }
+        return None;
+    }
+
+    let cell = match &qual.value {
+        Value::Cell(c) => c,
+        Value::Array(_) => return None,
+    };
+
+    let bson_val = cell_to_bson(field, cell);
+
+    match qual.operator.as_str() {
+        "=" => Some(doc! { field: { "$eq": bson_val } }),
+        "<>" | "!=" => Some(doc! { field: { "$ne": bson_val } }),
+        "<" => Some(doc! { field: { "$lt": bson_val } }),
+        "<=" => Some(doc! { field: { "$lte": bson_val } }),
+        ">" => Some(doc! { field: { "$gt": bson_val } }),
+        ">=" => Some(doc! { field: { "$gte": bson_val } }),
+        // `IS NULL` / `IS NOT NULL` arrive as operator "is" / "is not" with
+        // Cell::String("null") per the convention in mysql_fdw.
+        "is" => {
+            if matches!(cell, Cell::String(s) if s == "null") {
+                Some(doc! { field: { "$eq": Bson::Null } })
+            } else {
+                None
+            }
+        }
+        "is not" => {
+            if matches!(cell, Cell::String(s) if s == "null") {
+                Some(doc! { field: { "$ne": Bson::Null } })
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+fn quals_to_filter(quals: &[Qual]) -> Document {
+    let mut filter = Document::new();
+    let mut and_clauses: Vec<Document> = Vec::new();
+
+    for q in quals {
+        match qual_to_filter(q) {
+            Some(clause) => {
+                for (k, v) in clause {
+                    if filter.contains_key(&k) {
+                        // Two quals target the same field; preserve both via $and.
+                        let existing = filter.remove(&k).unwrap();
+                        and_clauses.push(doc! { &k: existing });
+                        and_clauses.push(doc! { &k: v });
+                    } else {
+                        filter.insert(k, v);
+                    }
+                }
+            }
+            None => continue, // unsupported -> Postgres re-checks
+        }
+    }
+
+    if !and_clauses.is_empty() {
+        let and_arr: Vec<Bson> = and_clauses.into_iter().map(Bson::Document).collect();
+        match filter.remove("$and") {
+            Some(Bson::Array(mut existing)) => {
+                existing.extend(and_arr);
+                filter.insert("$and", existing);
+            }
+            _ => {
+                filter.insert("$and", and_arr);
+            }
+        }
+    }
+
+    filter
+}
+
+fn sorts_to_doc(sorts: &[Sort]) -> Option<Document> {
+    if sorts.is_empty() {
+        return None;
+    }
+    let mut d = Document::new();
+    for s in sorts {
+        d.insert(&s.field, if s.reversed { -1i32 } else { 1i32 });
+    }
+    Some(d)
+}
+
+fn limit_value(limit: &Option<Limit>) -> Option<i64> {
+    limit.as_ref().map(|l| l.offset + l.count)
+}
+
+/// Build a Mongo projection from declared columns. Returns `None` when a
+/// `_doc` jsonb column is present — we need the full document in that case.
+fn columns_to_projection(columns: &[Column]) -> Option<Document> {
+    if columns.iter().any(|c| c.name == "_doc") {
+        return None;
+    }
+    if columns.is_empty() {
+        return None;
+    }
+    let mut p = Document::new();
+    for c in columns {
+        p.insert(&c.name, 1i32);
+    }
+    Some(p)
 }
 
 /// Cached state from begin_scan so re_scan can replay without re-deparsing.

--- a/wrappers/src/fdw/mongodb_fdw/mongodb_fdw.rs
+++ b/wrappers/src/fdw/mongodb_fdw/mongodb_fdw.rs
@@ -1,8 +1,9 @@
 use crate::stats;
-use bson::{Bson, Document};
+use bson::{Bson, Document, oid::ObjectId};
 use mongodb::{Client, Cursor};
 use pgrx::{pg_sys, varlena, PgBuiltInOids, PgOid, prelude::to_timestamp};
 use std::collections::HashMap;
+use std::str::FromStr;
 
 use supabase_wrappers::prelude::*;
 
@@ -110,6 +111,54 @@ fn bson_to_cell(value: &Bson, tgt_col: &Column) -> MongodbFdwResult<Option<Cell>
     };
 
     Ok(Some(cell))
+}
+
+/// Convert a `Cell` to a BSON value. `field_name` is used to detect `_id`
+/// fields for ObjectId hex coercion.
+fn cell_to_bson(field_name: &str, cell: &Cell) -> Bson {
+    match cell {
+        Cell::Bool(v) => Bson::Boolean(*v),
+        Cell::I8(v) => Bson::Int32(*v as i32),
+        Cell::I16(v) => Bson::Int32(*v as i32),
+        Cell::I32(v) => Bson::Int32(*v),
+        Cell::I64(v) => Bson::Int64(*v),
+        Cell::F32(v) => Bson::Double(*v as f64),
+        Cell::F64(v) => Bson::Double(*v),
+        Cell::Numeric(n) => match bson::Decimal128::from_str(&n.to_string()) {
+            Ok(d) => Bson::Decimal128(d),
+            Err(_) => Bson::String(n.to_string()),
+        },
+        Cell::String(s) => {
+            if field_name == "_id" && s.len() == 24 && s.chars().all(|c| c.is_ascii_hexdigit()) {
+                match ObjectId::parse_str(s) {
+                    Ok(oid) => Bson::ObjectId(oid),
+                    Err(_) => Bson::String(s.clone()),
+                }
+            } else {
+                Bson::String(s.clone())
+            }
+        }
+        Cell::Date(d) => {
+            // to_unix_epoch_days() returns days since Unix epoch (1970-01-01)
+            let millis = d.to_unix_epoch_days() as i64 * 86_400_000;
+            Bson::DateTime(bson::DateTime::from_millis(millis))
+        }
+        Cell::Timestamp(ts) => {
+            // into_inner() returns microseconds since PG epoch (2000-01-01);
+            // add PG_EPOCH_MS (946_684_800_000_000 µs) to get Unix µs, then convert to ms.
+            let pg_epoch_us: i64 = 946_684_800_000_000;
+            let unix_ms = (ts.into_inner() + pg_epoch_us) / 1000;
+            Bson::DateTime(bson::DateTime::from_millis(unix_ms))
+        }
+        Cell::Timestamptz(ts) => {
+            let pg_epoch_us: i64 = 946_684_800_000_000;
+            let unix_ms = (ts.into_inner() + pg_epoch_us) / 1000;
+            Bson::DateTime(bson::DateTime::from_millis(unix_ms))
+        }
+        Cell::Json(j) => bson::to_bson(&j.0).unwrap_or(Bson::Null),
+        Cell::Uuid(u) => Bson::String(u.to_string()),
+        _ => Bson::Null,
+    }
 }
 
 /// Cached state from begin_scan so re_scan can replay without re-deparsing.

--- a/wrappers/src/fdw/mongodb_fdw/mongodb_fdw.rs
+++ b/wrappers/src/fdw/mongodb_fdw/mongodb_fdw.rs
@@ -43,13 +43,25 @@ fn bson_to_cell(value: &Bson, tgt_col: &Column) -> MongodbFdwResult<Option<Cell>
             _ => return Err(mismatch(&format!("{:?}", value.element_type()))),
         },
         PgOid::BuiltIn(PgBuiltInOids::INT2OID) => match value {
-            Bson::Int32(v) => Cell::I16((*v) as i16),
-            Bson::Int64(v) => Cell::I16((*v) as i16),
+            Bson::Int32(v) => Cell::I16(i16::try_from(*v).map_err(|_| {
+                MongodbFdwError::ConversionError(format!(
+                    "column '{col_name}': bson int32 value {v} out of range for int2"
+                ))
+            })?),
+            Bson::Int64(v) => Cell::I16(i16::try_from(*v).map_err(|_| {
+                MongodbFdwError::ConversionError(format!(
+                    "column '{col_name}': bson int64 value {v} out of range for int2"
+                ))
+            })?),
             _ => return Err(mismatch(&format!("{:?}", value.element_type()))),
         },
         PgOid::BuiltIn(PgBuiltInOids::INT4OID) => match value {
             Bson::Int32(v) => Cell::I32(*v),
-            Bson::Int64(v) => Cell::I32((*v) as i32),
+            Bson::Int64(v) => Cell::I32(i32::try_from(*v).map_err(|_| {
+                MongodbFdwError::ConversionError(format!(
+                    "column '{col_name}': bson int64 value {v} out of range for int4"
+                ))
+            })?),
             _ => return Err(mismatch(&format!("{:?}", value.element_type()))),
         },
         PgOid::BuiltIn(PgBuiltInOids::INT8OID) => match value {
@@ -115,9 +127,11 @@ fn bson_to_cell(value: &Bson, tgt_col: &Column) -> MongodbFdwResult<Option<Cell>
 }
 
 /// Convert a `Cell` to a BSON value. `field_name` is used to detect `_id`
-/// fields for ObjectId hex coercion.
-fn cell_to_bson(field_name: &str, cell: &Cell) -> Bson {
-    match cell {
+/// fields for ObjectId hex coercion. Returns an error for unsupported Cell
+/// variants so callers don't silently store NULL for data that couldn't be
+/// encoded.
+fn cell_to_bson(field_name: &str, cell: &Cell) -> MongodbFdwResult<Bson> {
+    let bson = match cell {
         Cell::Bool(v) => Bson::Boolean(*v),
         Cell::I8(v) => Bson::Int32(*v as i32),
         Cell::I16(v) => Bson::Int32(*v as i32),
@@ -156,10 +170,17 @@ fn cell_to_bson(field_name: &str, cell: &Cell) -> Bson {
             let unix_ms = (ts.into_inner() + pg_epoch_us) / 1000;
             Bson::DateTime(bson::DateTime::from_millis(unix_ms))
         }
-        Cell::Json(j) => bson::to_bson(&j.0).unwrap_or(Bson::Null),
+        Cell::Json(j) => {
+            bson::to_bson(&j.0).map_err(|e| MongodbFdwError::BsonError(e.to_string()))?
+        }
         Cell::Uuid(u) => Bson::String(u.to_string()),
-        _ => Bson::Null,
-    }
+        _ => {
+            return Err(MongodbFdwError::ConversionError(format!(
+                "unsupported cell type for field '{field_name}'"
+            )));
+        }
+    };
+    Ok(bson)
 }
 
 /// Translate a single qual to a Mongo filter clause `{field: {$op: value}}`
@@ -173,7 +194,11 @@ fn qual_to_filter(qual: &Qual) -> Option<Document> {
     // translate to $in / $nin based on the per-element operator.
     if qual.use_or {
         if let Value::Array(cells) = &qual.value {
-            let vals: Vec<Bson> = cells.iter().map(|c| cell_to_bson(field, c)).collect();
+            let vals: Vec<Bson> = cells
+                .iter()
+                .map(|c| cell_to_bson(field, c))
+                .collect::<MongodbFdwResult<Vec<_>>>()
+                .ok()?;
             return match qual.operator.as_str() {
                 "=" => Some(doc! { field: { "$in": vals } }),
                 "<>" | "!=" => Some(doc! { field: { "$nin": vals } }),
@@ -188,7 +213,7 @@ fn qual_to_filter(qual: &Qual) -> Option<Document> {
         Value::Array(_) => return None,
     };
 
-    let bson_val = cell_to_bson(field, cell);
+    let bson_val = cell_to_bson(field, cell).ok()?;
 
     match qual.operator.as_str() {
         "=" => Some(doc! { field: { "$eq": bson_val } }),
@@ -404,40 +429,44 @@ impl ForeignDataWrapper<MongodbFdwError> for MongodbFdw {
     fn iter_scan(&mut self, row: &mut Row) -> MongodbFdwResult<Option<()>> {
         use futures_util::StreamExt;
 
-        if let Some(cursor) = &mut self.cursor {
-            let doc = self.rt.block_on(async { cursor.next().await });
+        // Pull the next document with a tight cursor borrow, then drop it so
+        // we can iterate self.tgt_cols without cloning.
+        let doc_opt = if let Some(cursor) = self.cursor.as_mut() {
+            self.rt.block_on(async { cursor.next().await })
+        } else {
+            None
+        };
 
-            if let Some(doc_result) = doc {
-                let doc = doc_result?;
-                let mut tgt_row = Row::new();
-                for col in &self.tgt_cols.clone() {
-                    if col.name == "_doc" {
-                        tgt_row.push(&col.name, Some(doc_to_jsonb_cell(&doc)?));
-                        continue;
-                    }
-                    let cell = match doc.get(&col.name) {
-                        Some(v) => bson_to_cell(v, col)?,
-                        None => None,
-                    };
-                    tgt_row.push(&col.name, cell);
-                }
-                row.replace_with(tgt_row);
-                self.scanned_row_cnt += 1;
-                return Ok(Some(()));
+        let Some(doc_result) = doc_opt else {
+            stats::inc_stats(
+                Self::FDW_NAME,
+                stats::Metric::RowsIn,
+                self.scanned_row_cnt as i64,
+            );
+            stats::inc_stats(
+                Self::FDW_NAME,
+                stats::Metric::RowsOut,
+                self.scanned_row_cnt as i64,
+            );
+            return Ok(None);
+        };
+        let doc = doc_result?;
+
+        let mut tgt_row = Row::new();
+        for col in &self.tgt_cols {
+            if col.name == "_doc" {
+                tgt_row.push(&col.name, Some(doc_to_jsonb_cell(&doc)?));
+                continue;
             }
+            let cell = match doc.get(&col.name) {
+                Some(v) => bson_to_cell(v, col)?,
+                None => None,
+            };
+            tgt_row.push(&col.name, cell);
         }
-
-        stats::inc_stats(
-            Self::FDW_NAME,
-            stats::Metric::RowsIn,
-            self.scanned_row_cnt as i64,
-        );
-        stats::inc_stats(
-            Self::FDW_NAME,
-            stats::Metric::RowsOut,
-            self.scanned_row_cnt as i64,
-        );
-        Ok(None)
+        row.replace_with(tgt_row);
+        self.scanned_row_cnt += 1;
+        Ok(Some(()))
     }
 
     fn re_scan(&mut self) -> MongodbFdwResult<()> {
@@ -468,7 +497,7 @@ impl ForeignDataWrapper<MongodbFdwError> for MongodbFdw {
                 continue;
             }
             if let Some(c) = cell {
-                doc.insert(name, cell_to_bson(name, c));
+                doc.insert(name, cell_to_bson(name, c)?);
             }
         }
 
@@ -499,7 +528,7 @@ impl ForeignDataWrapper<MongodbFdwError> for MongodbFdw {
             }
             match cell {
                 Some(c) => {
-                    set_doc.insert(name, cell_to_bson(name, c));
+                    set_doc.insert(name, cell_to_bson(name, c)?);
                 }
                 None => {
                     unset_doc.insert(name, "");
@@ -518,7 +547,7 @@ impl ForeignDataWrapper<MongodbFdwError> for MongodbFdw {
             return Ok(());
         }
 
-        let filter = doc! { &self.rowid_col: cell_to_bson(&self.rowid_col, rowid) };
+        let filter = doc! { &self.rowid_col: cell_to_bson(&self.rowid_col, rowid)? };
         let (database, collection) = self
             .modify_target
             .clone()
@@ -537,7 +566,7 @@ impl ForeignDataWrapper<MongodbFdwError> for MongodbFdw {
     }
 
     fn delete(&mut self, rowid: &Cell) -> MongodbFdwResult<()> {
-        let filter = doc! { &self.rowid_col: cell_to_bson(&self.rowid_col, rowid) };
+        let filter = doc! { &self.rowid_col: cell_to_bson(&self.rowid_col, rowid)? };
         let (database, collection) = self
             .modify_target
             .clone()
@@ -564,11 +593,20 @@ impl ForeignDataWrapper<MongodbFdwError> for MongodbFdw {
         options: Vec<Option<String>>,
         catalog: Option<pg_sys::Oid>,
     ) -> MongodbFdwResult<()> {
-        if let Some(oid) = catalog
-            && oid == FOREIGN_TABLE_RELATION_ID
-        {
-            check_options_contain(&options, "database")?;
-            check_options_contain(&options, "collection")?;
+        if let Some(oid) = catalog {
+            if oid == FOREIGN_SERVER_RELATION_ID {
+                let has_conn = check_options_contain(&options, "conn_string").is_ok();
+                let has_conn_id = check_options_contain(&options, "conn_string_id").is_ok();
+                if !has_conn && !has_conn_id {
+                    return Err(MongodbFdwError::MissingConnString);
+                }
+                if has_conn && has_conn_id {
+                    return Err(MongodbFdwError::ConflictingConnString);
+                }
+            } else if oid == FOREIGN_TABLE_RELATION_ID {
+                check_options_contain(&options, "database")?;
+                check_options_contain(&options, "collection")?;
+            }
         }
         Ok(())
     }

--- a/wrappers/src/fdw/mongodb_fdw/mongodb_fdw.rs
+++ b/wrappers/src/fdw/mongodb_fdw/mongodb_fdw.rs
@@ -1,7 +1,7 @@
 use crate::stats;
-use bson::{doc, Bson, Document, oid::ObjectId};
+use bson::{Bson, Document, doc, oid::ObjectId};
 use mongodb::{Client, Cursor};
-use pgrx::{pg_sys, varlena, PgBuiltInOids, PgOid, prelude::to_timestamp};
+use pgrx::{PgBuiltInOids, PgOid, pg_sys, prelude::to_timestamp, varlena};
 use std::collections::HashMap;
 use std::str::FromStr;
 
@@ -74,12 +74,13 @@ fn bson_to_cell(value: &Bson, tgt_col: &Column) -> MongodbFdwResult<Option<Cell>
             Bson::Int32(v) => Cell::Numeric(pgrx::AnyNumeric::from(*v)),
             _ => return Err(mismatch(&format!("{:?}", value.element_type()))),
         },
-        PgOid::BuiltIn(PgBuiltInOids::TEXTOID)
-        | PgOid::BuiltIn(PgBuiltInOids::VARCHAROID) => match value {
-            Bson::String(s) => Cell::String(s.clone()),
-            Bson::ObjectId(oid) => Cell::String(oid.to_hex()),
-            _ => return Err(mismatch(&format!("{:?}", value.element_type()))),
-        },
+        PgOid::BuiltIn(PgBuiltInOids::TEXTOID) | PgOid::BuiltIn(PgBuiltInOids::VARCHAROID) => {
+            match value {
+                Bson::String(s) => Cell::String(s.clone()),
+                Bson::ObjectId(oid) => Cell::String(oid.to_hex()),
+                _ => return Err(mismatch(&format!("{:?}", value.element_type()))),
+            }
+        }
         PgOid::BuiltIn(PgBuiltInOids::TIMESTAMPOID) => match value {
             Bson::DateTime(dt) => {
                 let secs = dt.timestamp_millis() as f64 / 1000.0;
@@ -337,7 +338,10 @@ impl MongodbFdw {
             opts.sort = state.sort.clone();
             opts.limit = state.limit;
             opts.projection = state.projection.clone();
-            collection.find(state.filter.clone()).with_options(opts).await
+            collection
+                .find(state.filter.clone())
+                .with_options(opts)
+                .await
         })?;
 
         self.cursor = Some(cursor);
@@ -423,8 +427,16 @@ impl ForeignDataWrapper<MongodbFdwError> for MongodbFdw {
             }
         }
 
-        stats::inc_stats(Self::FDW_NAME, stats::Metric::RowsIn, self.scanned_row_cnt as i64);
-        stats::inc_stats(Self::FDW_NAME, stats::Metric::RowsOut, self.scanned_row_cnt as i64);
+        stats::inc_stats(
+            Self::FDW_NAME,
+            stats::Metric::RowsIn,
+            self.scanned_row_cnt as i64,
+        );
+        stats::inc_stats(
+            Self::FDW_NAME,
+            stats::Metric::RowsOut,
+            self.scanned_row_cnt as i64,
+        );
         Ok(None)
     }
 

--- a/wrappers/src/fdw/mongodb_fdw/tests.rs
+++ b/wrappers/src/fdw/mongodb_fdw/tests.rs
@@ -1,0 +1,5 @@
+#[cfg(any(test, feature = "pg_test"))]
+#[pgrx::pg_schema]
+mod tests {
+    // Tests added in later tasks.
+}

--- a/wrappers/src/fdw/mongodb_fdw/tests.rs
+++ b/wrappers/src/fdw/mongodb_fdw/tests.rs
@@ -16,11 +16,11 @@ mod tests {
             let coll = db.collection::<Document>("users");
             coll.insert_many(vec![
                 doc! { "_id": "u1", "name": "Alice", "age": 30, "active": true,
-                       "tags": ["admin", "ops"], "profile": { "level": 5 } },
+                "tags": ["admin", "ops"], "profile": { "level": 5 } },
                 doc! { "_id": "u2", "name": "Bob",   "age": 41, "active": false,
-                       "tags": ["user"], "profile": { "level": 2 } },
+                "tags": ["user"], "profile": { "level": 2 } },
                 doc! { "_id": "u3", "name": "Carol", "age": 27, "active": true,
-                       "tags": ["editor"], "profile": { "level": 3 } },
+                "tags": ["editor"], "profile": { "level": 3 } },
                 doc! { "_id": "u4", "name": "Dave",  "active": true },
             ])
             .await
@@ -105,45 +105,86 @@ mod tests {
             // =
             let r: Option<String> = c
                 .select("SELECT name FROM users WHERE age = 30", None, &[])
-                .unwrap().first().get(1).unwrap();
+                .unwrap()
+                .first()
+                .get(1)
+                .unwrap();
             assert_eq!(r.as_deref(), Some("Alice"));
 
             // != (excludes u4 because its age is missing -> NULL is excluded by !=)
             let r: Option<i64> = c
-                .select("SELECT count(*)::bigint FROM users WHERE age != 30", None, &[])
-                .unwrap().first().get(1).unwrap();
+                .select(
+                    "SELECT count(*)::bigint FROM users WHERE age != 30",
+                    None,
+                    &[],
+                )
+                .unwrap()
+                .first()
+                .get(1)
+                .unwrap();
             assert_eq!(r, Some(2));
 
             // < / <= / > / >=
             for (op, expected) in [("<", 1), ("<=", 2), (">", 1), (">=", 2)] {
                 let r: Option<i64> = c
-                    .select(&format!("SELECT count(*)::bigint FROM users WHERE age {op} 30"), None, &[])
-                    .unwrap().first().get(1).unwrap();
+                    .select(
+                        &format!("SELECT count(*)::bigint FROM users WHERE age {op} 30"),
+                        None,
+                        &[],
+                    )
+                    .unwrap()
+                    .first()
+                    .get(1)
+                    .unwrap();
                 assert_eq!(r, Some(expected), "operator {op}");
             }
 
             // IN
             let r: Option<i64> = c
-                .select("SELECT count(*)::bigint FROM users WHERE _id IN ('u1','u3')", None, &[])
-                .unwrap().first().get(1).unwrap();
+                .select(
+                    "SELECT count(*)::bigint FROM users WHERE _id IN ('u1','u3')",
+                    None,
+                    &[],
+                )
+                .unwrap()
+                .first()
+                .get(1)
+                .unwrap();
             assert_eq!(r, Some(2));
 
             // IS NULL — u4 has no `age`
             let r: Option<String> = c
                 .select("SELECT name FROM users WHERE age IS NULL", None, &[])
-                .unwrap().first().get(1).unwrap();
+                .unwrap()
+                .first()
+                .get(1)
+                .unwrap();
             assert_eq!(r.as_deref(), Some("Dave"));
 
             // IS NOT NULL
             let r: Option<i64> = c
-                .select("SELECT count(*)::bigint FROM users WHERE age IS NOT NULL", None, &[])
-                .unwrap().first().get(1).unwrap();
+                .select(
+                    "SELECT count(*)::bigint FROM users WHERE age IS NOT NULL",
+                    None,
+                    &[],
+                )
+                .unwrap()
+                .first()
+                .get(1)
+                .unwrap();
             assert_eq!(r, Some(3));
 
             // ORDER BY + LIMIT
             let r: Option<String> = c
-                .select("SELECT name FROM users WHERE age IS NOT NULL ORDER BY age DESC LIMIT 1", None, &[])
-                .unwrap().first().get(1).unwrap();
+                .select(
+                    "SELECT name FROM users WHERE age IS NOT NULL ORDER BY age DESC LIMIT 1",
+                    None,
+                    &[],
+                )
+                .unwrap()
+                .first()
+                .get(1)
+                .unwrap();
             assert_eq!(r.as_deref(), Some("Bob"));
         });
     }
@@ -158,12 +199,17 @@ mod tests {
 
             c.update(
                 "INSERT INTO users (_id, name, age, active) VALUES ('u5', 'Eve', 35, true)",
-                None, &[],
-            ).unwrap();
+                None,
+                &[],
+            )
+            .unwrap();
 
             let r: Option<String> = c
                 .select("SELECT name FROM users WHERE _id = 'u5'", None, &[])
-                .unwrap().first().get(1).unwrap();
+                .unwrap()
+                .first()
+                .get(1)
+                .unwrap();
             assert_eq!(r.as_deref(), Some("Eve"));
         });
     }
@@ -176,17 +222,25 @@ mod tests {
         Spi::connect_mut(|c| {
             create_server_and_table(c);
 
-            c.update("UPDATE users SET age = 99 WHERE _id = 'u1'", None, &[]).unwrap();
+            c.update("UPDATE users SET age = 99 WHERE _id = 'u1'", None, &[])
+                .unwrap();
             let r: Option<i32> = c
                 .select("SELECT age FROM users WHERE _id = 'u1'", None, &[])
-                .unwrap().first().get(1).unwrap();
+                .unwrap()
+                .first()
+                .get(1)
+                .unwrap();
             assert_eq!(r, Some(99));
 
             // Setting a column to NULL should $unset the field.
-            c.update("UPDATE users SET age = NULL WHERE _id = 'u1'", None, &[]).unwrap();
+            c.update("UPDATE users SET age = NULL WHERE _id = 'u1'", None, &[])
+                .unwrap();
             let r: Option<i32> = c
                 .select("SELECT age FROM users WHERE _id = 'u1'", None, &[])
-                .unwrap().first().get(1).unwrap();
+                .unwrap()
+                .first()
+                .get(1)
+                .unwrap();
             assert_eq!(r, None);
         });
     }
@@ -199,10 +253,14 @@ mod tests {
         Spi::connect_mut(|c| {
             create_server_and_table(c);
 
-            c.update("DELETE FROM users WHERE _id = 'u2'", None, &[]).unwrap();
+            c.update("DELETE FROM users WHERE _id = 'u2'", None, &[])
+                .unwrap();
             let n: Option<i64> = c
                 .select("SELECT count(*)::bigint FROM users", None, &[])
-                .unwrap().first().get(1).unwrap();
+                .unwrap()
+                .first()
+                .get(1)
+                .unwrap();
             assert_eq!(n, Some(3));
         });
     }
@@ -218,17 +276,25 @@ mod tests {
             let level: Option<i32> = c
                 .select(
                     "SELECT (_doc -> 'profile' ->> 'level')::int FROM users WHERE _id = 'u1'",
-                    None, &[],
+                    None,
+                    &[],
                 )
-                .unwrap().first().get(1).unwrap();
+                .unwrap()
+                .first()
+                .get(1)
+                .unwrap();
             assert_eq!(level, Some(5));
 
             let tag0: Option<String> = c
                 .select(
                     "SELECT (_doc -> 'tags' ->> 0) FROM users WHERE _id = 'u2'",
-                    None, &[],
+                    None,
+                    &[],
                 )
-                .unwrap().first().get(1).unwrap();
+                .unwrap()
+                .first()
+                .get(1)
+                .unwrap();
             assert_eq!(tag0.as_deref(), Some("user"));
         });
     }
@@ -244,37 +310,55 @@ mod tests {
             db.collection::<Document>("oid_items").drop().await.ok();
             let coll = db.collection::<Document>("oid_items");
             let oid = bson::oid::ObjectId::parse_str(hex_id).unwrap();
-            coll.insert_one(doc! { "_id": oid, "label": "alpha" }).await.unwrap();
+            coll.insert_one(doc! { "_id": oid, "label": "alpha" })
+                .await
+                .unwrap();
         });
 
         Spi::connect_mut(|c| {
             c.update(
                 r#"CREATE FOREIGN DATA WRAPPER mongodb_wrapper
                     HANDLER mongodb_fdw_handler VALIDATOR mongodb_fdw_validator"#,
-                None, &[],
-            ).unwrap();
+                None,
+                &[],
+            )
+            .unwrap();
             c.update(
                 r#"CREATE SERVER mongo_server FOREIGN DATA WRAPPER mongodb_wrapper
                    OPTIONS (conn_string 'mongodb://localhost:27017')"#,
-                None, &[],
-            ).unwrap();
+                None,
+                &[],
+            )
+            .unwrap();
             c.update(
                 r#"CREATE FOREIGN TABLE oid_items (_id text, label text)
                    SERVER mongo_server
                    OPTIONS (database 'testdb', collection 'oid_items', rowid_column '_id')"#,
-                None, &[],
-            ).unwrap();
+                None,
+                &[],
+            )
+            .unwrap();
 
             // Read: ObjectId returns as 24-char hex string.
             let id: Option<String> = c
                 .select("SELECT _id FROM oid_items LIMIT 1", None, &[])
-                .unwrap().first().get(1).unwrap();
+                .unwrap()
+                .first()
+                .get(1)
+                .unwrap();
             assert_eq!(id.as_deref(), Some(hex_id));
 
             // Qual: filter by hex value should match the ObjectId-typed document.
             let label: Option<String> = c
-                .select(&format!("SELECT label FROM oid_items WHERE _id = '{hex_id}'"), None, &[])
-                .unwrap().first().get(1).unwrap();
+                .select(
+                    &format!("SELECT label FROM oid_items WHERE _id = '{hex_id}'"),
+                    None,
+                    &[],
+                )
+                .unwrap()
+                .first()
+                .get(1)
+                .unwrap();
             assert_eq!(label.as_deref(), Some("alpha"));
         });
     }

--- a/wrappers/src/fdw/mongodb_fdw/tests.rs
+++ b/wrappers/src/fdw/mongodb_fdw/tests.rs
@@ -149,6 +149,26 @@ mod tests {
     }
 
     #[pg_test]
+    fn mongodb_insert() {
+        let rt = create_async_runtime().unwrap();
+        setup_mongo_users(&rt);
+
+        Spi::connect_mut(|c| {
+            create_server_and_table(c);
+
+            c.update(
+                "INSERT INTO users (_id, name, age, active) VALUES ('u5', 'Eve', 35, true)",
+                None, &[],
+            ).unwrap();
+
+            let r: Option<String> = c
+                .select("SELECT name FROM users WHERE _id = 'u5'", None, &[])
+                .unwrap().first().get(1).unwrap();
+            assert_eq!(r.as_deref(), Some("Eve"));
+        });
+    }
+
+    #[pg_test]
     fn mongodb_doc_column() {
         let rt = create_async_runtime().unwrap();
         setup_mongo_users(&rt);

--- a/wrappers/src/fdw/mongodb_fdw/tests.rs
+++ b/wrappers/src/fdw/mongodb_fdw/tests.rs
@@ -324,10 +324,10 @@ mod tests {
                 "c_i4":          12345i32,
                 "c_i8_from_i32": 12345i32,
                 "c_i8_from_i64": bson::Bson::Int64(9_000_000_000i64),
-                "c_f8":          3.14f64,
+                "c_f8":          3.24f64,
                 "c_f4":          1.25f64,           // exactly representable as f32
                 "c_num_dec":     bson::Bson::Decimal128(bson::Decimal128::from_str("123.456").unwrap()),
-                "c_num_dbl":     6.28f64,
+                "c_num_dbl":     6.38f64,
                 "c_num_i64":     bson::Bson::Int64(42i64),
                 "c_str":         "hello",
                 "c_oid":         bson::oid::ObjectId::parse_str("507f1f77bcf86cd799439011").unwrap(),
@@ -439,7 +439,7 @@ mod tests {
                 .first()
                 .get(1)
                 .unwrap();
-            assert!((v.unwrap() - 3.14f64).abs() < 1e-10, "c_f8 mismatch: {v:?}");
+            assert!((v.unwrap() - 3.24f64).abs() < 1e-10, "c_f8 mismatch: {v:?}");
 
             // float4 from BSON Double (use a value exact in f32: 1.25)
             let v: Option<f32> = c
@@ -467,7 +467,7 @@ mod tests {
                 .get(1)
                 .unwrap();
             assert!(
-                v.as_deref().unwrap().starts_with("6.28"),
+                v.as_deref().unwrap().starts_with("6.38"),
                 "c_num_dbl unexpected: {v:?}"
             );
 
@@ -526,11 +526,7 @@ mod tests {
 
             // jsonb from BSON Document
             let v: Option<String> = c
-                .select(
-                    "SELECT c_doc->>'k' FROM types_read",
-                    None,
-                    &[],
-                )
+                .select("SELECT c_doc->>'k' FROM types_read", None, &[])
                 .unwrap()
                 .first()
                 .get(1)
@@ -538,11 +534,7 @@ mod tests {
             assert_eq!(v.as_deref(), Some("v"));
 
             let v: Option<i32> = c
-                .select(
-                    "SELECT (c_doc->>'n')::int FROM types_read",
-                    None,
-                    &[],
-                )
+                .select("SELECT (c_doc->>'n')::int FROM types_read", None, &[])
                 .unwrap()
                 .first()
                 .get(1)
@@ -564,11 +556,7 @@ mod tests {
 
             // bytea from BSON Binary — compare as hex
             let v: Option<String> = c
-                .select(
-                    "SELECT encode(c_bin, 'hex') FROM types_read",
-                    None,
-                    &[],
-                )
+                .select("SELECT encode(c_bin, 'hex') FROM types_read", None, &[])
                 .unwrap()
                 .first()
                 .get(1)
@@ -643,7 +631,7 @@ mod tests {
                      12345::int4,
                      9000000000::int8,
                      1.25::float4,
-                     3.14::float8,
+                     3.24::float8,
                      123.456::numeric,
                      'hello',
                      '2023-11-14 22:13:20'::timestamp,
@@ -708,7 +696,7 @@ mod tests {
                 .first()
                 .get(1)
                 .unwrap();
-            assert!((v.unwrap() - 3.14f64).abs() < 1e-10, "c_f8 mismatch: {v:?}");
+            assert!((v.unwrap() - 3.24f64).abs() < 1e-10, "c_f8 mismatch: {v:?}");
 
             // numeric round-trip (cell_to_bson encodes as Decimal128)
             let v: Option<String> = c

--- a/wrappers/src/fdw/mongodb_fdw/tests.rs
+++ b/wrappers/src/fdw/mongodb_fdw/tests.rs
@@ -8,12 +8,14 @@ mod tests {
 
     const MONGO_URI: &str = "mongodb://localhost:27017";
 
-    fn setup_mongo_users(rt: &tokio::runtime::Runtime) {
+    /// Set up a named users-style collection, dropping it first for idempotency.
+    /// Each test passes a unique collection name to avoid parallel-run collisions.
+    fn setup_mongo_users(rt: &tokio::runtime::Runtime, coll_name: &str) {
         rt.block_on(async {
             let client = Client::with_uri_str(MONGO_URI).await.unwrap();
             let db = client.database("testdb");
-            db.collection::<Document>("users").drop().await.ok();
-            let coll = db.collection::<Document>("users");
+            db.collection::<Document>(coll_name).drop().await.ok();
+            let coll = db.collection::<Document>(coll_name);
             coll.insert_many(vec![
                 doc! { "_id": "u1", "name": "Alice", "age": 30, "active": true,
                 "tags": ["admin", "ops"], "profile": { "level": 5 } },
@@ -28,7 +30,7 @@ mod tests {
         });
     }
 
-    fn create_server_and_table(c: &mut pgrx::spi::SpiClient) {
+    fn create_server_and_table(c: &mut pgrx::spi::SpiClient, coll_name: &str) {
         c.update(
             r#"CREATE FOREIGN DATA WRAPPER mongodb_wrapper
                 HANDLER mongodb_fdw_handler VALIDATOR mongodb_fdw_validator"#,
@@ -44,15 +46,17 @@ mod tests {
         )
         .unwrap();
         c.update(
-            r#"CREATE FOREIGN TABLE users (
-                _id text,
-                name text,
-                age int,
-                active bool,
-                _doc jsonb
-              )
-              SERVER mongo_server
-              OPTIONS (database 'testdb', collection 'users', rowid_column '_id')"#,
+            &format!(
+                r#"CREATE FOREIGN TABLE users (
+                    _id text,
+                    name text,
+                    age int,
+                    active bool,
+                    _doc jsonb
+                  )
+                  SERVER mongo_server
+                  OPTIONS (database 'testdb', collection '{coll_name}', rowid_column '_id')"#
+            ),
             None,
             &[],
         )
@@ -62,10 +66,10 @@ mod tests {
     #[pg_test]
     fn mongodb_smoketest() {
         let rt = create_async_runtime().unwrap();
-        setup_mongo_users(&rt);
+        setup_mongo_users(&rt, "users_smoketest");
 
         Spi::connect_mut(|c| {
-            create_server_and_table(c);
+            create_server_and_table(c, "users_smoketest");
 
             let n: Option<i64> = c
                 .select("SELECT count(*)::bigint FROM users", None, &[])
@@ -97,10 +101,10 @@ mod tests {
     #[pg_test]
     fn mongodb_pushdown() {
         let rt = create_async_runtime().unwrap();
-        setup_mongo_users(&rt);
+        setup_mongo_users(&rt, "users_pushdown");
 
         Spi::connect_mut(|c| {
-            create_server_and_table(c);
+            create_server_and_table(c, "users_pushdown");
 
             // =
             let r: Option<String> = c
@@ -192,10 +196,10 @@ mod tests {
     #[pg_test]
     fn mongodb_insert() {
         let rt = create_async_runtime().unwrap();
-        setup_mongo_users(&rt);
+        setup_mongo_users(&rt, "users_insert");
 
         Spi::connect_mut(|c| {
-            create_server_and_table(c);
+            create_server_and_table(c, "users_insert");
 
             c.update(
                 "INSERT INTO users (_id, name, age, active) VALUES ('u5', 'Eve', 35, true)",
@@ -217,10 +221,10 @@ mod tests {
     #[pg_test]
     fn mongodb_update() {
         let rt = create_async_runtime().unwrap();
-        setup_mongo_users(&rt);
+        setup_mongo_users(&rt, "users_update");
 
         Spi::connect_mut(|c| {
-            create_server_and_table(c);
+            create_server_and_table(c, "users_update");
 
             c.update("UPDATE users SET age = 99 WHERE _id = 'u1'", None, &[])
                 .unwrap();
@@ -248,10 +252,10 @@ mod tests {
     #[pg_test]
     fn mongodb_delete() {
         let rt = create_async_runtime().unwrap();
-        setup_mongo_users(&rt);
+        setup_mongo_users(&rt, "users_delete");
 
         Spi::connect_mut(|c| {
-            create_server_and_table(c);
+            create_server_and_table(c, "users_delete");
 
             c.update("DELETE FROM users WHERE _id = 'u2'", None, &[])
                 .unwrap();
@@ -268,10 +272,10 @@ mod tests {
     #[pg_test]
     fn mongodb_doc_column() {
         let rt = create_async_runtime().unwrap();
-        setup_mongo_users(&rt);
+        setup_mongo_users(&rt, "users_doc_column");
 
         Spi::connect_mut(|c| {
-            create_server_and_table(c);
+            create_server_and_table(c, "users_doc_column");
 
             let level: Option<i32> = c
                 .select(

--- a/wrappers/src/fdw/mongodb_fdw/tests.rs
+++ b/wrappers/src/fdw/mongodb_fdw/tests.rs
@@ -169,6 +169,45 @@ mod tests {
     }
 
     #[pg_test]
+    fn mongodb_update() {
+        let rt = create_async_runtime().unwrap();
+        setup_mongo_users(&rt);
+
+        Spi::connect_mut(|c| {
+            create_server_and_table(c);
+
+            c.update("UPDATE users SET age = 99 WHERE _id = 'u1'", None, &[]).unwrap();
+            let r: Option<i32> = c
+                .select("SELECT age FROM users WHERE _id = 'u1'", None, &[])
+                .unwrap().first().get(1).unwrap();
+            assert_eq!(r, Some(99));
+
+            // Setting a column to NULL should $unset the field.
+            c.update("UPDATE users SET age = NULL WHERE _id = 'u1'", None, &[]).unwrap();
+            let r: Option<i32> = c
+                .select("SELECT age FROM users WHERE _id = 'u1'", None, &[])
+                .unwrap().first().get(1).unwrap();
+            assert_eq!(r, None);
+        });
+    }
+
+    #[pg_test]
+    fn mongodb_delete() {
+        let rt = create_async_runtime().unwrap();
+        setup_mongo_users(&rt);
+
+        Spi::connect_mut(|c| {
+            create_server_and_table(c);
+
+            c.update("DELETE FROM users WHERE _id = 'u2'", None, &[]).unwrap();
+            let n: Option<i64> = c
+                .select("SELECT count(*)::bigint FROM users", None, &[])
+                .unwrap().first().get(1).unwrap();
+            assert_eq!(n, Some(3));
+        });
+    }
+
+    #[pg_test]
     fn mongodb_doc_column() {
         let rt = create_async_runtime().unwrap();
         setup_mongo_users(&rt);

--- a/wrappers/src/fdw/mongodb_fdw/tests.rs
+++ b/wrappers/src/fdw/mongodb_fdw/tests.rs
@@ -303,6 +303,491 @@ mod tests {
         });
     }
 
+    /// Seed a document with one field per BSON type variant exercised in
+    /// `bson_to_cell` and assert every Postgres column reads back correctly.
+    #[pg_test]
+    fn mongodb_types_read() {
+        use bson::spec::BinarySubtype;
+        use std::str::FromStr;
+
+        let rt = create_async_runtime().unwrap();
+
+        rt.block_on(async {
+            let client = Client::with_uri_str(MONGO_URI).await.unwrap();
+            let db = client.database("testdb");
+            db.collection::<Document>("types_read").drop().await.ok();
+            let coll = db.collection::<Document>("types_read");
+
+            let doc = doc! {
+                "c_bool":        true,
+                "c_i2":          12345i32,
+                "c_i4":          12345i32,
+                "c_i8_from_i32": 12345i32,
+                "c_i8_from_i64": bson::Bson::Int64(9_000_000_000i64),
+                "c_f8":          3.14f64,
+                "c_f4":          1.25f64,           // exactly representable as f32
+                "c_num_dec":     bson::Bson::Decimal128(bson::Decimal128::from_str("123.456").unwrap()),
+                "c_num_dbl":     6.28f64,
+                "c_num_i64":     bson::Bson::Int64(42i64),
+                "c_str":         "hello",
+                "c_oid":         bson::oid::ObjectId::parse_str("507f1f77bcf86cd799439011").unwrap(),
+                // 1_700_000_000_000 ms  →  2023-11-14 22:13:20 UTC (whole second)
+                "c_dt":          bson::DateTime::from_millis(1_700_000_000_000i64),
+                "c_dt_tz":       bson::DateTime::from_millis(1_700_000_000_000i64),
+                "c_doc":         { "k": "v", "n": 7i32 },
+                "c_arr":         [1i32, 2i32, 3i32],
+                "c_bin":         bson::Bson::Binary(bson::Binary {
+                                     subtype: BinarySubtype::Generic,
+                                     bytes: vec![0x01u8, 0x02u8, 0xffu8],
+                                 }),
+            };
+
+            coll.insert_one(doc).await.unwrap();
+        });
+
+        Spi::connect_mut(|c| {
+            c.update(
+                r#"CREATE FOREIGN DATA WRAPPER mongodb_wrapper
+                    HANDLER mongodb_fdw_handler VALIDATOR mongodb_fdw_validator"#,
+                None,
+                &[],
+            )
+            .unwrap();
+            c.update(
+                r#"CREATE SERVER mongo_server FOREIGN DATA WRAPPER mongodb_wrapper
+                   OPTIONS (conn_string 'mongodb://localhost:27017')"#,
+                None,
+                &[],
+            )
+            .unwrap();
+            c.update(
+                r#"CREATE FOREIGN TABLE types_read (
+                     c_bool          bool,
+                     c_i2            int2,
+                     c_i4            int4,
+                     c_i8_from_i32   int8,
+                     c_i8_from_i64   int8,
+                     c_f8            float8,
+                     c_f4            float4,
+                     c_num_dec       numeric,
+                     c_num_dbl       numeric,
+                     c_num_i64       numeric,
+                     c_str           text,
+                     c_oid           text,
+                     c_dt            timestamp,
+                     c_dt_tz         timestamptz,
+                     c_doc           jsonb,
+                     c_arr           jsonb,
+                     c_bin           bytea
+                   )
+                   SERVER mongo_server
+                   OPTIONS (database 'testdb', collection 'types_read')"#,
+                None,
+                &[],
+            )
+            .unwrap();
+
+            // bool
+            let v: Option<bool> = c
+                .select("SELECT c_bool FROM types_read", None, &[])
+                .unwrap()
+                .first()
+                .get(1)
+                .unwrap();
+            assert_eq!(v, Some(true));
+
+            // int2 from BSON Int32
+            let v: Option<i16> = c
+                .select("SELECT c_i2 FROM types_read", None, &[])
+                .unwrap()
+                .first()
+                .get(1)
+                .unwrap();
+            assert_eq!(v, Some(12345i16));
+
+            // int4 from BSON Int32
+            let v: Option<i32> = c
+                .select("SELECT c_i4 FROM types_read", None, &[])
+                .unwrap()
+                .first()
+                .get(1)
+                .unwrap();
+            assert_eq!(v, Some(12345i32));
+
+            // int8 from BSON Int32
+            let v: Option<i64> = c
+                .select("SELECT c_i8_from_i32 FROM types_read", None, &[])
+                .unwrap()
+                .first()
+                .get(1)
+                .unwrap();
+            assert_eq!(v, Some(12345i64));
+
+            // int8 from BSON Int64
+            let v: Option<i64> = c
+                .select("SELECT c_i8_from_i64 FROM types_read", None, &[])
+                .unwrap()
+                .first()
+                .get(1)
+                .unwrap();
+            assert_eq!(v, Some(9_000_000_000i64));
+
+            // float8 from BSON Double
+            let v: Option<f64> = c
+                .select("SELECT c_f8 FROM types_read", None, &[])
+                .unwrap()
+                .first()
+                .get(1)
+                .unwrap();
+            assert!((v.unwrap() - 3.14f64).abs() < 1e-10, "c_f8 mismatch: {v:?}");
+
+            // float4 from BSON Double (use a value exact in f32: 1.25)
+            let v: Option<f32> = c
+                .select("SELECT c_f4 FROM types_read", None, &[])
+                .unwrap()
+                .first()
+                .get(1)
+                .unwrap();
+            assert_eq!(v, Some(1.25f32));
+
+            // numeric from Decimal128
+            let v: Option<String> = c
+                .select("SELECT c_num_dec::text FROM types_read", None, &[])
+                .unwrap()
+                .first()
+                .get(1)
+                .unwrap();
+            assert_eq!(v.as_deref(), Some("123.456"));
+
+            // numeric from Double
+            let v: Option<String> = c
+                .select("SELECT c_num_dbl::text FROM types_read", None, &[])
+                .unwrap()
+                .first()
+                .get(1)
+                .unwrap();
+            assert!(
+                v.as_deref().unwrap().starts_with("6.28"),
+                "c_num_dbl unexpected: {v:?}"
+            );
+
+            // numeric from Int64
+            let v: Option<String> = c
+                .select("SELECT c_num_i64::text FROM types_read", None, &[])
+                .unwrap()
+                .first()
+                .get(1)
+                .unwrap();
+            assert_eq!(v.as_deref(), Some("42"));
+
+            // text from BSON String
+            let v: Option<String> = c
+                .select("SELECT c_str FROM types_read", None, &[])
+                .unwrap()
+                .first()
+                .get(1)
+                .unwrap();
+            assert_eq!(v.as_deref(), Some("hello"));
+
+            // text from BSON ObjectId
+            let v: Option<String> = c
+                .select("SELECT c_oid FROM types_read", None, &[])
+                .unwrap()
+                .first()
+                .get(1)
+                .unwrap();
+            assert_eq!(v.as_deref(), Some("507f1f77bcf86cd799439011"));
+
+            // timestamp from BSON DateTime
+            let v: Option<bool> = c
+                .select(
+                    "SELECT c_dt = '2023-11-14 22:13:20'::timestamp FROM types_read",
+                    None,
+                    &[],
+                )
+                .unwrap()
+                .first()
+                .get(1)
+                .unwrap();
+            assert_eq!(v, Some(true), "c_dt mismatch");
+
+            // timestamptz from BSON DateTime
+            let v: Option<bool> = c
+                .select(
+                    "SELECT c_dt_tz = '2023-11-14 22:13:20+00'::timestamptz FROM types_read",
+                    None,
+                    &[],
+                )
+                .unwrap()
+                .first()
+                .get(1)
+                .unwrap();
+            assert_eq!(v, Some(true), "c_dt_tz mismatch");
+
+            // jsonb from BSON Document
+            let v: Option<String> = c
+                .select(
+                    "SELECT c_doc->>'k' FROM types_read",
+                    None,
+                    &[],
+                )
+                .unwrap()
+                .first()
+                .get(1)
+                .unwrap();
+            assert_eq!(v.as_deref(), Some("v"));
+
+            let v: Option<i32> = c
+                .select(
+                    "SELECT (c_doc->>'n')::int FROM types_read",
+                    None,
+                    &[],
+                )
+                .unwrap()
+                .first()
+                .get(1)
+                .unwrap();
+            assert_eq!(v, Some(7));
+
+            // jsonb from BSON Array
+            let v: Option<i32> = c
+                .select(
+                    "SELECT jsonb_array_length(c_arr) FROM types_read",
+                    None,
+                    &[],
+                )
+                .unwrap()
+                .first()
+                .get(1)
+                .unwrap();
+            assert_eq!(v, Some(3));
+
+            // bytea from BSON Binary — compare as hex
+            let v: Option<String> = c
+                .select(
+                    "SELECT encode(c_bin, 'hex') FROM types_read",
+                    None,
+                    &[],
+                )
+                .unwrap()
+                .first()
+                .get(1)
+                .unwrap();
+            assert_eq!(v.as_deref(), Some("0102ff"));
+        });
+    }
+
+    /// Round-trip test: INSERT via SQL (exercises cell_to_bson) then SELECT
+    /// back (exercises bson_to_cell) and assert every column matches.
+    #[pg_test]
+    fn mongodb_types_write() {
+        let rt = create_async_runtime().unwrap();
+
+        // Drop the collection for idempotency.
+        rt.block_on(async {
+            let client = Client::with_uri_str(MONGO_URI).await.unwrap();
+            client
+                .database("testdb")
+                .collection::<Document>("types_write")
+                .drop()
+                .await
+                .ok();
+        });
+
+        Spi::connect_mut(|c| {
+            c.update(
+                r#"CREATE FOREIGN DATA WRAPPER mongodb_wrapper
+                    HANDLER mongodb_fdw_handler VALIDATOR mongodb_fdw_validator"#,
+                None,
+                &[],
+            )
+            .unwrap();
+            c.update(
+                r#"CREATE SERVER mongo_server FOREIGN DATA WRAPPER mongodb_wrapper
+                   OPTIONS (conn_string 'mongodb://localhost:27017')"#,
+                None,
+                &[],
+            )
+            .unwrap();
+            c.update(
+                r#"CREATE FOREIGN TABLE types_write (
+                     _id     text,
+                     c_bool  bool,
+                     c_i2    int2,
+                     c_i4    int4,
+                     c_i8    int8,
+                     c_f4    float4,
+                     c_f8    float8,
+                     c_num   numeric,
+                     c_str   text,
+                     c_dt    timestamp,
+                     c_dt_tz timestamptz,
+                     c_doc   jsonb,
+                     c_arr   jsonb
+                   )
+                   SERVER mongo_server
+                   OPTIONS (database 'testdb', collection 'types_write', rowid_column '_id')"#,
+                None,
+                &[],
+            )
+            .unwrap();
+
+            c.update(
+                r#"INSERT INTO types_write (
+                     _id, c_bool, c_i2, c_i4, c_i8, c_f4, c_f8, c_num,
+                     c_str, c_dt, c_dt_tz, c_doc, c_arr
+                   ) VALUES (
+                     'w1',
+                     true,
+                     12345::int2,
+                     12345::int4,
+                     9000000000::int8,
+                     1.25::float4,
+                     3.14::float8,
+                     123.456::numeric,
+                     'hello',
+                     '2023-11-14 22:13:20'::timestamp,
+                     '2023-11-14 22:13:20+00'::timestamptz,
+                     '{"k":"v","n":7}'::jsonb,
+                     '[1,2,3]'::jsonb
+                   )"#,
+                None,
+                &[],
+            )
+            .unwrap();
+
+            // bool round-trip
+            let v: Option<bool> = c
+                .select("SELECT c_bool FROM types_write WHERE _id = 'w1'", None, &[])
+                .unwrap()
+                .first()
+                .get(1)
+                .unwrap();
+            assert_eq!(v, Some(true));
+
+            // int2 round-trip (cell_to_bson encodes I16 as BSON Int32)
+            let v: Option<i16> = c
+                .select("SELECT c_i2 FROM types_write WHERE _id = 'w1'", None, &[])
+                .unwrap()
+                .first()
+                .get(1)
+                .unwrap();
+            assert_eq!(v, Some(12345i16));
+
+            // int4 round-trip
+            let v: Option<i32> = c
+                .select("SELECT c_i4 FROM types_write WHERE _id = 'w1'", None, &[])
+                .unwrap()
+                .first()
+                .get(1)
+                .unwrap();
+            assert_eq!(v, Some(12345i32));
+
+            // int8 round-trip (cell_to_bson encodes I64 as BSON Int64)
+            let v: Option<i64> = c
+                .select("SELECT c_i8 FROM types_write WHERE _id = 'w1'", None, &[])
+                .unwrap()
+                .first()
+                .get(1)
+                .unwrap();
+            assert_eq!(v, Some(9_000_000_000i64));
+
+            // float4 round-trip (cell_to_bson encodes F32 as BSON Double)
+            let v: Option<f32> = c
+                .select("SELECT c_f4 FROM types_write WHERE _id = 'w1'", None, &[])
+                .unwrap()
+                .first()
+                .get(1)
+                .unwrap();
+            assert_eq!(v, Some(1.25f32));
+
+            // float8 round-trip
+            let v: Option<f64> = c
+                .select("SELECT c_f8 FROM types_write WHERE _id = 'w1'", None, &[])
+                .unwrap()
+                .first()
+                .get(1)
+                .unwrap();
+            assert!((v.unwrap() - 3.14f64).abs() < 1e-10, "c_f8 mismatch: {v:?}");
+
+            // numeric round-trip (cell_to_bson encodes as Decimal128)
+            let v: Option<String> = c
+                .select(
+                    "SELECT c_num::text FROM types_write WHERE _id = 'w1'",
+                    None,
+                    &[],
+                )
+                .unwrap()
+                .first()
+                .get(1)
+                .unwrap();
+            assert_eq!(v.as_deref(), Some("123.456"));
+
+            // text round-trip (non-_id: stays BSON String)
+            let v: Option<String> = c
+                .select("SELECT c_str FROM types_write WHERE _id = 'w1'", None, &[])
+                .unwrap()
+                .first()
+                .get(1)
+                .unwrap();
+            assert_eq!(v.as_deref(), Some("hello"));
+
+            // timestamp round-trip
+            let v: Option<bool> = c
+                .select(
+                    "SELECT c_dt = '2023-11-14 22:13:20'::timestamp \
+                     FROM types_write WHERE _id = 'w1'",
+                    None,
+                    &[],
+                )
+                .unwrap()
+                .first()
+                .get(1)
+                .unwrap();
+            assert_eq!(v, Some(true), "c_dt mismatch");
+
+            // timestamptz round-trip
+            let v: Option<bool> = c
+                .select(
+                    "SELECT c_dt_tz = '2023-11-14 22:13:20+00'::timestamptz \
+                     FROM types_write WHERE _id = 'w1'",
+                    None,
+                    &[],
+                )
+                .unwrap()
+                .first()
+                .get(1)
+                .unwrap();
+            assert_eq!(v, Some(true), "c_dt_tz mismatch");
+
+            // jsonb Document round-trip
+            let v: Option<String> = c
+                .select(
+                    "SELECT c_doc->>'k' FROM types_write WHERE _id = 'w1'",
+                    None,
+                    &[],
+                )
+                .unwrap()
+                .first()
+                .get(1)
+                .unwrap();
+            assert_eq!(v.as_deref(), Some("v"));
+
+            // jsonb Array round-trip
+            let v: Option<i32> = c
+                .select(
+                    "SELECT jsonb_array_length(c_arr) FROM types_write WHERE _id = 'w1'",
+                    None,
+                    &[],
+                )
+                .unwrap()
+                .first()
+                .get(1)
+                .unwrap();
+            assert_eq!(v, Some(3));
+        });
+    }
+
     #[pg_test]
     fn mongodb_objectid_roundtrip() {
         let rt = create_async_runtime().unwrap();

--- a/wrappers/src/fdw/mongodb_fdw/tests.rs
+++ b/wrappers/src/fdw/mongodb_fdw/tests.rs
@@ -93,4 +93,58 @@ mod tests {
             assert_eq!(age, None);
         });
     }
+
+    #[pg_test]
+    fn mongodb_pushdown() {
+        let rt = create_async_runtime().unwrap();
+        setup_mongo_users(&rt);
+
+        Spi::connect_mut(|c| {
+            create_server_and_table(c);
+
+            // =
+            let r: Option<String> = c
+                .select("SELECT name FROM users WHERE age = 30", None, &[])
+                .unwrap().first().get(1).unwrap();
+            assert_eq!(r.as_deref(), Some("Alice"));
+
+            // != (excludes u4 because its age is missing -> NULL is excluded by !=)
+            let r: Option<i64> = c
+                .select("SELECT count(*)::bigint FROM users WHERE age != 30", None, &[])
+                .unwrap().first().get(1).unwrap();
+            assert_eq!(r, Some(2));
+
+            // < / <= / > / >=
+            for (op, expected) in [("<", 1), ("<=", 2), (">", 1), (">=", 2)] {
+                let r: Option<i64> = c
+                    .select(&format!("SELECT count(*)::bigint FROM users WHERE age {op} 30"), None, &[])
+                    .unwrap().first().get(1).unwrap();
+                assert_eq!(r, Some(expected), "operator {op}");
+            }
+
+            // IN
+            let r: Option<i64> = c
+                .select("SELECT count(*)::bigint FROM users WHERE _id IN ('u1','u3')", None, &[])
+                .unwrap().first().get(1).unwrap();
+            assert_eq!(r, Some(2));
+
+            // IS NULL — u4 has no `age`
+            let r: Option<String> = c
+                .select("SELECT name FROM users WHERE age IS NULL", None, &[])
+                .unwrap().first().get(1).unwrap();
+            assert_eq!(r.as_deref(), Some("Dave"));
+
+            // IS NOT NULL
+            let r: Option<i64> = c
+                .select("SELECT count(*)::bigint FROM users WHERE age IS NOT NULL", None, &[])
+                .unwrap().first().get(1).unwrap();
+            assert_eq!(r, Some(3));
+
+            // ORDER BY + LIMIT
+            let r: Option<String> = c
+                .select("SELECT name FROM users WHERE age IS NOT NULL ORDER BY age DESC LIMIT 1", None, &[])
+                .unwrap().first().get(1).unwrap();
+            assert_eq!(r.as_deref(), Some("Bob"));
+        });
+    }
 }

--- a/wrappers/src/fdw/mongodb_fdw/tests.rs
+++ b/wrappers/src/fdw/mongodb_fdw/tests.rs
@@ -232,4 +232,50 @@ mod tests {
             assert_eq!(tag0.as_deref(), Some("user"));
         });
     }
+
+    #[pg_test]
+    fn mongodb_objectid_roundtrip() {
+        let rt = create_async_runtime().unwrap();
+        let hex_id = "507f1f77bcf86cd799439011";
+
+        rt.block_on(async {
+            let client = Client::with_uri_str(MONGO_URI).await.unwrap();
+            let db = client.database("testdb");
+            db.collection::<Document>("oid_items").drop().await.ok();
+            let coll = db.collection::<Document>("oid_items");
+            let oid = bson::oid::ObjectId::parse_str(hex_id).unwrap();
+            coll.insert_one(doc! { "_id": oid, "label": "alpha" }).await.unwrap();
+        });
+
+        Spi::connect_mut(|c| {
+            c.update(
+                r#"CREATE FOREIGN DATA WRAPPER mongodb_wrapper
+                    HANDLER mongodb_fdw_handler VALIDATOR mongodb_fdw_validator"#,
+                None, &[],
+            ).unwrap();
+            c.update(
+                r#"CREATE SERVER mongo_server FOREIGN DATA WRAPPER mongodb_wrapper
+                   OPTIONS (conn_string 'mongodb://localhost:27017')"#,
+                None, &[],
+            ).unwrap();
+            c.update(
+                r#"CREATE FOREIGN TABLE oid_items (_id text, label text)
+                   SERVER mongo_server
+                   OPTIONS (database 'testdb', collection 'oid_items', rowid_column '_id')"#,
+                None, &[],
+            ).unwrap();
+
+            // Read: ObjectId returns as 24-char hex string.
+            let id: Option<String> = c
+                .select("SELECT _id FROM oid_items LIMIT 1", None, &[])
+                .unwrap().first().get(1).unwrap();
+            assert_eq!(id.as_deref(), Some(hex_id));
+
+            // Qual: filter by hex value should match the ObjectId-typed document.
+            let label: Option<String> = c
+                .select(&format!("SELECT label FROM oid_items WHERE _id = '{hex_id}'"), None, &[])
+                .unwrap().first().get(1).unwrap();
+            assert_eq!(label.as_deref(), Some("alpha"));
+        });
+    }
 }

--- a/wrappers/src/fdw/mongodb_fdw/tests.rs
+++ b/wrappers/src/fdw/mongodb_fdw/tests.rs
@@ -1,5 +1,96 @@
 #[cfg(any(test, feature = "pg_test"))]
 #[pgrx::pg_schema]
 mod tests {
-    // Tests added in later tasks.
+    use bson::{Document, doc};
+    use mongodb::Client;
+    use pgrx::prelude::*;
+    use supabase_wrappers::prelude::create_async_runtime;
+
+    const MONGO_URI: &str = "mongodb://localhost:27017";
+
+    fn setup_mongo_users(rt: &tokio::runtime::Runtime) {
+        rt.block_on(async {
+            let client = Client::with_uri_str(MONGO_URI).await.unwrap();
+            let db = client.database("testdb");
+            db.collection::<Document>("users").drop().await.ok();
+            let coll = db.collection::<Document>("users");
+            coll.insert_many(vec![
+                doc! { "_id": "u1", "name": "Alice", "age": 30, "active": true,
+                       "tags": ["admin", "ops"], "profile": { "level": 5 } },
+                doc! { "_id": "u2", "name": "Bob",   "age": 41, "active": false,
+                       "tags": ["user"], "profile": { "level": 2 } },
+                doc! { "_id": "u3", "name": "Carol", "age": 27, "active": true,
+                       "tags": ["editor"], "profile": { "level": 3 } },
+                doc! { "_id": "u4", "name": "Dave",  "active": true },
+            ])
+            .await
+            .unwrap();
+        });
+    }
+
+    fn create_server_and_table(c: &mut pgrx::spi::SpiClient) {
+        c.update(
+            r#"CREATE FOREIGN DATA WRAPPER mongodb_wrapper
+                HANDLER mongodb_fdw_handler VALIDATOR mongodb_fdw_validator"#,
+            None,
+            &[],
+        )
+        .unwrap();
+        c.update(
+            r#"CREATE SERVER mongo_server FOREIGN DATA WRAPPER mongodb_wrapper
+               OPTIONS (conn_string 'mongodb://localhost:27017')"#,
+            None,
+            &[],
+        )
+        .unwrap();
+        c.update(
+            r#"CREATE FOREIGN TABLE users (
+                _id text,
+                name text,
+                age int,
+                active bool,
+                _doc jsonb
+              )
+              SERVER mongo_server
+              OPTIONS (database 'testdb', collection 'users', rowid_column '_id')"#,
+            None,
+            &[],
+        )
+        .unwrap();
+    }
+
+    #[pg_test]
+    fn mongodb_smoketest() {
+        let rt = create_async_runtime().unwrap();
+        setup_mongo_users(&rt);
+
+        Spi::connect_mut(|c| {
+            create_server_and_table(c);
+
+            let n: Option<i64> = c
+                .select("SELECT count(*)::bigint FROM users", None, &[])
+                .unwrap()
+                .first()
+                .get(1)
+                .unwrap();
+            assert_eq!(n, Some(4));
+
+            let name: Option<String> = c
+                .select("SELECT name FROM users WHERE _id = 'u1'", None, &[])
+                .unwrap()
+                .first()
+                .get(1)
+                .unwrap();
+            assert_eq!(name.as_deref(), Some("Alice"));
+
+            // Missing field on u4 → NULL
+            let age: Option<i32> = c
+                .select("SELECT age FROM users WHERE _id = 'u4'", None, &[])
+                .unwrap()
+                .first()
+                .get(1)
+                .unwrap();
+            assert_eq!(age, None);
+        });
+    }
 }

--- a/wrappers/src/fdw/mongodb_fdw/tests.rs
+++ b/wrappers/src/fdw/mongodb_fdw/tests.rs
@@ -147,4 +147,30 @@ mod tests {
             assert_eq!(r.as_deref(), Some("Bob"));
         });
     }
+
+    #[pg_test]
+    fn mongodb_doc_column() {
+        let rt = create_async_runtime().unwrap();
+        setup_mongo_users(&rt);
+
+        Spi::connect_mut(|c| {
+            create_server_and_table(c);
+
+            let level: Option<i32> = c
+                .select(
+                    "SELECT (_doc -> 'profile' ->> 'level')::int FROM users WHERE _id = 'u1'",
+                    None, &[],
+                )
+                .unwrap().first().get(1).unwrap();
+            assert_eq!(level, Some(5));
+
+            let tag0: Option<String> = c
+                .select(
+                    "SELECT (_doc -> 'tags' ->> 0) FROM users WHERE _id = 'u2'",
+                    None, &[],
+                )
+                .unwrap().first().get(1).unwrap();
+            assert_eq!(tag0.as_deref(), Some("user"));
+        });
+    }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to add new native foreign data wrapper for MongoDB.

## What is the current behavior?

No MongoDB FDW exists in the repo.

## What is the new behavior?

Adds `mongodb_fdw` as a native FDW.

- Built on the official mongodb Rust driver; supports `mongodb://` and `mongodb+srv://` (incl. Atlas), TLS, replica sets, Vault for conn_string_id.
- Top-level BSON fields map by name to declared columns; missing fields → NULL. Optional `_doc` jsonb meta-column receives the full document for nested access.
- Pushdown: `=, !=, <, <=, >, >=, IN, NOT IN, IS NULL, IS NOT NULL, AND, OR, ORDER BY, LIMIT`.
- Writes via `rowid_column` (typically `_id`); UPDATE with NULL → `$unset`. ObjectId round-trips as 24-char hex.
- Full BSON↔Postgres type mapping (bool, ints, doubles, Decimal128, text, ObjectId, DateTime, Document/Array →jsonb, Binary → bytea).

Out of scope for v1: aggregate pushdown, import_foreign_schema, LIKE → $regex, nested field paths, transactions, change streams.

## Additional context

N/A
