### PR TITLE
fix(openapi_fdw): respect quoted strings and escapes in Link header

### DIFF
--- a/wasm-wrappers/fdw/openapi_fdw/src/response.rs
+++ b/wasm-wrappers/fdw/openapi_fdw/src/response.rs
@@ -247,10 +247,40 @@ fn split_link_entries(s: &str) -> Vec<&str> {
     entries
 }
 
+/// Split the parameter portion of a Link entry on top-level semicolons,
+/// ignoring semicolons inside quoted strings. Honors RFC 7230 `quoted-pair`
+/// escapes so an escaped quote (e.g. `title="a \"semi;colon\""`) does not
+/// flip the quote state.
+fn split_link_params(s: &str) -> Vec<&str> {
+    let mut params = Vec::new();
+    let mut in_quotes = false;
+    let mut escape = false;
+    let mut start = 0;
+    for (i, c) in s.char_indices() {
+        if escape {
+            escape = false;
+            continue;
+        }
+        match c {
+            '\\' if in_quotes => escape = true,
+            '"' => in_quotes = !in_quotes,
+            ';' if !in_quotes => {
+                params.push(&s[start..i]);
+                start = i + 1;
+            }
+            _ => {}
+        }
+    }
+    if start <= s.len() {
+        params.push(&s[start..]);
+    }
+    params
+}
+
 /// Returns true if the parameter list (after the URI part of a Link entry)
 /// contains a `rel` parameter whose value is or includes `next`.
 fn has_rel_next(params: &str) -> bool {
-    for raw in params.split(';') {
+    for raw in split_link_params(params) {
         let part = raw.trim();
         let Some((name, value)) = part.split_once('=') else {
             continue;

--- a/wasm-wrappers/fdw/openapi_fdw/src/response_tests.rs
+++ b/wasm-wrappers/fdw/openapi_fdw/src/response_tests.rs
@@ -984,3 +984,57 @@ fn test_link_header_empty_or_malformed() {
     fdw.handle_pagination(&resp, &headers);
     assert!(fdw.pagination.next.is_none());
 }
+
+#[test]
+fn test_link_header_quoted_semicolon_in_param() {
+    // A quoted parameter value containing a semicolon (e.g. title="a;rel=next")
+    // must not split the parameter list and wrongly identify rel=next when rel is actually "last".
+    let mut fdw = make_fdw_for_pagination("");
+    let resp = serde_json::json!({});
+    let headers = vec![h(
+        "Link",
+        "<https://api.example.com/x>; title=\"a;rel=next\"; rel=\"last\"",
+    )];
+    fdw.handle_pagination(&resp, &headers);
+    assert!(
+        fdw.pagination.next.is_none(),
+        "Expected no next URL because rel is 'last', but got: {:?}",
+        fdw.pagination.next
+    );
+}
+
+#[test]
+fn test_link_header_quoted_semicolon_with_valid_next() {
+    // Semicolons inside other parameters must not disrupt finding rel="next".
+    let mut fdw = make_fdw_for_pagination("");
+    let resp = serde_json::json!({});
+    let headers = vec![h(
+        "Link",
+        "<https://api.example.com/x>; title=\"item 1; item 2; item 3\"; rel=\"next\"",
+    )];
+    fdw.handle_pagination(&resp, &headers);
+    assert_eq!(
+        fdw.pagination.next,
+        Some(PaginationToken::Url(
+            "https://api.example.com/x".to_string()
+        ))
+    );
+}
+
+#[test]
+fn test_link_header_escaped_quote_in_param() {
+    // Backslash-escaped quotes inside parameters must not disrupt quote state.
+    let mut fdw = make_fdw_for_pagination("");
+    let resp = serde_json::json!({});
+    let headers = vec![h(
+        "Link",
+        "<https://api.example.com/x>; title=\"item \\\"foo;bar\\\"\"; rel=\"next\"",
+    )];
+    fdw.handle_pagination(&resp, &headers);
+    assert_eq!(
+        fdw.pagination.next,
+        Some(PaginationToken::Url(
+            "https://api.example.com/x".to_string()
+        ))
+    );
+}


### PR DESCRIPTION
### Summary

Fixes an RFC 8288 parameter parsing bug in `openapi_fdw/src/response.rs` where a semicolon inside a quoted parameter value (such as `title="item;rel=next"`) was treated as a top-level parameter delimiter, causing `has_rel_next()` to falsely identify the link entry as having `rel="next"`.

---

### Problem

In `split_link_entries()`, entries are split on commas while carefully respecting quoted strings and RFC 7230 backslash escapes (`\"`). 

However, `has_rel_next()` previously split parameters using a plain `params.split(';')`. When a quoted parameter contained a semicolon and the substring
`rel=next` (e.g. `<https://api.example.com/items>; title="page;rel=next"; rel="last"`):
1. `split(';')` split the parameter into fragments `title="page` and `rel=next"`.
2. `split_once('=')` matched `name="rel"`, and `trim_matches('"')` produced `value="next"`.
3. `has_rel_next()` returned `true`, incorrectly treating a `rel="last"` URL as the next pagination page.

---

### Solution

- Added `split_link_params()`, which splits parameter lists on top-level semicolons while honoring quoted strings and RFC 7230 `quoted-pair` backslash escapes
(mirroring the entry splitting behavior in `split_link_entries()`).
- Updated `has_rel_next()` to iterate over `split_link_params(params)` instead of `params.split(';')`.
- Added unit regression tests in `response_tests.rs` covering:
  - Quoted semicolons in non-rel parameters (e.g. `title="a;rel=next"; rel="last"` returning `None`).
  - Quoted semicolons with valid `rel="next"` parameters present.
  - Backslash-escaped quotes inside parameters (e.g. `title="item \"foo;bar\""; rel="next"`).

---

### Verification

- Regression test reproduces the failure on `main` and passes with this fix.
- Full `make check` suite in `wasm-wrappers/fdw/openapi_fdw` passes cleanly:
  - `cargo fmt` clean
  - `cargo clippy --all --tests --no-deps` with 0 warnings
  - All 566 unit tests passing
  - `cargo component build --release --target wasm32-unknown-unknown` succeeds