### PR TITLE
fix(mysql_fdw): support varchar and bpchar text columns

### DIFF
--- a/docs/catalog/mysql.md
+++ b/docs/catalog/mysql.md
@@ -236,6 +236,8 @@ Primary key columns are automatically detected and set as the `rowid_column` opt
 
     `decimal` and `numeric` columns with explicit precision and scale (e.g. `decimal(12,2)`) are imported as `numeric(p,s)` in Postgres.
 
+    `import foreign schema` always generates `text` for MySQL string types, but when defining a foreign table manually you may also declare these columns as `varchar(n)` or `char(n)`; all three Postgres types are read correctly.
+
 ## Limitations
 
 This section describes important limitations and considerations when using this FDW:

--- a/wrappers/src/fdw/mysql_fdw/README.md
+++ b/wrappers/src/fdw/mysql_fdw/README.md
@@ -10,5 +10,6 @@ This is a foreign data wrapper for [MySQL](https://www.mysql.com/). It is develo
 
 | Version | Date       | Notes                                          |
 | ------- | ---------- | ---------------------------------------------- |
+| 0.1.2   | 2026-06-26 | Support `varchar` and `char` text columns      |
 | 0.1.1   | 2026-04-28 | Added aggregate pushdown support               |
 | 0.1.0   | 2026-03-27 | Initial version                                |

--- a/wrappers/src/fdw/mysql_fdw/mysql_fdw.rs
+++ b/wrappers/src/fdw/mysql_fdw/mysql_fdw.rs
@@ -218,7 +218,7 @@ impl CellFormatter for MysqlCellFormatter {
 }
 
 #[wrappers_fdw(
-    version = "0.1.1",
+    version = "0.1.2",
     author = "Wener",
     website = "https://github.com/supabase/wrappers/tree/main/wrappers/src/fdw/mysql_fdw",
     error_type = "MysqlFdwError"

--- a/wrappers/src/fdw/mysql_fdw/mysql_fdw.rs
+++ b/wrappers/src/fdw/mysql_fdw/mysql_fdw.rs
@@ -42,7 +42,9 @@ fn field_to_cell(src_row: &MySqlRow, tgt_col: &Column) -> MysqlFdwResult<Option<
             .map(pgrx::AnyNumeric::try_from)
             .transpose()?
             .map(Cell::Numeric),
-        PgOid::BuiltIn(PgBuiltInOids::TEXTOID) => {
+        PgOid::BuiltIn(PgBuiltInOids::TEXTOID)
+        | PgOid::BuiltIn(PgBuiltInOids::VARCHAROID)
+        | PgOid::BuiltIn(PgBuiltInOids::BPCHAROID) => {
             get_col::<String>(src_row, col_name)?.map(Cell::String)
         }
         PgOid::BuiltIn(PgBuiltInOids::JSONBOID) => match get_col::<String>(src_row, col_name)? {

--- a/wrappers/src/fdw/mysql_fdw/tests.rs
+++ b/wrappers/src/fdw/mysql_fdw/tests.rs
@@ -138,8 +138,8 @@ mod tests {
                 r#"
                 CREATE FOREIGN TABLE mysql.users2 (
                     id bigint,
-                    name text,
-                    email text,
+                    name varchar(100),
+                    email varchar(200),
                     active boolean,
                     age integer,
                     balance numeric,
@@ -155,7 +155,6 @@ mod tests {
                 &[],
             )
             .expect("failed to create foreign table with custom query");
-
             let results = c
                 .select("SELECT * FROM mysql.users order by id", None, &[])
                 .unwrap()
@@ -169,6 +168,14 @@ mod tests {
                 .filter_map(|r| r.get_by_name::<&str, _>("name").unwrap())
                 .collect::<Vec<_>>();
             assert_eq!(results, vec!["Alice", "Bob", "Carol", "Dave"]);
+
+            let varchar_email = c
+                .select("SELECT email FROM mysql.users2 WHERE id = 1", None, &[])
+                .expect("failed to select varchar email")
+                .next()
+                .and_then(|r| r.get_by_name::<&str, _>("email").ok().flatten())
+                .map(str::to_string);
+            assert_eq!(varchar_email.as_deref(), Some("alice@example.com"));
 
             c.update(
                 r#"INSERT INTO mysql.users

--- a/wrappers/src/fdw/mysql_fdw/tests.rs
+++ b/wrappers/src/fdw/mysql_fdw/tests.rs
@@ -31,6 +31,7 @@ mod tests {
                 id BIGINT PRIMARY KEY AUTO_INCREMENT,
                 name VARCHAR(100) NOT NULL,
                 email VARCHAR(200) NOT NULL,
+                country_code CHAR(2),
                 active BOOLEAN NOT NULL DEFAULT TRUE,
                 age INT,
                 score SMALLINT,
@@ -44,11 +45,11 @@ mod tests {
         );
         exec_mysql_query("TRUNCATE TABLE testdb.users");
         exec_mysql_query(
-            r#"INSERT INTO testdb.users (name, email, active, age, score, rating, salary, balance, birth_date, metadata, created_at) VALUES
-                ('Alice', 'alice@example.com', TRUE, 30, 85, 4.5, 75000.50, 120.50, '1995-03-15', '{\"role\": \"admin\", \"level\": 5}', '2026-03-01 10:00:00'),
-                ('Bob', 'bob@example.com', FALSE, 41, 72, 3.5, 52000.75, 88.25, '1984-07-22', '{\"role\": \"user\", \"level\": 2}', '2026-03-02 11:30:00'),
-                ('Carol', 'carol@example.com', TRUE, 27, 91, 5.0, 98000.00, 999.99, '1998-11-30', '{\"role\": \"editor\", \"level\": 3}', '2026-03-03 09:15:00'),
-                ('Dave', 'dave@example.com', TRUE, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '2026-03-04 14:45:00')"#,
+            r#"INSERT INTO testdb.users (name, email, country_code, active, age, score, rating, salary, balance, birth_date, metadata, created_at) VALUES
+                ('Alice', 'alice@example.com', 'US', TRUE, 30, 85, 4.5, 75000.50, 120.50, '1995-03-15', '{\"role\": \"admin\", \"level\": 5}', '2026-03-01 10:00:00'),
+                ('Bob', 'bob@example.com', 'GB', FALSE, 41, 72, 3.5, 52000.75, 88.25, '1984-07-22', '{\"role\": \"user\", \"level\": 2}', '2026-03-02 11:30:00'),
+                ('Carol', 'carol@example.com', 'FR', TRUE, 27, 91, 5.0, 98000.00, 999.99, '1998-11-30', '{\"role\": \"editor\", \"level\": 3}', '2026-03-03 09:15:00'),
+                ('Dave', 'dave@example.com', NULL, TRUE, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '2026-03-04 14:45:00')"#,
         );
     }
 
@@ -140,6 +141,7 @@ mod tests {
                     id bigint,
                     name varchar(100),
                     email varchar(200),
+                    country_code char(2),
                     active boolean,
                     age integer,
                     balance numeric,
@@ -147,7 +149,7 @@ mod tests {
                 )
                 SERVER mysql_server
                 OPTIONS (
-                    table '(select id,name,email,active,age,balance,created_at from testdb.users)',
+                    table '(select id,name,email,country_code,active,age,balance,created_at from testdb.users)',
                     rowid_column 'id'
                 );
             "#,
@@ -176,6 +178,30 @@ mod tests {
                 .and_then(|r| r.get_by_name::<&str, _>("email").ok().flatten())
                 .map(str::to_string);
             assert_eq!(varchar_email.as_deref(), Some("alice@example.com"));
+
+            let char_country = c
+                .select(
+                    "SELECT country_code::text AS country_code FROM mysql.users2 WHERE id = 1",
+                    None,
+                    &[],
+                )
+                .expect("failed to select char country_code")
+                .next()
+                .and_then(|r| r.get_by_name::<&str, _>("country_code").ok().flatten())
+                .map(str::to_string);
+            assert_eq!(char_country.as_deref(), Some("US"));
+
+            let null_country = c
+                .select(
+                    "SELECT country_code::text AS country_code FROM mysql.users2 WHERE id = 4",
+                    None,
+                    &[],
+                )
+                .expect("failed to select null char country_code")
+                .next()
+                .and_then(|r| r.get_by_name::<&str, _>("country_code").ok().flatten())
+                .map(str::to_string);
+            assert_eq!(null_country, None);
 
             c.update(
                 r#"INSERT INTO mysql.users


### PR DESCRIPTION
## Summary
- Map PostgreSQL `varchar` and `bpchar` target columns to `Cell::String` in MySQL FDW scans
- Extend the MySQL FDW pgrx smoke test to cover a `varchar` projection and a `char(n)` projection

## Validation
- `git diff --check`
- Conflict marker scan with `rg`
- Not run locally: `cargo`/`rustc` are unavailable in this agent environment; GitHub CI should run the Rust checks/tests