### PR TITLE
docs(openapi): update checksum for version 0.2.1

### DIFF
--- a/docs/catalog/openapi.md
+++ b/docs/catalog/openapi.md
@@ -18,7 +18,7 @@ This wrapper allows you to query any REST API endpoint as a PostgreSQL foreign t
 
 | Version | Wasm Package URL | Checksum | Required Wrappers Version |
 | ------- | ---------------- | -------- | ------------------------- |
-| 0.2.1 | `https://github.com/supabase/wrappers/releases/download/wasm_openapi_fdw_v0.2.1/openapi_fdw.wasm` | `tbd` | >=0.5.0 |
+| 0.2.1 | `https://github.com/supabase/wrappers/releases/download/wasm_openapi_fdw_v0.2.1/openapi_fdw.wasm` | `12c902f3089e18142a1d8d35c66b9ceb85c193224229687bd929aff6b44cddde` | >=0.6.2 |
 | 0.2.0 | `https://github.com/supabase/wrappers/releases/download/wasm_openapi_fdw_v0.2.0/openapi_fdw.wasm` | `f0d4d6e50f7c519a66363bd8bdbe1ea8086ca810ca14b43fb0ed18b64acdf6aa` | >=0.5.0 |
 | 0.1.4 | `https://github.com/supabase/wrappers/releases/download/wasm_openapi_fdw_v0.1.4/openapi_fdw.wasm` | `dd434f8565b060b181d1e69e1e4d5c8b9c3ac5ca444056d3c2fb939038d308fe` | >=0.5.0 |
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to update WASM file checksum of OpenAPI FDW v0.2.1 .

## What is the current behavior?

The v0.2.1 isn't released yet, currently the checksum is `tbd`.

## What is the new behavior?

Checksum is updated with checksum in [OpenAPI FDW v0.2.1 release](https://github.com/supabase/wrappers/releases/tag/wasm_openapi_fdw_v0.2.1).

## Additional context

The OpenAPI FDW v0.2.1 depends on Wrappers v0.6.2 which is already live on prod for new projects.
