### PR TITLE
fix(docs) Resolve note formatting

### DIFF
--- a/docs/catalog/hubspot.md
+++ b/docs/catalog/hubspot.md
@@ -43,6 +43,7 @@ create foreign data wrapper wasm_wrapper
 ```
 
 !!! note "About Authentication"
+
     HubSpot deprecated their legacy API Keys in November 2022. The `api_key` option in this wrapper accepts a **Private App Access Token**, which is HubSpot's recommended authentication method. See [HubSpot Private Apps](https://developers.hubspot.com/docs/guides/apps/private-apps/overview) for setup instructions.
 
 ### Store your credentials (optional)


### PR DESCRIPTION
Closes DOCS-994

## What kind of change does this PR introduce?

Resolves note formatting by following convention and adding an empty line in between.

**Note:** I need help verifying that this change actually worked. Review before approving.

