### PR TITLE
fix(stripe_fdw): add missing status column to subscriptions table

### DIFF
--- a/docs/catalog/stripe.md
+++ b/docs/catalog/stripe.md
@@ -1010,6 +1010,7 @@ create foreign table stripe.subscriptions (
   currency text,
   current_period_start timestamp,
   current_period_end timestamp,
+  status text,
   attrs jsonb
 )
   server stripe_server

--- a/wrappers/src/fdw/stripe_fdw/README.md
+++ b/wrappers/src/fdw/stripe_fdw/README.md
@@ -10,6 +10,7 @@ This is a foreign data wrapper for [Stripe](https://stripe.com/) developed using
 
 | Version | Date       | Notes                                                |
 | ------- | ---------- | ---------------------------------------------------- |
+| 0.1.13  | 2026-08-10 | Added missing 'status' column to 'subscriptions'     |
 | 0.1.12  | 2025-03-06 | Added import foreign schema support                  |
 | 0.1.11  | 2024-09-20 | Added Meter object                                   |
 | 0.1.10  | 2024-08-26 | Added 'api_key_name' server option                   |

--- a/wrappers/src/fdw/stripe_fdw/stripe_fdw.rs
+++ b/wrappers/src/fdw/stripe_fdw/stripe_fdw.rs
@@ -340,6 +340,7 @@ fn create_table_config() -> TableConfig {
                     ("currency", "text"),
                     ("current_period_start", "timestamp"),
                     ("current_period_end", "timestamp"),
+                    ("status", "text"),
                 ],
             ),
         ),

--- a/wrappers/src/fdw/stripe_fdw/stripe_fdw.rs
+++ b/wrappers/src/fdw/stripe_fdw/stripe_fdw.rs
@@ -668,7 +668,7 @@ fn inc_stats_request_cnt(stats_metadata: &mut JsonB) -> StripeFdwResult<()> {
 }
 
 #[wrappers_fdw(
-    version = "0.1.12",
+    version = "0.1.13",
     author = "Supabase",
     website = "https://github.com/supabase/wrappers/tree/main/wrappers/src/fdw/stripe_fdw",
     error_type = "StripeFdwError"

--- a/wrappers/src/fdw/stripe_fdw/tests.rs
+++ b/wrappers/src/fdw/stripe_fdw/tests.rs
@@ -392,16 +392,20 @@ mod tests {
                                 .unwrap(),
                         )
                         .zip(r.get_by_name::<Timestamp, _>("current_period_end").unwrap())
+                        .zip(r.get_by_name::<&str, _>("status").unwrap())
                 })
                 .collect::<Vec<_>>();
             assert_eq!(
                 results,
                 vec![(
                     (
-                        ("cus_QXg1o8vcGmoR32", "usd"),
+                        (
+                            ("cus_QXg1o8vcGmoR32", "usd"),
+                            Timestamp::try_from(287883090000000i64).unwrap()
+                        ),
                         Timestamp::try_from(287883090000000i64).unwrap()
                     ),
-                    Timestamp::try_from(287883090000000i64).unwrap()
+                    "active"
                 )]
             );
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

`stripe_fdw` already treats `status` as a pushdown qualifier for `stripe.subscriptions`, and `docs/catalog/stripe.md` recommends filtering subscriptions by `id, customer, price, status` — but the `status` column was never added to the table's column config.
As a result, `where status = 'active'` fails with `ERROR: column "status" does not exist`, even though both the code and the docs advertise it as filterable.

Closes: #317 

## What is the new behavior?

`status text` is added to the `subscriptions` column config and to the example in `docs/catalog/stripe.md`, matching the existing pattern already used for `refunds`.

Also the subscriptions test in `tests.rs` is extended to assert the new column.

## Additional context

`price` has the same missing-column symptom (registered as a pushdown qual at `stripe_fdw.rs:336`, listed in the same docs note) but isn't fixable the same way — `price` lives nested under `items.data[].price` on the Stripe API object, not top-level like `status`, so it needs real flattening logic rather than a column-config addition. Noting it here as a follow-up, not part of this fix.