### PR TITLE
fix(stripe): remove price pushdown from subscriptions

### DIFF
--- a/docs/catalog/stripe.md
+++ b/docs/catalog/stripe.md
@@ -1030,7 +1030,6 @@ create foreign table stripe.subscriptions (
 - While any column is allowed in a where clause, it is most efficient to filter by:
       - id
       - customer
-      - price
       - status
 
 ### Tokens

--- a/wrappers/src/fdw/stripe_fdw/README.md
+++ b/wrappers/src/fdw/stripe_fdw/README.md
@@ -10,6 +10,7 @@ This is a foreign data wrapper for [Stripe](https://stripe.com/) developed using
 
 | Version | Date       | Notes                                                |
 | ------- | ---------- | ---------------------------------------------------- |
+| 0.1.14  | 2026-08-11 | Removed 'price' pushdown filter from subscriptions   |
 | 0.1.13  | 2026-08-10 | Added missing 'status' column to 'subscriptions'     |
 | 0.1.12  | 2025-03-06 | Added import foreign schema support                  |
 | 0.1.11  | 2024-09-20 | Added Meter object                                   |

--- a/wrappers/src/fdw/stripe_fdw/stripe_fdw.rs
+++ b/wrappers/src/fdw/stripe_fdw/stripe_fdw.rs
@@ -333,7 +333,7 @@ fn create_table_config() -> TableConfig {
             "subscriptions",
             (
                 "subscriptions",
-                vec!["customer", "price", "status"],
+                vec!["customer", "status"],
                 vec![
                     ("id", "text"),
                     ("customer", "text"),
@@ -668,7 +668,7 @@ fn inc_stats_request_cnt(stats_metadata: &mut JsonB) -> StripeFdwResult<()> {
 }
 
 #[wrappers_fdw(
-    version = "0.1.13",
+    version = "0.1.14",
     author = "Supabase",
     website = "https://github.com/supabase/wrappers/tree/main/wrappers/src/fdw/stripe_fdw",
     error_type = "StripeFdwError"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix,

## What is the current behavior?

The `price` parameter is listed as a pushdown filter for `subscriptions`, but is missing from the table columns. Attempting to query or filter by it throws a `column "price" does not exist` error.

## What is the new behavior?

Removed `price` from the `subscriptions` pushdown options and updated the docs.

Since price is nested inside the `items` array and a subscription can have multiple items (a 1:n relationship), we chose to avoid mapping it to a single top-level column and instead remove it from the pushdown options.

## Additional context

This follows the discussion in #623.