### PR TITLE
chore: bump Wrappers version to 0.6.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8192,7 +8192,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "supabase-wrappers"
-version = "0.1.27"
+version = "0.1.28"
 dependencies = [
  "pgrx",
  "pgrx-tests",
@@ -10488,7 +10488,7 @@ dependencies = [
 
 [[package]]
 name = "wrappers"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "arrow-array 55.2.0",

--- a/supabase-wrappers/Cargo.toml
+++ b/supabase-wrappers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "supabase-wrappers"
-version = "0.1.27"
+version = "0.1.28"
 authors = ["Supabase Inc. https://supabase.com/"]
 license = "Apache-2.0"
 description = "Postgres Foreign Data Wrapper development framework in Rust."

--- a/wrappers/Cargo.toml
+++ b/wrappers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wrappers"
-version = "0.6.1"
+version = "0.6.2"
 publish = false
 homepage = "https://github.com/supabase/wrappers/tree/main/wrappers"
 repository = "https://github.com/supabase/wrappers/tree/main/wrappers"


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to bump Wrappers version to `0.6.2`. This is a minor release, changes in this release:

- Added MongoDB FDW
- Added per-request credentials support from session variables, bump framework version to `0.1.28`
- Bumped OpenAPI FDW version to `0.2.1`

## What is the current behavior?

N/A

## What is the new behavior?

N/A

## Additional context

N/A
