### PR TITLE
feat(paddle_fdw): rich query pushdown, more entities, richer import schema

### DIFF
--- a/docs/catalog/paddle.md
+++ b/docs/catalog/paddle.md
@@ -299,8 +299,10 @@ create foreign table paddle.subscriptions (
   customer_id text,
   address_id text,
   business_id text,
+  price_id text,
   currency_code text,
   collection_mode text,
+  scheduled_change_action text,
   started_at timestamptz,
   first_billed_at timestamptz,
   next_billed_at timestamptz,
@@ -322,6 +324,7 @@ create foreign table paddle.subscriptions (
 
 - Requires `rowid_column` option for data modification operations
 - Pushed-down filters: `id`, `customer_id`, `status`, `price_id`, `address_id`, `collection_mode`, `scheduled_change_action`
+- `price_id` and `scheduled_change_action` are filter-oriented columns: Paddle nests the underlying values, so the columns themselves read as `null` — the actual data is available via `attrs->'items'` and `attrs->'scheduled_change'`
 - Subscription items can be extracted using: `attrs->'items'`
 
 ### Transactions

--- a/docs/catalog/paddle.md
+++ b/docs/catalog/paddle.md
@@ -9,7 +9,7 @@ tags:
 
 # Paddle
 
-[Paddle](https://www.paddle.com) is a merchant of record that acts to provide a payment infrastructure to thousands of software companies around the world.
+[Paddle](https://developer.paddle.com/) is a merchant of record platform built for modern SaaS, mobile app, AI, and digital product businesses. It manages your payments, taxes, and subscriptions in a single integration.
 
 The Paddle Wrapper is a WebAssembly(Wasm) foreign data wrapper which allows you to read and write data from Paddle within your Postgres database.
 
@@ -17,6 +17,7 @@ The Paddle Wrapper is a WebAssembly(Wasm) foreign data wrapper which allows you 
 
 | Version | Wasm Package URL                                                                                    | Checksum                                                           | Required Wrappers Version |
 | ------- | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ | ------------------------- |
+| 0.3.0   | `https://github.com/supabase/wrappers/releases/download/wasm_paddle_fdw_v0.3.0/paddle_fdw.wasm`     | `<checksum added when the v0.3.0 artifact is released>`            | >=0.5.0                   |
 | 0.2.0   | `https://github.com/supabase/wrappers/releases/download/wasm_paddle_fdw_v0.2.0/paddle_fdw.wasm`     | `e788b29ae46c158643e1e1f229d94b28a9af8edbd3233f59c5a79053c25da213` | >=0.5.0                   |
 | 0.1.1   | `https://github.com/supabase/wrappers/releases/download/wasm_paddle_fdw_v0.1.1/paddle_fdw.wasm`     | `c5ac70bb2eef33693787b7d4efce9a83cde8d4fa40889d2037403a51263ba657` | >=0.4.0                   |
 | 0.1.0   | `https://github.com/supabase/wrappers/releases/download/wasm_paddle_fdw_v0.1.0/paddle_fdw.wasm`     | `7d0b902440ac2ef1af85d09807145247f14d1d8fd4d700227e5a4d84c8145409` | >=0.4.0                   |
@@ -66,10 +67,10 @@ We need to provide Postgres with the credentials to access Paddle, and any addit
     create server paddle_server
       foreign data wrapper wasm_wrapper
       options (
-        fdw_package_url 'https://github.com/supabase/wrappers/releases/download/wasm_paddle_fdw_v0.2.0/paddle_fdw.wasm',
+        fdw_package_url 'https://github.com/supabase/wrappers/releases/download/wasm_paddle_fdw_v0.3.0/paddle_fdw.wasm',
         fdw_package_name 'supabase:paddle-fdw',
-        fdw_package_version '0.2.0',
-        fdw_package_checksum 'e788b29ae46c158643e1e1f229d94b28a9af8edbd3233f59c5a79053c25da213',
+        fdw_package_version '0.3.0',
+        fdw_package_checksum '<checksum added when the v0.3.0 artifact is released>',
         api_url 'https://sandbox-api.paddle.com', -- Use https://api.paddle.com for live account
         api_key_id '<key_ID>' -- The Key ID from above.
       );
@@ -81,10 +82,10 @@ We need to provide Postgres with the credentials to access Paddle, and any addit
     create server paddle_server
       foreign data wrapper wasm_wrapper
       options (
-        fdw_package_url 'https://github.com/supabase/wrappers/releases/download/wasm_paddle_fdw_v0.2.0/paddle_fdw.wasm',
+        fdw_package_url 'https://github.com/supabase/wrappers/releases/download/wasm_paddle_fdw_v0.3.0/paddle_fdw.wasm',
         fdw_package_name 'supabase:paddle-fdw',
-        fdw_package_version '0.2.0',
-        fdw_package_checksum 'e788b29ae46c158643e1e1f229d94b28a9af8edbd3233f59c5a79053c25da213',
+        fdw_package_version '0.3.0',
+        fdw_package_checksum '<checksum added when the v0.3.0 artifact is released>',
         api_url 'https://sandbox-api.paddle.com', -- Use https://api.paddle.com for live account
         api_key 'bb4e69088ea07a98a90565ac610c63654423f8f1e2d48b39b5'
       );
@@ -113,8 +114,11 @@ Supported objects are listed below:
 | products              |
 | prices                |
 | discounts             |
+| discount-groups       |
 | customers             |
+| subscriptions         |
 | transactions          |
+| adjustments           |
 | reports               |
 | notification-settings |
 | notifications         |
@@ -125,7 +129,11 @@ Supported objects are listed below:
 
 We can use SQL [import foreign schema](https://www.postgresql.org/docs/current/sql-importforeignschema.html) to import foreign table definitions from Paddle.
 
-For example, using below SQL can automatically create foreign tables in the `paddle` schema.
+`import foreign schema` creates typed foreign tables for the following objects:
+`customers`, `products`, `prices`, `subscriptions`, `transactions`, `discounts`,
+and `adjustments`. Each table exposes the object's commonly-used fields as
+columns plus a catch-all `attrs jsonb` column for everything else. The
+`limit to` / `except` clauses are honored.
 
 ```sql
 -- create all the foreign tables
@@ -141,6 +149,10 @@ import foreign schema paddle
    except ("customers")
    from server paddle_server into paddle;
 ```
+
+You can also create foreign tables for other objects (`discount-groups`,
+`reports`, `notification-settings`, `notifications`) by hand, setting the
+`object` table option accordingly.
 
 ### Products
 
@@ -160,11 +172,14 @@ Ref: [Paddle API docs](https://developer.paddle.com/api-reference/about/data-typ
 create foreign table paddle.products (
   id text,
   name text,
+  description text,
+  type text,
   tax_category text,
   status text,
-  description text,
-  created_at timestamp,
-  updated_at timestamp,
+  image_url text,
+  custom_data jsonb,
+  created_at timestamptz,
+  updated_at timestamptz,
   attrs jsonb
 )
   server paddle_server
@@ -177,8 +192,48 @@ create foreign table paddle.products (
 #### Notes
 
 - Requires `rowid_column` option for data modification operations
-- Query pushdown supported for `id` column
-- Product type can be extracted using: `attrs->>'type'`
+- Pushed-down filters: `id`, `status`, `tax_category`, `type`
+
+### Prices
+
+This is an object representing Paddle Prices.
+
+Ref: [Paddle API docs](https://developer.paddle.com/api-reference/about/data-types)
+
+#### Operations
+
+| Object | Select | Insert | Update | Delete | Truncate |
+| ------ | :----: | :----: | :----: | :----: | :------: |
+| Prices |   ✅    |   ✅    |   ✅    |   ❌    |    ❌     |
+
+#### Usage
+
+```sql
+create foreign table paddle.prices (
+  id text,
+  product_id text,
+  description text,
+  type text,
+  name text,
+  tax_mode text,
+  status text,
+  custom_data jsonb,
+  created_at timestamptz,
+  updated_at timestamptz,
+  attrs jsonb
+)
+  server paddle_server
+  options (
+    object 'prices',
+    rowid_column 'id'
+  );
+```
+
+#### Notes
+
+- Requires `rowid_column` option for data modification operations
+- Pushed-down filters: `id`, `product_id`, `status`, `type`
+- Unit price can be extracted using: `attrs->'unit_price'`
 
 ### Customers
 
@@ -200,9 +255,11 @@ create foreign table paddle.customers (
   name text,
   email text,
   status text,
+  marketing_consent boolean,
+  locale text,
   custom_data jsonb,
-  created_at timestamp,
-  updated_at timestamp,
+  created_at timestamptz,
+  updated_at timestamptz,
   attrs jsonb
 )
   server paddle_server
@@ -215,7 +272,7 @@ create foreign table paddle.customers (
 #### Notes
 
 - Requires `rowid_column` option for data modification operations
-- Query pushdown supported for `id` column
+- Pushed-down filters: `id`, `status`, `email`
 - Custom data stored in dedicated `custom_data` column
 
 ### Subscriptions
@@ -228,7 +285,10 @@ Ref: [Paddle API docs](https://developer.paddle.com/api-reference/about/data-typ
 
 | Object        | Select | Insert | Update | Delete | Truncate |
 | ------------- | :----: | :----: | :----: | :----: | :------: |
-| Subscriptions |   ✅    |   ✅    |   ✅    |   ❌    |    ❌     |
+| Subscriptions |   ✅    |   ❌    |   ✅    |   ❌    |    ❌     |
+
+Paddle has no create-subscription endpoint — subscriptions are created through
+checkout or transactions — so `insert` is not supported.
 
 #### Usage
 
@@ -236,8 +296,19 @@ Ref: [Paddle API docs](https://developer.paddle.com/api-reference/about/data-typ
 create foreign table paddle.subscriptions (
   id text,
   status text,
-  created_at timestamp,
-  updated_at timestamp,
+  customer_id text,
+  address_id text,
+  business_id text,
+  currency_code text,
+  collection_mode text,
+  started_at timestamptz,
+  first_billed_at timestamptz,
+  next_billed_at timestamptz,
+  paused_at timestamptz,
+  canceled_at timestamptz,
+  created_at timestamptz,
+  updated_at timestamptz,
+  custom_data jsonb,
   attrs jsonb
 )
   server paddle_server
@@ -250,15 +321,182 @@ create foreign table paddle.subscriptions (
 #### Notes
 
 - Requires `rowid_column` option for data modification operations
-- Query pushdown supported for `id` column
-- Subscription items status can be extracted using: `attrs#>'{items,status}'`
+- Pushed-down filters: `id`, `customer_id`, `status`, `price_id`, `address_id`, `collection_mode`, `scheduled_change_action`
+- Subscription items can be extracted using: `attrs->'items'`
+
+### Transactions
+
+This is an object representing Paddle Transactions.
+
+Ref: [Paddle API docs](https://developer.paddle.com/api-reference/about/data-types)
+
+#### Operations
+
+| Object       | Select | Insert | Update | Delete | Truncate |
+| ------------ | :----: | :----: | :----: | :----: | :------: |
+| Transactions |   ✅    |   ✅    |   ✅    |   ❌    |    ❌     |
+
+#### Usage
+
+```sql
+create foreign table paddle.transactions (
+  id text,
+  status text,
+  customer_id text,
+  address_id text,
+  business_id text,
+  subscription_id text,
+  invoice_id text,
+  invoice_number text,
+  collection_mode text,
+  discount_id text,
+  origin text,
+  currency_code text,
+  custom_data jsonb,
+  billed_at timestamptz,
+  revised_at timestamptz,
+  created_at timestamptz,
+  updated_at timestamptz,
+  attrs jsonb
+)
+  server paddle_server
+  options (
+    object 'transactions',
+    rowid_column 'id'
+  );
+```
+
+#### Notes
+
+- Requires `rowid_column` option for data modification operations
+- Pushed-down filters: `id`, `customer_id`, `subscription_id`, `status`, `collection_mode`, `origin`, `invoice_number`
+- Date-range pushdown is supported for `created_at`, `updated_at`, and `billed_at` using `<`, `<=`, `>`, `>=` operators (see [Query Pushdown Support](#query-pushdown-support))
+- Line items and totals can be extracted using: `attrs->'details'`
+
+### Adjustments
+
+This is an object representing Paddle Adjustments (refunds, credits, and chargebacks).
+
+Ref: [Paddle API docs](https://developer.paddle.com/api-reference/about/data-types)
+
+#### Operations
+
+| Object      | Select | Insert | Update | Delete | Truncate |
+| ----------- | :----: | :----: | :----: | :----: | :------: |
+| Adjustments |   ✅    |   ✅    |   ❌    |   ❌    |    ❌     |
+
+#### Usage
+
+```sql
+create foreign table paddle.adjustments (
+  id text,
+  action text,
+  type text,
+  transaction_id text,
+  subscription_id text,
+  customer_id text,
+  reason text,
+  currency_code text,
+  status text,
+  credit_applied_to_balance boolean,
+  created_at timestamptz,
+  updated_at timestamptz,
+  attrs jsonb
+)
+  server paddle_server
+  options (
+    object 'adjustments',
+    rowid_column 'id'
+  );
+```
+
+#### Notes
+
+- Requires `rowid_column` option for data modification operations
+- `id` is pushed down as a list filter (Paddle has no single-object adjustment endpoint)
+- Pushed-down filters: `id`, `customer_id`, `subscription_id`, `transaction_id`, `status`, `action`
+- Adjustment items and totals can be extracted using: `attrs->'totals'`
+
+### Discounts
+
+This is an object representing Paddle Discounts.
+
+Ref: [Paddle API docs](https://developer.paddle.com/api-reference/about/data-types)
+
+#### Operations
+
+| Object    | Select | Insert | Update | Delete | Truncate |
+| --------- | :----: | :----: | :----: | :----: | :------: |
+| Discounts |   ✅    |   ✅    |   ✅    |   ❌    |    ❌     |
+
+#### Usage
+
+```sql
+create foreign table paddle.discounts (
+  id text,
+  status text,
+  description text,
+  code text,
+  type text,
+  mode text,
+  amount text,
+  currency_code text,
+  recur boolean,
+  times_used integer,
+  enabled_for_checkout boolean,
+  discount_group_id text,
+  expires_at timestamptz,
+  created_at timestamptz,
+  updated_at timestamptz,
+  custom_data jsonb,
+  attrs jsonb
+)
+  server paddle_server
+  options (
+    object 'discounts',
+    rowid_column 'id'
+  );
+```
+
+#### Notes
+
+- Requires `rowid_column` option for data modification operations
+- Pushed-down filters: `id`, `code`, `status`, `mode`, `discount_group_id`
 
 ## Query Pushdown Support
 
-This FDW supports `where` clause pushdown with `id` as the filter. For example,
+This FDW pushes `where` clause filters down to the Paddle API so that filtering
+happens at the source instead of after a full table scan. Two kinds of pushdown
+are supported:
+
+**Single-object lookup.** For objects that expose a `GET /{object}/{id}`
+endpoint, `where id = '...'` is turned into a direct single-object request:
 
 ```sql
 select * from paddle.customers where id = 'ctm_01hymwgpkx639a6mkvg99563sp';
+```
+
+**List filters.** Equality filters on supported columns are pushed down as query
+parameters (see each entity's Notes for the exact list). Multiple filters are
+combined, and `in (...)` lists are pushed as comma-separated values:
+
+```sql
+-- server-side filtered instead of a full scan
+select * from paddle.transactions
+where customer_id = 'ctm_01hymwgpkx639a6mkvg99563sp'
+  and status = 'completed';
+
+select * from paddle.subscriptions where status = 'active';
+```
+
+**Date-range filters (transactions only).** Paddle supports range operators on
+the transactions list endpoint, so `<`, `<=`, `>`, `>=` on `created_at`,
+`updated_at`, and `billed_at` are pushed down as `[LT]`/`[LTE]`/`[GT]`/`[GTE]`
+filters:
+
+```sql
+select * from paddle.transactions
+where created_at >= '2024-01-01' and created_at < '2024-02-01';
 ```
 
 ## Supported Data Types
@@ -283,8 +521,11 @@ The Paddle API uses JSON formatted data, please refer to [Paddle docs](https://d
 
 This section describes important limitations and considerations when using this FDW:
 
-- Query pushdown is only supported for the `id` column, resulting in full table scans for other filters
+- Query pushdown is supported for `id` and the per-object filters listed in each entity's Notes; filtering on other columns falls back to a full table scan
+- Date-range pushdown (`<`, `<=`, `>`, `>=`) is only available for `transactions` (`created_at`, `updated_at`, `billed_at`)
+- Paddle's list endpoints for `products`, `prices`, `customers`, and `discounts` default to returning only `active` (non-archived) entities. Unless you filter on `status` explicitly, archived rows are not returned — keep this in mind for reconciliation, and add `where status = 'archived'` to see archived entities
 - Large result sets may experience slower performance due to full data transfer requirement
+- This is a read-mostly wrapper that queries Paddle over HTTP on demand; it is not a replacement for webhook-driven fulfilment. Do not put a live FDW query on a latency-critical path (e.g. per-request access checks) — use it for reporting, reconciliation, and backfill instead
 - Materialized views using these foreign tables may fail during logical backups
 
 ## Examples
@@ -300,8 +541,8 @@ create foreign table paddle.customers (
   email text,
   status text,
   custom_data jsonb,
-  created_at timestamp,
-  updated_at timestamp,
+  created_at timestamptz,
+  updated_at timestamptz,
   attrs jsonb
 )
   server paddle_server
@@ -324,8 +565,8 @@ create foreign table paddle.products (
   tax_category text,
   status text,
   description text,
-  created_at timestamp,
-  updated_at timestamp,
+  created_at timestamptz,
+  updated_at timestamptz,
   attrs jsonb
 )
   server paddle_server
@@ -341,8 +582,9 @@ from paddle.products where id = 'pro_01hymwj50rfavry9kqsf2vk6sy';
 create foreign table paddle.subscriptions (
   id text,
   status text,
-  created_at timestamp,
-  updated_at timestamp,
+  customer_id text,
+  created_at timestamptz,
+  updated_at timestamptz,
   attrs jsonb
 )
   server paddle_server
@@ -351,10 +593,43 @@ create foreign table paddle.subscriptions (
     rowid_column 'id'
   );
 
--- extract subscription items for a subscription
-select id, attrs#>'{items,status}' as item_status
+-- extract the subscription items array (items is a JSON array, not an object)
+select id, attrs->'items' as items
 from paddle.subscriptions where id = 'sub_01hv959anj4zrw503h2acawb3p';
 ```
+
+### Reconciliation and Reporting
+
+Because filters are pushed down to Paddle, the wrapper works well for
+reporting and for reconciling Paddle against your own tables — for example, a
+periodic job that pulls only recently-changed transactions, or a per-customer
+subscription lookup. Assumes the foreign tables were created via
+`import foreign schema` (see [Entities](#entities)).
+
+```sql
+-- incremental pull: only transactions updated since the last sync
+-- (updated_at range is pushed down, so this is a targeted request, not a full scan)
+select id, status, customer_id, currency_code, billed_at, updated_at
+from paddle.transactions
+where updated_at >= '2024-06-01T00:00:00';
+
+-- a customer's active subscriptions (customer_id + status pushed down)
+select id, status, next_billed_at
+from paddle.subscriptions
+where customer_id = 'ctm_01hymwgpkx639a6mkvg99563sp'
+  and status = 'active';
+
+-- refunds and chargebacks for reporting (adjustments)
+select id, action, transaction_id, customer_id, currency_code, created_at
+from paddle.adjustments
+where action = 'refund';
+```
+
+For real-time provisioning (granting/revoking access as subscriptions change),
+use Paddle webhooks to keep your own tables up to date, and use this wrapper for
+the reporting and reconciliation queries above. See Paddle's
+[Provision access and handle subscription state](https://developer.paddle.com/build/subscriptions/provision-access-webhooks)
+guide.
 
 ### Data Modify Example
 

--- a/docs/catalog/paddle.md
+++ b/docs/catalog/paddle.md
@@ -299,7 +299,6 @@ create foreign table paddle.subscriptions (
   customer_id text,
   address_id text,
   business_id text,
-  price_id text,
   currency_code text,
   collection_mode text,
   scheduled_change_action text,
@@ -323,9 +322,9 @@ create foreign table paddle.subscriptions (
 #### Notes
 
 - Requires `rowid_column` option for data modification operations
-- Pushed-down filters: `id`, `customer_id`, `status`, `price_id`, `address_id`, `collection_mode`, `scheduled_change_action`
-- `price_id` and `scheduled_change_action` are filter-oriented columns: Paddle nests the underlying values, so the columns themselves read as `null` — the actual data is available via `attrs->'items'` and `attrs->'scheduled_change'`
-- Subscription items can be extracted using: `attrs->'items'`
+- Pushed-down filters: `id`, `customer_id`, `status`, `address_id`, `collection_mode`, `scheduled_change_action`
+- `scheduled_change_action` reflects the nested `scheduled_change.action` and is `none` when the subscription has no pending change, so you can filter by subscriptions scheduled to `cancel`, `pause`, `resume`, or `none`
+- Filtering by price is not supported on subscriptions (a subscription can have multiple items/prices); subscription items and their prices can be extracted from `attrs->'items'`
 
 ### Transactions
 

--- a/wasm-wrappers/fdw/Cargo.lock
+++ b/wasm-wrappers/fdw/Cargo.lock
@@ -246,7 +246,7 @@ dependencies = [
 
 [[package]]
 name = "paddle_fdw"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "serde_json",

--- a/wasm-wrappers/fdw/paddle_fdw/Cargo.toml
+++ b/wasm-wrappers/fdw/paddle_fdw/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "paddle_fdw"
-version = "0.2.0"
+version = "0.3.0"
 edition = { workspace = true }
 homepage = { workspace = true }
 rust-version = { workspace = true }

--- a/wasm-wrappers/fdw/paddle_fdw/src/lib.rs
+++ b/wasm-wrappers/fdw/paddle_fdw/src/lib.rs
@@ -597,7 +597,8 @@ impl Guest for PaddleFdw {
             (
                 "subscriptions",
                 "status text, customer_id text, address_id text, business_id text, \
-                 currency_code text, collection_mode text, started_at timestamptz, \
+                 price_id text, currency_code text, collection_mode text, \
+                 scheduled_change_action text, started_at timestamptz, \
                  first_billed_at timestamptz, next_billed_at timestamptz, paused_at timestamptz, \
                  canceled_at timestamptz, created_at timestamptz, updated_at timestamptz, \
                  custom_data jsonb",

--- a/wasm-wrappers/fdw/paddle_fdw/src/lib.rs
+++ b/wasm-wrappers/fdw/paddle_fdw/src/lib.rs
@@ -96,7 +96,6 @@ impl PaddleFdw {
                     "id",
                     "customer_id",
                     "status",
-                    "price_id",
                     "address_id",
                     "collection_mode",
                     "scheduled_change_action",
@@ -219,17 +218,24 @@ impl PaddleFdw {
 
     // add supported qual filters to the query string
     fn add_pushdown(&self, qs: &mut Vec<String>, quals: &[Qual]) -> Result<(), FdwError> {
+        // Paddle list filters that accept only a single value (not a
+        // comma-separated list). An `IN (...)` on these can't be represented, so
+        // it isn't pushed — it falls back to a full scan + local recheck rather
+        // than sending a comma list Paddle would reject.
+        const SINGLE_VALUE_FILTERS: &[&str] = &["collection_mode", "type", "mode"];
+
         let (filter_fields, date_fields) = self.pushdown_fields();
         for qual in quals {
             let field = qual.field();
             let op = qual.operator();
             if qual.use_or() {
                 // the only OR'ed qual we can represent is an `IN (...)` list on a
-                // filter field (operator '=', array value), which maps directly
+                // list-typed filter field (operator '=', array value), which maps
                 // onto Paddle's comma-separated list syntax. Anything else can't
                 // be pushed as ANDed query params, so skip it.
                 if op == "="
                     && filter_fields.contains(&field.as_str())
+                    && !SINGLE_VALUE_FILTERS.contains(&field.as_str())
                     && matches!(qual.value(), Value::Array(_))
                 {
                     Self::push_filter(qs, &field, &qual.value());
@@ -347,6 +353,21 @@ impl PaddleFdw {
         // put all properties into 'attrs' JSON column
         if &tgt_col_name == "attrs" {
             return Ok(Some(Cell::Json(src_row.to_string())));
+        }
+
+        // `scheduled_change_action` mirrors the subscriptions list filter of the
+        // same name. Its value lives in the nested `scheduled_change.action`, and
+        // a subscription with no pending change maps to 'none' (matching the
+        // filter's enum). Populating it (rather than leaving it NULL) is what
+        // lets the pushed-down filter survive Postgres's local qual recheck.
+        // Gated to `subscriptions` so a same-named column on any other object
+        // isn't fabricated.
+        if self.object == "subscriptions" && &tgt_col_name == "scheduled_change_action" {
+            let action = src_row
+                .pointer("/scheduled_change/action")
+                .and_then(|v| v.as_str())
+                .unwrap_or("none");
+            return Ok(Some(Cell::String(action.to_owned())));
         }
 
         // a column defined in the foreign table but absent from the Paddle
@@ -597,7 +618,7 @@ impl Guest for PaddleFdw {
             (
                 "subscriptions",
                 "status text, customer_id text, address_id text, business_id text, \
-                 price_id text, currency_code text, collection_mode text, \
+                 currency_code text, collection_mode text, \
                  scheduled_change_action text, started_at timestamptz, \
                  first_billed_at timestamptz, next_billed_at timestamptz, paused_at timestamptz, \
                  canceled_at timestamptz, created_at timestamptz, updated_at timestamptz, \

--- a/wasm-wrappers/fdw/paddle_fdw/src/lib.rs
+++ b/wasm-wrappers/fdw/paddle_fdw/src/lib.rs
@@ -7,8 +7,8 @@ use bindings::{
     supabase::wrappers::{
         http, stats, time,
         types::{
-            Cell, Column, Context, FdwError, FdwResult, ImportForeignSchemaStmt, OptionsType, Row,
-            TypeOid, Value,
+            Cell, Column, Context, FdwError, FdwResult, ImportForeignSchemaStmt, ImportSchemaType,
+            OptionsType, Qual, Row, TypeOid, Value,
         },
         utils,
     },
@@ -50,41 +50,237 @@ impl PaddleFdw {
         }
     }
 
-    // check if current object can support id pushdown
+    // check if current object supports single-object id pushdown, i.e. a
+    // `GET /{object}/{id}` endpoint. Note `adjustments` is intentionally absent:
+    // it has no `GET /adjustments/{id}` endpoint, so its `id` filter is pushed
+    // down to the list endpoint (`?id=...`) instead.
     fn can_pushdown_id(&self) -> bool {
-        self.object.starts_with("products")
-            || self.object.starts_with("prices")
-            || self.object.starts_with("discounts")
-            || self.object.starts_with("customers")
-            || self.object.starts_with("transactions")
-            || self.object.starts_with("reports")
-            || self.object.starts_with("notification-settings")
-            || self.object.starts_with("notifications")
+        matches!(
+            self.object.as_str(),
+            "products"
+                | "prices"
+                | "discounts"
+                | "discount-groups"
+                | "customers"
+                | "transactions"
+                | "subscriptions"
+                | "reports"
+                | "notification-settings"
+                | "notifications"
+        )
+    }
+
+    // get the (equality-filter fields, date-range fields) that can be pushed
+    // down to the current object's list endpoint.
+    // ref: https://developer.paddle.com/api-reference/about/filtering
+    //
+    // Date-range operators ([LT]/[LTE]/[GT]/[GTE]) are only supported by Paddle
+    // on the transactions list endpoint, so `date_fields` is non-empty there
+    // and empty everywhere else.
+    fn pushdown_fields(&self) -> (&'static [&'static str], &'static [&'static str]) {
+        match self.object.as_str() {
+            "transactions" => (
+                &[
+                    "id",
+                    "customer_id",
+                    "subscription_id",
+                    "status",
+                    "collection_mode",
+                    "origin",
+                    "invoice_number",
+                ],
+                &["created_at", "updated_at", "billed_at"],
+            ),
+            "subscriptions" => (
+                &[
+                    "id",
+                    "customer_id",
+                    "status",
+                    "price_id",
+                    "address_id",
+                    "collection_mode",
+                    "scheduled_change_action",
+                ],
+                &[],
+            ),
+            "adjustments" => (
+                &[
+                    "id",
+                    "customer_id",
+                    "subscription_id",
+                    "transaction_id",
+                    "status",
+                    "action",
+                ],
+                &[],
+            ),
+            "customers" => (&["id", "status", "email"], &[]),
+            "products" => (&["id", "status", "tax_category", "type"], &[]),
+            "prices" => (&["id", "product_id", "status", "type"], &[]),
+            "discounts" => (&["id", "code", "status", "mode", "discount_group_id"], &[]),
+            "discount-groups" => (&["id"], &[]),
+            "reports" => (&["status"], &[]),
+            "notifications" => (&["status", "notification_setting_id"], &[]),
+            _ => (&[], &[]),
+        }
+    }
+
+    // render a cell as a query parameter value (only scalars that make sense as
+    // Paddle filter values)
+    fn cell_to_query_value(cell: &Cell) -> Option<String> {
+        match cell {
+            Cell::String(s) => Some(s.clone()),
+            Cell::Bool(b) => Some(b.to_string()),
+            _ => None,
+        }
+    }
+
+    // percent-encode a query value or path segment, encoding everything outside
+    // the RFC 3986 unreserved set. Without this a value like an email address
+    // ('user+tag@example.com') or one containing '&' or '/' would corrupt the
+    // request URL and silently return the wrong rows.
+    fn percent_encode(s: &str) -> String {
+        let mut out = String::with_capacity(s.len());
+        for &b in s.as_bytes() {
+            match b {
+                b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' => {
+                    out.push(b as char)
+                }
+                _ => out.push_str(&format!("%{b:02X}")),
+            }
+        }
+        out
+    }
+
+    // convert an equality/IN qual to a Paddle list filter query parameter
+    // e.g.
+    //   "customer_id = 'ctm_1'" -> "customer_id=ctm_1"
+    //   "status in ('a', 'b')"  -> "status=a,b"  (Paddle uses comma-separated lists)
+    // Values are percent-encoded; the comma list separator is left literal.
+    fn push_filter(qs: &mut Vec<String>, field: &str, value: &Value) {
+        let rendered = match value {
+            Value::Cell(cell) => Self::cell_to_query_value(cell).map(|v| Self::percent_encode(&v)),
+            Value::Array(cells) => {
+                let joined = cells
+                    .iter()
+                    .filter_map(Self::cell_to_query_value)
+                    .map(|v| Self::percent_encode(&v))
+                    .collect::<Vec<_>>()
+                    .join(",");
+                if joined.is_empty() {
+                    None
+                } else {
+                    Some(joined)
+                }
+            }
+        };
+        if let Some(v) = rendered {
+            qs.push(format!("{field}={v}"));
+        }
+    }
+
+    // convert a date comparison qual to Paddle date filter query parameter(s).
+    // e.g. "created_at >= '2024-01-01'" -> "created_at[GTE]=2024-01-01T00:00:00"
+    //
+    // Paddle date filters are whole-second, so we round to the enclosing second
+    // in the direction that keeps the pushed range a SUPERSET of the SQL qual:
+    // lower bounds round down, upper bounds round up. This matters because
+    // Postgres rechecks quals locally — a narrower pushed bound would silently
+    // drop rows Paddle never returned. (A sub-second '=' becomes a one-second
+    // window that recheck then narrows to the exact value.)
+    fn push_date_filter(
+        qs: &mut Vec<String>,
+        field: &str,
+        oper: &str,
+        value: &Value,
+    ) -> Result<(), FdwError> {
+        let micros = match value {
+            Value::Cell(Cell::Timestamp(t)) | Value::Cell(Cell::Timestamptz(t)) => *t,
+            Value::Cell(Cell::Date(d)) => *d * 1_000_000,
+            _ => return Ok(()),
+        };
+        let floor = micros.div_euclid(1_000_000) * 1_000_000;
+        let ceil = floor + 1_000_000;
+        // render epoch micros as the 'YYYY-MM-DDTHH:MM:SS' portion of RFC 3339
+        let sec = |m: i64| -> Result<String, FdwError> {
+            Ok(time::epoch_ms_to_rfc3339(m)?.chars().take(19).collect())
+        };
+        match oper {
+            ">" | ">=" => qs.push(format!("{field}[GTE]={}", sec(floor)?)),
+            "<" | "<=" => qs.push(format!("{field}[LT]={}", sec(ceil)?)),
+            "=" => {
+                qs.push(format!("{field}[GTE]={}", sec(floor)?));
+                qs.push(format!("{field}[LT]={}", sec(ceil)?));
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    // add supported qual filters to the query string
+    fn add_pushdown(&self, qs: &mut Vec<String>, quals: &[Qual]) -> Result<(), FdwError> {
+        let (filter_fields, date_fields) = self.pushdown_fields();
+        for qual in quals {
+            let field = qual.field();
+            let op = qual.operator();
+            if qual.use_or() {
+                // the only OR'ed qual we can represent is an `IN (...)` list on a
+                // filter field (operator '=', array value), which maps directly
+                // onto Paddle's comma-separated list syntax. Anything else can't
+                // be pushed as ANDed query params, so skip it.
+                if op == "="
+                    && filter_fields.contains(&field.as_str())
+                    && matches!(qual.value(), Value::Array(_))
+                {
+                    Self::push_filter(qs, &field, &qual.value());
+                }
+                continue;
+            }
+            if date_fields.contains(&field.as_str()) {
+                Self::push_date_filter(qs, &field, &op, &qual.value())?;
+            } else if op == "=" && filter_fields.contains(&field.as_str()) {
+                Self::push_filter(qs, &field, &qual.value());
+            }
+        }
+        Ok(())
+    }
+
+    // build the request url for a scan, pushing down filters where possible
+    fn build_url(&self, ctx: &Context) -> Result<String, FdwError> {
+        let quals = ctx.get_quals();
+
+        // single-object GET optimization: `id = 'xxx'` -> GET /{object}/{id}
+        if self.can_pushdown_id()
+            && let Some(id_qual) = quals
+                .iter()
+                .find(|q| q.field() == "id" && q.operator() == "=" && !q.use_or())
+            && let Value::Cell(Cell::String(id)) = id_qual.value()
+        {
+            return Ok(format!(
+                "{}/{}/{}",
+                self.base_url,
+                self.object,
+                Self::percent_encode(&id)
+            ));
+        }
+
+        // otherwise, query the list endpoint with any supported filters pushed down
+        let mut qs = vec![format!("per_page={}", self.page_size())];
+        self.add_pushdown(&mut qs, &quals)?;
+        Ok(format!(
+            "{}/{}?{}",
+            self.base_url,
+            self.object,
+            qs.join("&")
+        ))
     }
 
     // make the request to Paddle API
     fn make_request(&mut self, ctx: &Context) -> FdwResult {
-        let quals = ctx.get_quals();
-
         let url = if let Some(ref url) = self.url {
             url.clone()
         } else {
-            let object = quals
-                .iter()
-                .find(|q| q.field() == "id")
-                .and_then(|id| {
-                    if !self.can_pushdown_id() {
-                        return None;
-                    }
-
-                    // push down id filter
-                    match id.value() {
-                        Value::Cell(Cell::String(s)) => Some(format!("{}/{}", self.object, s)),
-                        _ => None,
-                    }
-                })
-                .unwrap_or_else(|| self.object.clone());
-            format!("{}/{}?per_page={}", self.base_url, object, self.page_size())
+            self.build_url(ctx)?
         };
         let req = http::Request {
             method: http::Method::Get,
@@ -153,10 +349,13 @@ impl PaddleFdw {
             return Ok(Some(Cell::Json(src_row.to_string())));
         }
 
-        let src = src_row
-            .as_object()
-            .and_then(|v| v.get(&tgt_col_name))
-            .ok_or(format!("source column '{tgt_col_name}' not found"))?;
+        // a column defined in the foreign table but absent from the Paddle
+        // response is treated as SQL NULL rather than an error, so richer
+        // schemas can list occasionally-absent optional fields safely
+        let src = match src_row.as_object().and_then(|v| v.get(&tgt_col_name)) {
+            Some(v) => v,
+            None => return Ok(None),
+        };
 
         // column type mapping
         let cell = match tgt_col.type_oid() {
@@ -376,56 +575,87 @@ impl Guest for PaddleFdw {
         _ctx: &Context,
         stmt: ImportForeignSchemaStmt,
     ) -> Result<Vec<String>, FdwError> {
-        let ret = vec![
-            format!(
-                r#"create foreign table if not exists customers (
-                id text,
-                name text,
-                email text,
-                status text,
-                custom_data jsonb,
-                created_at timestamptz,
-                updated_at timestamp,
-                attrs jsonb
-            )
-            server {} options (
-                object 'customers',
-                rowid_column 'id'
-            )"#,
-                stmt.server_name,
+        // (object name, column definitions). An `id text` column and a trailing
+        // `attrs jsonb` catch-all are added automatically. Timestamps use
+        // `timestamptz` since Paddle returns RFC 3339 UTC values.
+        let tables: Vec<(&str, &str)> = vec![
+            (
+                "customers",
+                "name text, email text, status text, marketing_consent boolean, \
+                 locale text, custom_data jsonb, created_at timestamptz, updated_at timestamptz",
             ),
-            format!(
-                r#"create foreign table if not exists products (
-                id text,
-                name text,
-                tax_category text,
-                status text,
-                description text,
-                created_at timestamp,
-                updated_at timestamp,
-                attrs jsonb
-            )
-            server {} options (
-                object 'products',
-                rowid_column 'id'
-            )"#,
-                stmt.server_name,
+            (
+                "products",
+                "name text, description text, type text, tax_category text, status text, \
+                 image_url text, custom_data jsonb, created_at timestamptz, updated_at timestamptz",
             ),
-            format!(
-                r#"create foreign table if not exists subscriptions (
-                id text,
-                status text,
-                created_at timestamp,
-                updated_at timestamp,
-                attrs jsonb
-            )
-            server {} options (
-                object 'subscriptions',
-                rowid_column 'id'
-            )"#,
-                stmt.server_name,
+            (
+                "prices",
+                "product_id text, description text, type text, name text, tax_mode text, \
+                 status text, custom_data jsonb, created_at timestamptz, updated_at timestamptz",
+            ),
+            (
+                "subscriptions",
+                "status text, customer_id text, address_id text, business_id text, \
+                 currency_code text, collection_mode text, started_at timestamptz, \
+                 first_billed_at timestamptz, next_billed_at timestamptz, paused_at timestamptz, \
+                 canceled_at timestamptz, created_at timestamptz, updated_at timestamptz, \
+                 custom_data jsonb",
+            ),
+            (
+                "transactions",
+                "status text, customer_id text, address_id text, business_id text, \
+                 subscription_id text, invoice_id text, invoice_number text, \
+                 collection_mode text, discount_id text, origin text, currency_code text, \
+                 custom_data jsonb, billed_at timestamptz, revised_at timestamptz, \
+                 created_at timestamptz, updated_at timestamptz",
+            ),
+            (
+                "discounts",
+                "status text, description text, code text, type text, mode text, amount text, \
+                 currency_code text, recur boolean, times_used integer, \
+                 enabled_for_checkout boolean, discount_group_id text, expires_at timestamptz, \
+                 created_at timestamptz, updated_at timestamptz, custom_data jsonb",
+            ),
+            (
+                "adjustments",
+                "action text, type text, transaction_id text, subscription_id text, \
+                 customer_id text, reason text, currency_code text, status text, \
+                 credit_applied_to_balance boolean, created_at timestamptz, updated_at timestamptz",
             ),
         ];
+
+        // honor the `limit to (...)` / `except (...)` clauses
+        let selected: Vec<(&str, &str)> = match stmt.list_type {
+            ImportSchemaType::All => tables,
+            ImportSchemaType::LimitTo => tables
+                .into_iter()
+                .filter(|(name, _)| stmt.table_list.iter().any(|t| t.as_str() == *name))
+                .collect(),
+            ImportSchemaType::Except => tables
+                .into_iter()
+                .filter(|(name, _)| !stmt.table_list.iter().any(|t| t.as_str() == *name))
+                .collect(),
+        };
+
+        let ret: Vec<String> = selected
+            .iter()
+            .map(|(object, columns)| {
+                format!(
+                    r#"create foreign table if not exists {object} (
+                id text,
+                {columns},
+                attrs jsonb
+            )
+            server {} options (
+                object '{object}',
+                rowid_column 'id'
+            )"#,
+                    stmt.server_name,
+                )
+            })
+            .collect();
+
         Ok(ret)
     }
 }

--- a/wrappers/dockerfiles/wasm/server.py
+++ b/wrappers/dockerfiles/wasm/server.py
@@ -57,7 +57,37 @@ class MockServer(BaseHTTPRequestHandler):
 }
             """
             elif req_path.startswith("/subscriptions"):
-                body = '{"data": [], "meta": {"request_id": "req-sub", "pagination": {"per_page": 200, "next": "", "has_more": false, "estimated_total": 0}}}'
+                # list endpoint: return a sub with a pending cancel only when the
+                # scheduled_change_action filter was pushed down, so the test proves
+                # the qual reached the url AND that the column is populated from the
+                # nested scheduled_change.action (else the local recheck drops it).
+                if "scheduled_change_action=cancel" in req_path:
+                    body = """
+{
+    "data": [{
+        "id": "sub_01hv959anj4zrw503h2acawb3p",
+        "status": "active",
+        "customer_id": "ctm_01hymwgpkx639a6mkvg99563sp",
+        "address_id": "add_01hv8gq3318ktkfengj2r75gfx",
+        "business_id": null,
+        "currency_code": "USD",
+        "collection_mode": "automatic",
+        "scheduled_change": {"action": "cancel", "effective_at": "2024-06-01T00:00:00Z"},
+        "started_at": "2024-04-12T10:33:00Z",
+        "first_billed_at": "2024-04-12T10:33:00Z",
+        "next_billed_at": "2024-05-12T10:33:00Z",
+        "paused_at": null,
+        "canceled_at": null,
+        "created_at": "2024-04-12T10:33:00Z",
+        "updated_at": "2024-04-12T10:33:00Z",
+        "custom_data": null,
+        "items": [{"status": "active", "price": {"id": "pri_01gsz8x8sawmvhz1pv30nge1ke"}}]
+    }],
+    "meta": {"request_id": "req-sub", "pagination": {"per_page": 200, "next": "", "has_more": false, "estimated_total": 1}}
+}
+            """
+                else:
+                    body = '{"data": [], "meta": {"request_id": "req-sub", "pagination": {"per_page": 200, "next": "", "has_more": false, "estimated_total": 0}}}'
             elif req_path.startswith("/transactions"):
                 # return a row only when customer_id was pushed down (proves the
                 # qual reached the url); a comma in the value means an IN(...) list

--- a/wrappers/dockerfiles/wasm/server.py
+++ b/wrappers/dockerfiles/wasm/server.py
@@ -28,7 +28,89 @@ class MockServer(BaseHTTPRequestHandler):
         print(fdw, req_path)
 
         if fdw == "paddle":
-            body = """
+            if req_path.startswith("/subscriptions/sub_"):
+                # single-object GET (id pushdown). `data` is an OBJECT, which also
+                # exercises make_request's object->array normalization. The bare
+                # "/subscriptions" list below returns nothing, so a regression to
+                # the old full-scan behaviour would yield 0 rows and fail the test.
+                body = """
+{
+    "data": {
+        "id": "sub_01hv959anj4zrw503h2acawb3p",
+        "status": "active",
+        "customer_id": "ctm_01hymwgpkx639a6mkvg99563sp",
+        "address_id": "add_01hv8gq3318ktkfengj2r75gfx",
+        "business_id": null,
+        "currency_code": "USD",
+        "collection_mode": "automatic",
+        "started_at": "2024-04-12T10:33:00Z",
+        "first_billed_at": "2024-04-12T10:33:00Z",
+        "next_billed_at": "2024-05-12T10:33:00Z",
+        "paused_at": null,
+        "canceled_at": null,
+        "created_at": "2024-04-12T10:33:00Z",
+        "updated_at": "2024-04-12T10:33:00Z",
+        "custom_data": null,
+        "items": [{"status": "active", "price": {"id": "pri_01gsz8x8sawmvhz1pv30nge1ke"}}]
+    },
+    "meta": {"request_id": "req-sub"}
+}
+            """
+            elif req_path.startswith("/subscriptions"):
+                body = '{"data": [], "meta": {"request_id": "req-sub", "pagination": {"per_page": 200, "next": "", "has_more": false, "estimated_total": 0}}}'
+            elif req_path.startswith("/transactions"):
+                # return a row only when customer_id was pushed down (proves the
+                # qual reached the url); a comma in the value means an IN(...) list
+                # was comma-joined, which we tag with a distinct id to prove it.
+                cust = ""
+                if "customer_id=" in req_path:
+                    cust = req_path.split("customer_id=")[1].split("&")[0]
+                if "," in cust:
+                    txn_id = "txn_from_in_list"
+                elif cust:
+                    txn_id = "txn_01hv8xxw3etar07vaxsqbyqasy"
+                else:
+                    txn_id = ""
+                if txn_id:
+                    txn = (
+                        '{"id": "' + txn_id + '", "status": "completed", '
+                        '"customer_id": "ctm_01hymwgpkx639a6mkvg99563sp", "address_id": null, '
+                        '"business_id": null, "subscription_id": "sub_01hv959anj4zrw503h2acawb3p", '
+                        '"invoice_id": null, "invoice_number": null, "collection_mode": "automatic", '
+                        '"discount_id": null, "origin": "web", "currency_code": "USD", '
+                        '"custom_data": null, "billed_at": "2024-04-12T10:33:52Z", "revised_at": null, '
+                        '"created_at": "2024-04-12T10:33:52Z", "updated_at": "2024-04-12T10:33:52Z"}'
+                    )
+                else:
+                    txn = ""
+                body = (
+                    '{"data": [' + txn + '], "meta": {"request_id": "req-txn", "pagination":'
+                    ' {"per_page": 30, "next": "", "has_more": false, "estimated_total": 1}}}'
+                )
+            elif req_path.startswith("/adjustments/"):
+                # adjustments has NO single-object GET endpoint, so its id filter
+                # must go via the list ("/adjustments?id=..."). Returning nothing
+                # here makes a regression to path-GET routing fail the test.
+                body = '{"data": [], "meta": {"request_id": "req-adj", "pagination": {"per_page": 50, "next": "", "has_more": false, "estimated_total": 0}}}'
+            elif req_path.startswith("/adjustments"):
+                adj_id = "adj_01h8b7k0a1b2c3d4e5f6g7h8"
+                action = "refund"
+                if "id=adj_regression_test" in req_path:
+                    adj_id = "adj_regression_test"
+                    action = "credit"
+                body = (
+                    '{"data": [{"id": "' + adj_id + '", "action": "' + action + '", '
+                    '"type": "partial", "transaction_id": "txn_01hv8xxw3etar07vaxsqbyqasy", '
+                    '"subscription_id": "sub_01hv959anj4zrw503h2acawb3p", '
+                    '"customer_id": "ctm_01hymwgpkx639a6mkvg99563sp", '
+                    '"reason": "requested_by_customer", "currency_code": "USD", '
+                    '"status": "approved", "credit_applied_to_balance": false, '
+                    '"created_at": "2024-04-15T10:00:00Z", "updated_at": "2024-04-15T10:00:00Z"}], '
+                    '"meta": {"request_id": "req-adj", "pagination": {"per_page": 50, '
+                    '"next": "", "has_more": false, "estimated_total": 1}}}'
+                )
+            else:
+                body = """
 {
     "data": [{
         "id": "ctm_01hytsesv6f8wqzw1eyctqw6qm",

--- a/wrappers/src/fdw/wasm_fdw/tests.rs
+++ b/wrappers/src/fdw/wasm_fdw/tests.rs
@@ -107,6 +107,20 @@ mod tests {
                 .collect::<Vec<_>>();
             assert_eq!(results, vec!["active"]);
 
+            // Paddle: scheduled_change_action is pushed down AND populated from the
+            // nested scheduled_change.action, so the row survives Postgres's local
+            // recheck (a NULL column would make `= 'cancel'` drop every row).
+            let results = c
+                .select(
+                    "SELECT * FROM paddle.subscriptions WHERE scheduled_change_action = 'cancel'",
+                    None,
+                    &[],
+                )
+                .unwrap()
+                .filter_map(|r| r.get_by_name::<&str, _>("scheduled_change_action").unwrap())
+                .collect::<Vec<_>>();
+            assert_eq!(results, vec!["cancel"]);
+
             // Paddle: multi-column + date-range filter pushdown for transactions.
             // The mock only returns the row when `customer_id` reaches the request
             // url, so this asserts the qual was actually pushed down.

--- a/wrappers/src/fdw/wasm_fdw/tests.rs
+++ b/wrappers/src/fdw/wasm_fdw/tests.rs
@@ -95,6 +95,74 @@ mod tests {
                 .collect::<Vec<_>>();
             assert_eq!(results, vec!["test@test.com"]);
 
+            // Paddle: single-object id pushdown for subscriptions
+            let results = c
+                .select(
+                    "SELECT * FROM paddle.subscriptions WHERE id = 'sub_01hv959anj4zrw503h2acawb3p'",
+                    None,
+                    &[],
+                )
+                .unwrap()
+                .filter_map(|r| r.get_by_name::<&str, _>("status").unwrap())
+                .collect::<Vec<_>>();
+            assert_eq!(results, vec!["active"]);
+
+            // Paddle: multi-column + date-range filter pushdown for transactions.
+            // The mock only returns the row when `customer_id` reaches the request
+            // url, so this asserts the qual was actually pushed down.
+            let results = c
+                .select(
+                    "SELECT * FROM paddle.transactions \
+                     WHERE customer_id = 'ctm_01hymwgpkx639a6mkvg99563sp' \
+                       AND created_at >= '2024-01-01'",
+                    None,
+                    &[],
+                )
+                .unwrap()
+                .filter_map(|r| r.get_by_name::<&str, _>("id").unwrap())
+                .collect::<Vec<_>>();
+            assert_eq!(results, vec!["txn_01hv8xxw3etar07vaxsqbyqasy"]);
+
+            // Paddle: adjustments list + filter pushdown (refunds/chargebacks)
+            let results = c
+                .select(
+                    "SELECT * FROM paddle.adjustments WHERE action = 'refund'",
+                    None,
+                    &[],
+                )
+                .unwrap()
+                .filter_map(|r| r.get_by_name::<&str, _>("id").unwrap())
+                .collect::<Vec<_>>();
+            assert_eq!(results, vec!["adj_01h8b7k0a1b2c3d4e5f6g7h8"]);
+
+            // Paddle: adjustments `id` is pushed as a list filter (no single-object
+            // endpoint); the mock returns nothing for a path GET, so this proves
+            // the list route (`?id=...`) is used rather than `/adjustments/{id}`.
+            let results = c
+                .select(
+                    "SELECT * FROM paddle.adjustments WHERE id = 'adj_regression_test'",
+                    None,
+                    &[],
+                )
+                .unwrap()
+                .filter_map(|r| r.get_by_name::<&str, _>("id").unwrap())
+                .collect::<Vec<_>>();
+            assert_eq!(results, vec!["adj_regression_test"]);
+
+            // Paddle: IN (...) list pushdown becomes a comma-separated value; the
+            // mock tags the comma-joined request with a distinct id to prove it.
+            let results = c
+                .select(
+                    "SELECT * FROM paddle.transactions \
+                     WHERE customer_id IN ('ctm_01hymwgpkx639a6mkvg99563sp', 'ctm_zzz')",
+                    None,
+                    &[],
+                )
+                .unwrap()
+                .filter_map(|r| r.get_by_name::<&str, _>("id").unwrap())
+                .collect::<Vec<_>>();
+            assert_eq!(results, vec!["txn_from_in_list"]);
+
             // Notion FDW test
             c.update(
                 r#"CREATE SERVER notion_server


### PR DESCRIPTION
Hey team 👋 I'm a dev advocate at Paddle and a big fan of Supabase. Love that there's a Paddle wrapper 💛 - cheers for building this! Was digging into it and spotted a few places where we could improve things.

Once this lands, I'll get out some docs on our side + a developer changelog entry, and I'll include in our next roundup email newsletter (similar to your monthly "Supa Update" one).

## What kind of change does this PR introduce?

Feature + docs, with a small bug fix.

Everything is contained in the Paddle Wasm FDW (`wasm-wrappers/fdw/paddle_fdw`), version bumped to 0.3.0.

## What is the current behavior?

The Paddle wrapper only pushes down a single `id` equality. Any other `WHERE` clause falls back to a full paginated scan of the object. `import foreign schema` creates just three tables (customers, products, subscriptions) with minimal cols, so most fields have to be pulled out of `attrs`.

Two specific gaps: 

- `subscriptions` is missing from the id-pushdown allowlist, so `where id = 'sub_...'` does a full scan instead of a single-object GET
- `adjustments` (refunds, credits, chargebacks) is half-wired. It has page-size tuning but no pushdown, import, ordocs).

## What is the new behavior?

- `subscriptions` id lookups now do a single-object GET.
- Per-object filter pushdown on the list endpoints (e.g. `customer_id`, `subscription_id`, `status`, `product_id` — full list per entity in the docs), `IN (...)` pushed as Paddle comma-separated lists, and date-range pushdown for transactions (`created_at` / `updated_at` / `billed_at`). Filter values and the id path segment are percent-encoded.
- `adjustments` is fully wired - this is esp. useful for chargebacks reporting.
- `import foreign schema` now generates 7 typed tables and honors the `limit to` / `except` clauses.
- A column that's absent from a given API response now maps to NULL instead of failing the whole scan.
- `docs/catalog/paddle.md` updated to match. I also made a small tweak to our intro - we don't generally lead with being payments infrastructure as we're not a PSP.

Auth and the pinned `Paddle-Version` header are unchanged.

## Additional context

### Testing

- Mock integration tests (`cargo pgrx test --features "wasm_fdw pg15"`) cover the single-object id GET, multi-column + date-range pushdown, `IN (...)`, and the adjustments list-filter path.
- Also verified the built wasm end-to-end against a Paddle sandbox account via `cargo pgrx run`, with `api_url` pointed at a small logging proxy to confirm the pushed-down URLs actually reach Paddle, e.g. `GET /transactions?per_page=30&customer_id=...&created_at[GTE]=...&created_at[LT]=...`.
- `cargo fmt`, `cargo clippy -D warnings`, and `cargo component build` are clean.

Everything went through Fable 5 adversarial review, too.

### Other

- Paddle's date filters are whole-second, so bounds are rounded to keep the pushed range a superset of the SQL qual (Postgres rechecks locally), meaning pushdown never drops rows.
- The `0.3.0` checksum in the docs is a placeholder for now. I understand the real one comes from the release build.
- I thought about adding nested customer subresources (e.g. addresses) but they require `customer_id` in the path. I'm going to take this back to the team and think about the pattern some more.
- As before no `delete` support, since we typically only offer archiving via a status update (we're an MoR).