### PR TITLE
fix(wasm): check HTTP status before deserializing response body

### DIFF
--- a/wasm-wrappers/fdw/cal_fdw/src/lib.rs
+++ b/wasm-wrappers/fdw/cal_fdw/src/lib.rs
@@ -158,12 +158,12 @@ impl CalFdw {
                 }
             }
 
+            // check for errors
+            http::error_for_status(&resp).map_err(|err| format!("{}: {}", err, resp.body))?;
+
             // transform response to json
             let resp_json: JsonValue =
                 serde_json::from_str(&resp.body).map_err(|e| e.to_string())?;
-
-            // check for errors
-            http::error_for_status(&resp).map_err(|err| format!("{}: {}", err, resp.body))?;
 
             // unify response object to array and save source rows
             let resp_data = resp_json

--- a/wasm-wrappers/fdw/calendly_fdw/src/lib.rs
+++ b/wasm-wrappers/fdw/calendly_fdw/src/lib.rs
@@ -150,12 +150,12 @@ impl CalendlyFdw {
                 }
             }
 
+            // check for errors
+            http::error_for_status(&resp).map_err(|err| format!("{}: {}", err, resp.body))?;
+
             // transform response to json
             let resp_json: JsonValue =
                 serde_json::from_str(&resp.body).map_err(|e| e.to_string())?;
-
-            // check for errors
-            http::error_for_status(&resp).map_err(|err| format!("{}: {}", err, resp.body))?;
 
             // unify response object to array and save source rows
             let resp_data = if resp_json.pointer("/collection").is_some() {

--- a/wasm-wrappers/fdw/cfd1_fdw/src/lib.rs
+++ b/wasm-wrappers/fdw/cfd1_fdw/src/lib.rs
@@ -226,12 +226,12 @@ impl Cfd1Fdw {
                 continue;
             }
 
+            // check for HTTP errors
+            http::error_for_status(&resp).map_err(|err| format!("{}: {}", err, resp.body))?;
+
             // transform response to json
             let resp_json: JsonValue =
                 serde_json::from_str(&resp.body).map_err(|e| e.to_string())?;
-
-            // check for HTTP errors
-            http::error_for_status(&resp).map_err(|err| format!("{}: {}", err, resp.body))?;
 
             // check for API request errors
             if let Some(success) = resp_json["success"].as_bool() {

--- a/wasm-wrappers/fdw/notion_fdw/src/lib.rs
+++ b/wasm-wrappers/fdw/notion_fdw/src/lib.rs
@@ -245,19 +245,22 @@ impl NotionFdw {
                 }
             }
 
+            // check for errors
+            if resp.status_code == 404 {
+                // if the 404 is caused by no object found, we shouldn't take it as an error
+                if let Ok(resp_json) = serde_json::from_str::<JsonValue>(&resp.body) {
+                    if resp_json.pointer("/code").and_then(|v| v.as_str())
+                        == Some("object_not_found")
+                    {
+                        break;
+                    }
+                }
+            }
+            http::error_for_status(&resp).map_err(|err| format!("{}: {}", err, resp.body))?;
+
             // transform response to json
             let resp_json: JsonValue =
                 serde_json::from_str(&resp.body).map_err(|e| e.to_string())?;
-
-            // if the 404 is caused by no object found, we shouldn't take it as an error
-            if resp.status_code == 404
-                && resp_json.pointer("/code").and_then(|v| v.as_str()) == Some("object_not_found")
-            {
-                break;
-            }
-
-            // check for errors
-            http::error_for_status(&resp).map_err(|err| format!("{}: {}", err, resp.body))?;
 
             // unify response object to array and save source rows
             let resp_data = if resp_json.pointer("/object").and_then(|v| v.as_str()) == Some("list")

--- a/wasm-wrappers/fdw/paddle_fdw/src/lib.rs
+++ b/wasm-wrappers/fdw/paddle_fdw/src/lib.rs
@@ -1,6 +1,6 @@
 #[allow(warnings)]
 mod bindings;
-use serde_json::{json, Map as JsonMap, Value as JsonValue};
+use serde_json::{Map as JsonMap, Value as JsonValue, json};
 
 use bindings::{
     exports::supabase::wrappers::routines::Guest,

--- a/wasm-wrappers/fdw/paddle_fdw/src/lib.rs
+++ b/wasm-wrappers/fdw/paddle_fdw/src/lib.rs
@@ -1,6 +1,6 @@
 #[allow(warnings)]
 mod bindings;
-use serde_json::{Map as JsonMap, Value as JsonValue, json};
+use serde_json::{json, Map as JsonMap, Value as JsonValue};
 
 use bindings::{
     exports::supabase::wrappers::routines::Guest,
@@ -295,18 +295,22 @@ impl PaddleFdw {
             body: String::default(),
         };
         let resp = http::get(&req)?;
-        let resp_json: JsonValue = serde_json::from_str(&resp.body).map_err(|e| e.to_string())?;
 
-        // if the 404 is caused by no object found, we shouldn't take it as an error
-        if resp.status_code == 404 && resp_json.pointer("/error/code") == Some(&json!("not_found"))
-        {
-            self.src_rows = Vec::default();
-            self.src_idx = 0;
-            self.url = None;
-            return Ok(());
+        // check for errors
+        if resp.status_code == 404 {
+            // if the 404 is caused by no object found, we shouldn't take it as an error
+            if let Ok(resp_json) = serde_json::from_str::<JsonValue>(&resp.body) {
+                if resp_json.pointer("/error/code") == Some(&json!("not_found")) {
+                    self.src_rows = Vec::default();
+                    self.src_idx = 0;
+                    self.url = None;
+                    return Ok(());
+                }
+            }
         }
-
         http::error_for_status(&resp).map_err(|err| format!("{}: {}", err, resp.body))?;
+
+        let resp_json: JsonValue = serde_json::from_str(&resp.body).map_err(|e| e.to_string())?;
 
         // save source rows
         self.src_rows = resp_json

--- a/wasm-wrappers/fdw/snowflake_fdw/src/lib.rs
+++ b/wasm-wrappers/fdw/snowflake_fdw/src/lib.rs
@@ -61,6 +61,10 @@ impl SnowflakeFdw {
             http::Method::Post => http::post(&req),
             _ => unreachable!(),
         }?;
+
+        // Check for errors
+        http::error_for_status(&resp).map_err(|err| format!("{}: {}", err, resp.body))?;
+
         let json_value = serde_json::from_str(&resp.body).map_err(|e| e.to_string())?;
 
         stats::inc_stats(FDW_NAME, stats::Metric::BytesIn, resp.body.len() as i64);
@@ -213,7 +217,7 @@ impl SnowflakeFdw {
 
         // polling query result
         loop {
-            http::error_for_status(&resp)?;
+            http::error_for_status(&resp).map_err(|err| format!("{}: {}", err, resp.body))?;
 
             // make sure response status code is 200 or 202 only
             if resp.status_code != 200 && resp.status_code != 202 {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When upstream APIs reject a connection (e.g., 401 Unauthorized or 403 Forbidden) and return a non-JSON error body (such as HTML or plain text), WASM Foreign Data Wrappers fail during JSON deserialization (`serde_json::from_str`) with a generic error: `ERROR: HV000: guest fdw error: expected value at line 1 column 1`

This occurs because WASM wrappers blindly attempt to deserialize the response body into JSON *before* checking the HTTP status code via `http::error_for_status`, hiding the actual HTTP error status and response body from PostgreSQL logs.

Closes: #386 

## What is the new behavior?

- Ensures `http::error_for_status(&resp)` is checked *before* attempting `serde_json::from_str` across WASM FDWs (`snowflake_fdw`, `cal_fdw`, `calendly_fdw`, `cfd1_fdw`, `notion_fdw`, `paddle_fdw`).
- Preserves missing-object 404 logic in `notion_fdw` and `paddle_fdw` while ensuring unexpected 404 or HTTP error responses properly bubble up the HTTP status and body text.
- Enriches HTTP error mappings in `snowflake_fdw` polling loops so response bodies are included in error messages.