### PR TITLE
fix(qual): use operator commutator when swapping operands in WHERE clauses

### DIFF
--- a/supabase-wrappers/src/qual.rs
+++ b/supabase-wrappers/src/qual.rs
@@ -191,7 +191,7 @@ pub(crate) unsafe fn extract_from_op_expr(
 
                 // get operator
                 let opno = (*expr).opno;
-                let opr = get_operator(opno);
+                let mut opr = get_operator(opno);
                 if opr.is_null() {
                     report_warning("operator is empty");
                     return None;
@@ -205,6 +205,7 @@ pub(crate) unsafe fn extract_from_op_expr(
                     && !is_a(left, pg_sys::NodeTag::T_Var)
                     && (*opr).oprcom != Oid::INVALID
                 {
+                    opr = get_operator((*opr).oprcom);
                     std::mem::swap(&mut left, &mut right);
                 }
 


### PR DESCRIPTION
### Summary
Fixes #643

**Problem:** When extracting WHERE clauses with constants on the left (e.g. `100 > price`), operand swapping kept the original operator instead of its commutator. This pushed inverted operators to remote systems (e.g. `price > 100` instead of `price < 100`), returning incorrect results.

**Fix:** Update `opr` with `get_operator((*opr).oprcom)` when operands are swapped, ensuring the correct commuted operator is used (e.g. `<` for `>`, `<=` for `>=`, `<@` for `@>`).